### PR TITLE
[wordpress] Added HTTPRoute

### DIFF
--- a/charts/wordpress/templates/httproute.yaml
+++ b/charts/wordpress/templates/httproute.yaml
@@ -17,7 +17,7 @@ metadata:
   {{- end }}
 spec:
   parentRefs:
-    {{- required "A valid .Values.httpRoute.parentRefs entry is required when httpRoute.enabled is true" .Values.httpRoute.parentRefs | toYaml | nindent 4 }}
+    {{- .Values.httpRoute.parentRefs | toYaml | nindent 4 }}
   {{- with .Values.httpRoute.hostnames }}
   hostnames:
     {{- toYaml . | nindent 4 }}

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -996,19 +996,23 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "Enable HTTPRoute resource for Gateway API"
+                    "description": "Enable HTTPRoute resource for Gateway API",
+                    "default": false
                 },
                 "annotations": {
                     "type": "object",
-                    "description": "Annotations for HTTPRoute resource"
+                    "description": "Annotations for HTTPRoute resource",
+                    "default": {}
                 },
                 "labels": {
                     "type": "object",
-                    "description": "Additional labels for HTTPRoute resource"
+                    "description": "Additional labels for HTTPRoute resource",
+                    "default": {}
                 },
                 "parentRefs": {
                     "type": "array",
                     "description": "Parent references (REQUIRED when enabled - HTTPRoute will not work without this)",
+                    "default": [],
                     "items": {
                         "type": "object",
                         "properties": {
@@ -1031,6 +1035,7 @@
                 "hostnames": {
                     "type": "array",
                     "description": "Hostnames for the HTTPRoute",
+                    "default": [],
                     "items": {
                         "type": "string"
                     }
@@ -1038,8 +1043,23 @@
                 "rules": {
                     "type": "array",
                     "description": "Custom routing rules (optional, defaults to path prefix /)",
+                    "default": [],
                     "items": {
                         "type": "object"
+                    }
+                }
+            },
+            "if": {
+                "properties": {
+                    "enabled": {
+                        "const": true
+                    }
+                }
+            },
+            "then": {
+                "properties": {
+                    "parentRefs": {
+                        "minItems": 1
                     }
                 }
             }

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -536,24 +536,24 @@ service:
 ## ```
 ## @descriptionEnd
 httpRoute:
-  # -- Enable HTTPRoute resource for Gateway API
+  # @param httpRoute.enabled bool Enable HTTPRoute resource for Gateway API
   enabled: false
-  # -- Annotations for HTTPRoute resource
+  # @param httpRoute.annotations object Annotations for HTTPRoute resource
   annotations: {}
-  # -- Additional labels for HTTPRoute resource
+  # @param httpRoute.labels object Additional labels for HTTPRoute resource
   labels: {}
-  # -- Parent references (REQUIRED when enabled - HTTPRoute will not work without this)
+  # @param httpRoute.parentRefs list Parent references (REQUIRED when enabled - HTTPRoute will not work without this)
   # Example:
   # parentRefs:
   #   - name: my-gateway
   #     namespace: gateway-namespace
   parentRefs: []
-  # -- Hostnames for the HTTPRoute
+  # @param httpRoute.hostnames list Hostnames for the HTTPRoute
   # Example:
   # hostnames:
   #   - wordpress.example.com
   hostnames: []
-  # -- Custom routing rules (optional, defaults to path prefix /)
+  # @param httpRoute.rules list Custom routing rules (optional, defaults to path prefix /)
   # If not specified, a default rule routing all traffic to the service is used
   rules: []
   # Example custom rules:
@@ -563,7 +563,7 @@ httpRoute:
   #           type: PathPrefix
   #           value: /wordpress
   #     backendRefs:
-  #       - name: wordpress
+  #       - name: my-release-wordpress
   #         port: 80
 
 ## @section Ingress configuration


### PR DESCRIPTION
## Changes

- Added `HTTPRoute` as the new `Ingress` alternative (GatewayAPI)

Heavily inspired by https://github.com/kubernetes-sigs/headlamp/pull/4299

## Considerations

- If `TLSRoute` is also desired, consider generalizing to `route` and adding `kind` e.g. https://github.com/nextcloud/helm/blob/main/charts/nextcloud/templates/route.yaml