### PR TITLE
Fixed errors in the Wordpress helm chart such as those preventing extra environment variables.

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wordpress
 description: "Using the official WordPress image. This chart provides automation for installation, user management, plugin installation, and metrics."
 type: application
-version: 0.2.9
+version: 0.2.10
 appVersion: "6.8.3"
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -26,15 +26,15 @@ annotations:
     - name: slydlake
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
-    - kind: changed
-      description: "wordpress bumped to 6.8.3-php8.1-apache"
-      url: https://github.com/slydlake/helm-charts/issues/16
-    - kind: changed
-      description: "memcached chart update"
-      url: https://github.com/slydlake/helm-charts/issues/19
-    - kind: changed
-      description: "mariadb chart update"
-      url: https://github.com/slydlake/helm-charts/issues/17
+    - kind: fixed
+      description: "extraEnvVars are now working in wodpress deployment (thanks to ScionOfDesign)"
+      url: https://github.com/slydlake/helm-charts/issues/21
+    - kind: fixed
+      description: "secret value database name (thanks to ScionOfDesign)"
+      url: https://github.com/slydlake/helm-charts/issues/21
+    - kind: fixed
+      description: "uses WORDPRESS_ env variables if defined in values.yaml (thanks to ScionOfDesign)"
+      url: https://github.com/slydlake/helm-charts/issues/21
   artifacthub.io/containsSecurityUpdates: false
   artifacthub.io/images: |
     - name: wordpress

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -201,10 +201,10 @@ spec:
           {{- end }}
           image: "{{ .Values.image.repository | default "docker.io/wordpress" }}{{- if or .Values.image.tag .Chart.AppVersion -}}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- end }}{{- if .Values.image.digest }}@{{ .Values.image.digest }}{{- end }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
+          env:
           {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 12 }}
           {{- end }}
-          env:
             - name: WP_HOME
               value: {{ .Values.wordpress.url | quote }}
             - name: WP_SITEURL
@@ -230,6 +230,15 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.externalDatabase.existingSecret }}
                   key: db.password
+          {{- else if and (not .Values.mariadb.enabled ) (not .Values.externalDatabase.existingSecret) }}
+            - name: WORDPRESS_DB_HOST
+              value: {{ .Values.externalDatabase.host | quote }}
+            - name: WORDPRESS_DB_NAME
+              value: {{ .Values.externalDatabase.database | quote }}
+            - name: WORDPRESS_DB_USER
+              value: {{ .Values.externalDatabase.username | quote }}
+            - name: WORDPRESS_DB_PASSWORD
+              value: {{ .Values.externalDatabase.password | quote }}
           {{- end }}
           {{- if .Values.wordpress.debug }}
             - name: WORDPRESS_DEBUG

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -28,7 +28,7 @@ data:
   {{- else }}
   {{- $host := .Values.externalDatabase.host }}
   {{- $port := default 3306 .Values.externalDatabase.port }}
-  WORDPRESS_DB_NAME: {{ .Values.externalDatabase.dbName | b64enc }}
+  WORDPRESS_DB_NAME: {{ .Values.externalDatabase.database | b64enc }}
   WORDPRESS_DB_HOST: {{ printf "%s:%v" $host $port | b64enc }}
   {{- if .Values.externalDatabase.username }}
   WORDPRESS_DB_USER: {{ .Values.externalDatabase.username | b64enc }}


### PR DESCRIPTION
I was testing out this chart as I needed to migrate away from Bitnami and noticed some issues with the basic secret-less installation, which I was using for testing. The initialization script would work, but then I would get a database error.

This PR fixes three issues:
1. It fixes where `extraEnvVars` are inserted so that they can actually be used.
2. It removes the reference to `dbName` which should be `database`
3. It explicitly adds the external database information to the wordpress container environment variables if there is no external secret for them.