### PR TITLE
chore: enable platform auto-merge and helmv3 automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
     "extends": [
         "config:recommended"
     ],
+    "platformAutomerge": true,
     "semanticCommits": "disabled",
     "enabledManagers": [
         "helm-values",
@@ -122,6 +123,7 @@
                 "minor",
                 "patch"
             ],
+            "automerge": true,
             "groupName": "charts/{{{ replace \"charts/\" \"\" parentDir }}}",
             "labels": [
                 "dependencies",


### PR DESCRIPTION
Add top-level `platformAutomerge: true` and enable `automerge: true` for the `helmv3` packageRule so Renovate sets GitHub native auto-merge for helmv3 grouped PRs.