### PR TITLE
feat(runtimeClassName): allow runtimeClassName to be set to improve security

### DIFF
--- a/charts/wg-easy/templates/statefulset.yaml
+++ b/charts/wg-easy/templates/statefulset.yaml
@@ -46,6 +46,9 @@ spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- end }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/charts/wg-easy/values.schema.json
+++ b/charts/wg-easy/values.schema.json
@@ -172,6 +172,11 @@
         "additionalProperties": true
       }
     },
+    "runtimeClassName":{
+      "type": "string",
+      "title": "Runtime Class Name",
+      "description": "The kubernetes runtime class which will execute the containers. Defaults to the default runtimeClassName."
+    },
     "storage": {
       "title": "Persistent storage",
       "type": "object",

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -88,6 +88,9 @@ initContainers: []
 ## @param sidecars list Sidecar containers to add to the pod
 sidecars: []
 
+## @param runtimeclass that the wireguard pod will have
+runtimeClassName: {}
+
 ## @section Storage configuration
 storage:
   ## @param storage.existingClaim string Name of an existing PVC to use


### PR DESCRIPTION
This PR adds the ability to specify the wireguard pod's `runtimeClassName` parameter.  This is helpful in situations where users with to isolate the `privileged: true` wireguard requirements by using a virtualized or paravirtualized runtime such as kata-containers kata-qemu.