### PR TITLE
fix: remove duplicate code block in base.sh causing syntax error

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wordpress
 description: "Using the official WordPress image. This chart provides automation for installation, user management, plugin installation, and metrics."
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: "6.8.3"
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts
@@ -26,38 +26,8 @@ annotations:
     - name: slydlake
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added Grafana Dashboard auto-deployment feature for WordPress metrics (metrics.wordpress.grafanaDashboard) with automatic discovery via grafana_dashboard label and optional folder organization"
-    - kind: added
-      description: "Added WORDPRESS_CONFIG_EXTRA environment variable support to init container for consistent configuration across all containers"
-    - kind: added
-      description: "Added wordpress.plugins option to define plugins to be installed via Composer during init."
-    - kind: added
-      description: "Added wordpress.themes option to define themes to be installed via Composer during init."
-    - kind: added
-      description: "Added wordpress.composer.repositories option to configure custom Composer repositories (e.g., private GitHub, Satis, premium plugins). Default repositories (wpackagist.org) are documented in values.yaml"
-    - kind: added
-      description: "Added init container support for installing Composer plugins and themes during initialization"
-    - kind: added
-      description: "Added wordpress.pluginsPrune option to automatically remove all plugins not defined in wordpress.plugins list during init"
-    - kind: added
-      description: "Added wordpress.themesPrune option to automatically remove all themes not defined in wordpress.themes list during init (protects active theme with automatic fallback activation)"
-    - kind: added
-      description: "Added samples/composer.values.yaml sample file demonstrating usage of Composer plugins, themes, and custom repositories"
-    - kind: changed
-      description: "Changed samples/customInit.values.yaml and muPlugins.values.yaml with fixed nodePort for easier testing"
     - kind: fixed
-      description: "Better startupProbe and livenessProbe initial delays and periods for more reliable container health checking"
-    - kind: added
-      description: "Refactored init scripts into modular libraries (lib-core.sh, lib-lock.sh, lib-composer.sh) for better maintainability and testability"
-    - kind: added
-      description: "Added DRY_RUN and TEST_MODE support with assert() function for testing init scripts without making changes"
-    - kind: deprecated
-      description: "Traditional Helm Repository is deprecated, only OCI-based Helm charts are supported."
-    - kind: added
-      description: "Registry value added. Added functionality to _helpers.tpl to support it."
-    - kind: changed
-      description: "Better comments for documentation in values.yaml."
+      description: "fixed base script problem"
   artifacthub.io/images: |
     - name: wordpress
       image: docker.io/wordpress:6.8.3-php8.1-apache

--- a/charts/wordpress/templates/configmap.yaml
+++ b/charts/wordpress/templates/configmap.yaml
@@ -135,78 +135,9 @@ data:
         fi
 
         # Copy wp-content skeleton if not present
-
-    # Helper function to extract WordPress version from version.php
-    get_wp_version() {
-      local version_file="$1"
-      if [ -f "$version_file" ]; then
-        grep "^\$wp_version" "$version_file" | sed "s/.*'\([^']*\)'.*/\1/"
-      else
-        echo ""
-      fi
-    }
-
-    # Helper function to copy WordPress core files (excludes wp-content)
-    copy_wp_core() {
-      echo "Copying WordPress core files..."
-      cd /usr/src/wordpress || exit 1
-      for item in *; do
-        if [ "$item" != "wp-content" ]; then
-          cp -r "$item" /tmp/wordpress/ || exit 1
-        fi
-      done
-      echo "WordPress core files copied successfully!"
-    }
-
-    # Get versions from image and PVC
-    IMAGE_VERSION=$(get_wp_version "/usr/src/wordpress/wp-includes/version.php")
-    PVC_VERSION=$(get_wp_version "/tmp/wordpress/wp-includes/version.php")
-
-    echo "========================================="
-    echo "WordPress Version Check"
-    echo "========================================="
-    echo "Image version: ${IMAGE_VERSION:-'not found'}"
-    echo "PVC version:   ${PVC_VERSION:-'not installed'}"
-    echo "========================================="
-
-    # Check if WordPress needs to be installed or updated
-    if [ -z "$PVC_VERSION" ]; then
-        echo "WordPress not found in /tmp/wordpress - fresh installation..."
-        mkdir -p /tmp/wordpress
-        copy_wp_core
-
-        # Handle wp-config-docker.php for fresh install
-        if [ -f "/usr/src/wordpress/wp-config-docker.php" ] && [ ! -s /tmp/wordpress/wp-config.php ]; then
-          awk '
-            /put your unique phrase here/ {
-              cmd = "head -c1m /dev/urandom | sha1sum | cut -d\\  -f1"
-              cmd | getline str
-              close(cmd)
-              gsub("put your unique phrase here", str)
-            }
-            { print }
-          ' /usr/src/wordpress/wp-config-docker.php > /tmp/wordpress/wp-config.php
-        fi
-
-        # Copy wp-content skeleton if not present
         if [ ! -d /tmp/wordpress/wp-content ]; then
             cp -r /usr/src/wordpress/wp-content /tmp/wordpress/wp-content 2>/dev/null || true
-            cp -r /usr/src/wordpress/wp-content /tmp/wordpress/wp-content 2>/dev/null || true
         fi
-        echo "Complete! WordPress has been successfully installed to /tmp/wordpress"
-
-    elif [ "$IMAGE_VERSION" != "$PVC_VERSION" ]; then
-        echo "WordPress version mismatch detected!"
-        echo "Updating core files from $PVC_VERSION to $IMAGE_VERSION..."
-        echo "Note: wp-content directory will be preserved."
-        copy_wp_core
-        echo "Complete! WordPress core has been updated to $IMAGE_VERSION"
-
-        # Mark that a core update happened (used by init.sh to disable auto-updates)
-        touch /tmp/wordpress/.wp-core-updated
-
-    else
-        echo "WordPress version matches - no update needed."
         echo "Complete! WordPress has been successfully installed to /tmp/wordpress"
 
     elif [ "$IMAGE_VERSION" != "$PVC_VERSION" ]; then


### PR DESCRIPTION
Fixes syntax error in base.sh init script:
- Removed duplicate code block (functions and if/elif/else logic were duplicated)
- Fixed 'unexpected token elif' error
- Removed duplicate cp command for wp-content