### PR TITLE
[wordpress] Improve init wordpress scripts

### DIFF
--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wordpress
 description: "Using the official WordPress image. This chart provides automation for installation, user management, plugin installation, and metrics."
 type: application
-version: 3.6.33
+version: 3.6.34
 appVersion: "6.9.4" # renovate: image=docker.io/wordpress
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts
@@ -27,7 +27,7 @@ annotations:
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update valkey to 0.20.1"
+      description: "Improved wordpress init scripts"
   artifacthub.io/images: |
     - name: wordpress
       image: docker.io/wordpress:6.9.4-php8.3-apache

--- a/charts/wordpress/templates/_init-lib-core.tpl
+++ b/charts/wordpress/templates/_init-lib-core.tpl
@@ -89,34 +89,17 @@ execute() {
 # Performance Note:
 #   Each wp call loads WordPress core - can be slow
 #   Use batch operations where possible (e.g., install multiple plugins at once)
-_wp_cli_db_extra_args() {
-  if [ "${1:-}" = "db" ] && [ "${WORDPRESS_DB_SSL_REQUIRED:-true}" = "false" ]; then
-    printf '%s\n' "--skip-ssl"
-  fi
-}
-
 wp() {
-  local extra_db_arg=""
-  extra_db_arg="$(_wp_cli_db_extra_args "$1")"
-
   if [ "${DRY_RUN}" = "true" ]; then
-    echo "[DRY_RUN] wp $* ${extra_db_arg}"
+    echo "[DRY_RUN] wp $*"
     return 0
   fi
   # --skip-plugins/themes: avoid loading all installed plugins on every call
   # (huge speedup when Composer packages like s3-uploads are installed)
   if [ "${DEBUG}" = "true" ]; then
-    if [ -n "$extra_db_arg" ]; then
-      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes --debug "$@" "$extra_db_arg"
-    else
-      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes --debug "$@"
-    fi
+    command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes --debug "$@"
   else
-    if [ -n "$extra_db_arg" ]; then
-      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes "$@" "$extra_db_arg"
-    else
-      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes "$@"
-    fi
+    command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes "$@"
   fi
 }
 
@@ -125,26 +108,15 @@ wp() {
 #
 # Args: All arguments are passed through to wp-cli
 wp_with_plugins() {
-  local extra_db_arg=""
-  extra_db_arg="$(_wp_cli_db_extra_args "$1")"
-
   if [ "${DRY_RUN}" = "true" ]; then
-    echo "[DRY_RUN] wp(with-plugins) $* ${extra_db_arg}"
+    echo "[DRY_RUN] wp(with-plugins) $*"
     return 0
   fi
 
   if [ "${DEBUG}" = "true" ]; then
-    if [ -n "$extra_db_arg" ]; then
-      command wp --path="${WORDPRESS_PATH}" --skip-themes --debug "$@" "$extra_db_arg"
-    else
-      command wp --path="${WORDPRESS_PATH}" --skip-themes --debug "$@"
-    fi
+    command wp --path="${WORDPRESS_PATH}" --skip-themes --debug "$@"
   else
-    if [ -n "$extra_db_arg" ]; then
-      command wp --path="${WORDPRESS_PATH}" --skip-themes "$@" "$extra_db_arg"
-    else
-      command wp --path="${WORDPRESS_PATH}" --skip-themes "$@"
-    fi
+    command wp --path="${WORDPRESS_PATH}" --skip-themes "$@"
   fi
 }
 

--- a/charts/wordpress/templates/_init-lib-core.tpl
+++ b/charts/wordpress/templates/_init-lib-core.tpl
@@ -89,17 +89,34 @@ execute() {
 # Performance Note:
 #   Each wp call loads WordPress core - can be slow
 #   Use batch operations where possible (e.g., install multiple plugins at once)
+_wp_cli_db_extra_args() {
+  if [ "${1:-}" = "db" ] && [ "${WORDPRESS_DB_SSL_REQUIRED:-true}" = "false" ]; then
+    printf '%s\n' "--skip-ssl"
+  fi
+}
+
 wp() {
+  local extra_db_arg=""
+  extra_db_arg="$(_wp_cli_db_extra_args "$1")"
+
   if [ "${DRY_RUN}" = "true" ]; then
-    echo "[DRY_RUN] wp $*"
+    echo "[DRY_RUN] wp $* ${extra_db_arg}"
     return 0
   fi
   # --skip-plugins/themes: avoid loading all installed plugins on every call
   # (huge speedup when Composer packages like s3-uploads are installed)
   if [ "${DEBUG}" = "true" ]; then
-    command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes --debug "$@"
+    if [ -n "$extra_db_arg" ]; then
+      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes --debug "$@" "$extra_db_arg"
+    else
+      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes --debug "$@"
+    fi
   else
-    command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes "$@"
+    if [ -n "$extra_db_arg" ]; then
+      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes "$@" "$extra_db_arg"
+    else
+      command wp --path="${WORDPRESS_PATH}" --skip-plugins --skip-themes "$@"
+    fi
   fi
 }
 
@@ -108,15 +125,26 @@ wp() {
 #
 # Args: All arguments are passed through to wp-cli
 wp_with_plugins() {
+  local extra_db_arg=""
+  extra_db_arg="$(_wp_cli_db_extra_args "$1")"
+
   if [ "${DRY_RUN}" = "true" ]; then
-    echo "[DRY_RUN] wp(with-plugins) $*"
+    echo "[DRY_RUN] wp(with-plugins) $* ${extra_db_arg}"
     return 0
   fi
 
   if [ "${DEBUG}" = "true" ]; then
-    command wp --path="${WORDPRESS_PATH}" --skip-themes --debug "$@"
+    if [ -n "$extra_db_arg" ]; then
+      command wp --path="${WORDPRESS_PATH}" --skip-themes --debug "$@" "$extra_db_arg"
+    else
+      command wp --path="${WORDPRESS_PATH}" --skip-themes --debug "$@"
+    fi
   else
-    command wp --path="${WORDPRESS_PATH}" --skip-themes "$@"
+    if [ -n "$extra_db_arg" ]; then
+      command wp --path="${WORDPRESS_PATH}" --skip-themes "$@" "$extra_db_arg"
+    else
+      command wp --path="${WORDPRESS_PATH}" --skip-themes "$@"
+    fi
   fi
 }
 
@@ -133,6 +161,56 @@ run() {
   else
     "$@" >/dev/null 2>&1
   fi
+}
+
+# Check whether a database table exists without relying on wp db query/mysql client.
+# This uses the same PHP mysqli path as WordPress itself, which is more reliable
+# during bootstrap against external databases.
+db_table_exists() {
+  local table_name="$1"
+
+  if [ -z "$table_name" ]; then
+    return 1
+  fi
+
+  DB_TABLE_NAME="$table_name" php <<'PHPEOF'
+<?php
+mysqli_report(MYSQLI_REPORT_OFF);
+
+$host = getenv('WORDPRESS_DB_HOST');
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$name = getenv('WORDPRESS_DB_NAME');
+$table = getenv('DB_TABLE_NAME');
+
+if ($table === false || $table === '') {
+  exit(1);
+}
+
+$c = @new mysqli($host, $user, $pass, $name);
+if ($c->connect_error) {
+  exit(1);
+}
+
+$escapedTable = $c->real_escape_string($table);
+$result = $c->query("SELECT 1 FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '{$escapedTable}' LIMIT 1");
+if ($result && $result->fetch_row()) {
+  $result->free();
+  $c->close();
+  exit(0);
+}
+
+if ($result) {
+  $result->free();
+}
+
+$c->close();
+exit(1);
+PHPEOF
+}
+
+wp_table_exists() {
+  db_table_exists "${TABLE_PREFIX}$1"
 }
 
 # Multisite-aware wp wrapper for site-specific operations

--- a/charts/wordpress/templates/_init-lib-lock.tpl
+++ b/charts/wordpress/templates/_init-lib-lock.tpl
@@ -70,6 +70,77 @@ _stop_heartbeat() {
   fi
 }
 
+_lock_db_query() {
+  local sql="$1"
+
+  LOCK_SQL="$sql" php <<'PHPEOF'
+<?php
+mysqli_report(MYSQLI_REPORT_OFF);
+
+$host = getenv('WORDPRESS_DB_HOST');
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$name = getenv('WORDPRESS_DB_NAME');
+$sql = getenv('LOCK_SQL');
+
+$m = @new mysqli($host, $user, $pass, $name);
+if ($m->connect_error) {
+  fwrite(STDERR, $m->connect_error);
+  exit(1);
+}
+
+if ($sql === false || $sql === '') {
+  fwrite(STDERR, 'missing SQL statement');
+  $m->close();
+  exit(1);
+}
+
+if (!$m->query($sql)) {
+  fwrite(STDERR, $m->error);
+  $m->close();
+  exit(1);
+}
+
+$m->close();
+PHPEOF
+}
+
+_lock_db_read_value() {
+  local sql="$1"
+
+  LOCK_SQL="$sql" php <<'PHPEOF'
+<?php
+mysqli_report(MYSQLI_REPORT_OFF);
+
+$host = getenv('WORDPRESS_DB_HOST');
+$user = getenv('WORDPRESS_DB_USER');
+$pass = getenv('WORDPRESS_DB_PASSWORD');
+$name = getenv('WORDPRESS_DB_NAME');
+$sql = getenv('LOCK_SQL');
+
+$m = @new mysqli($host, $user, $pass, $name);
+if ($m->connect_error) {
+  fwrite(STDERR, $m->connect_error);
+  exit(1);
+}
+
+$result = $m->query($sql);
+if (!$result) {
+  fwrite(STDERR, $m->error);
+  $m->close();
+  exit(1);
+}
+
+$row = $result->fetch_row();
+if ($row && array_key_exists(0, $row) && $row[0] !== null) {
+  echo $row[0];
+}
+
+$result->free();
+$m->close();
+PHPEOF
+}
+
 # Attempt to claim bootstrap lock using dedicated helm_locks table
 # This is used BEFORE WordPress installation when wp_options doesn't exist yet
 #
@@ -95,16 +166,20 @@ claim_bootstrap_lock() {
     # Ensure helm_locks table exists on every attempt
     # (CREATE TABLE IF NOT EXISTS is idempotent and fast when table already exists)
     # This handles the case where MariaDB accepts connections but isn't fully ready for DDL yet
-    wp db query "
+    local create_table_output=""
+    if ! create_table_output=$(_lock_db_query "
       CREATE TABLE IF NOT EXISTS ${TABLE_PREFIX}helm_locks (
         lock_name VARCHAR(64) PRIMARY KEY,
         lock_value VARCHAR(255) NOT NULL,
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       );
-    " >/dev/null 2>&1
+    " 2>&1); then
+      return 1
+    fi
 
     # Atomic lock claim: override if same hostname OR no heartbeat for STALE_THRESHOLD seconds
-    wp db query "
+    local claim_output=""
+    if ! claim_output=$(_lock_db_query "
       INSERT INTO ${TABLE_PREFIX}helm_locks (lock_name, lock_value)
       VALUES ('bootstrap', '$pod_hostname-$current_time')
       ON DUPLICATE KEY UPDATE
@@ -114,12 +189,19 @@ claim_bootstrap_lock() {
           '$pod_hostname-$current_time',
           lock_value
         );
-    " >/dev/null 2>&1
+    " 2>&1); then
+      return 1
+    fi
 
     sleep 0.1
 
     # Check if we got the lock
-    local lock_owner=$(wp db query "SELECT lock_value FROM ${TABLE_PREFIX}helm_locks WHERE lock_name='bootstrap';" --skip-column-names 2>/dev/null || echo "")
+    local lock_owner=""
+    local lock_query_output=""
+    if ! lock_query_output=$(_lock_db_read_value "SELECT lock_value FROM ${TABLE_PREFIX}helm_locks WHERE lock_name='bootstrap';" 2>&1); then
+      return 1
+    fi
+    lock_owner="$lock_query_output"
 
     if [[ "$lock_owner" == "$pod_hostname-$current_time" ]]; then
       echo "Bootstrap lock acquired successfully!"
@@ -175,7 +257,8 @@ claim_config_lock() {
     current_time=$(date +%s)
 
     # Atomic lock claim: override if same hostname OR no heartbeat for STALE_THRESHOLD seconds
-    wp db query "
+    local claim_output=""
+    if ! claim_output=$(_lock_db_query "
       INSERT INTO ${TABLE_PREFIX}options (option_name, option_value, autoload)
       VALUES ('_helm_config_lock', '$pod_hostname-$current_time', 'no')
       ON DUPLICATE KEY UPDATE
@@ -185,12 +268,19 @@ claim_config_lock() {
           '$pod_hostname-$current_time',
           option_value
         );
-    " >/dev/null 2>&1
+    " 2>&1); then
+      return 1
+    fi
 
     sleep 0.1
 
     # Check if we got the lock
-    local lock_owner=$(wp db query "SELECT option_value FROM ${TABLE_PREFIX}options WHERE option_name='_helm_config_lock';" --skip-column-names 2>/dev/null || echo "")
+    local lock_owner=""
+    local lock_query_output=""
+    if ! lock_query_output=$(_lock_db_read_value "SELECT option_value FROM ${TABLE_PREFIX}options WHERE option_name='_helm_config_lock';" 2>&1); then
+      return 1
+    fi
+    lock_owner="$lock_query_output"
 
     if [[ "$lock_owner" == "$pod_hostname-$current_time" ]]; then
       CONFIG_LOCK_ACQUIRED=true

--- a/charts/wordpress/templates/_init-script.tpl
+++ b/charts/wordpress/templates/_init-script.tpl
@@ -165,7 +165,7 @@ fi
 
 # Check if WordPress is already installed (quick check before claiming lock)
 WP_ALREADY_INSTALLED=false
-if wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}options';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}options"; then
+if wp_table_exists "options"; then
   if run wp core is-installed --url="${WP_URL}" 2>/dev/null; then
     WP_ALREADY_INSTALLED=true
     echo "WordPress is already installed, skipping bootstrap lock."
@@ -195,7 +195,7 @@ if [ "${WP_INIT}" = "true" ]; then
   WP_INSTALLED=false
   if run wp core is-installed --url="${WP_URL}" 2>/dev/null; then
     # wp-cli says installed, but verify tables actually exist
-    if wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}options';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}options"; then
+    if wp_table_exists "options"; then
       WP_INSTALLED=true
       echo "WordPress is already installed, skipping installation."
     else
@@ -216,7 +216,7 @@ if [ "${WP_INIT}" = "true" ]; then
       --locale="${WP_LOCALE}"
 
     # Verify installation succeeded
-    if ! wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}options';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}options"; then
+    if ! wp_table_exists "options"; then
       echo "ERROR: WordPress installation failed - wp_options table not created!"
       exit 1
     fi
@@ -236,7 +236,7 @@ if [ "${WP_INIT}" = "true" ]; then
       echo "Network domain: ${DOMAIN_CURRENT_SITE}"
 
       # Check if already converted to multisite (check for wp_sitemeta table)
-      if ! wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}sitemeta';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}sitemeta"; then
+      if ! wp_table_exists "sitemeta"; then
         echo "Converting WordPress to multisite..."
 
         # Determine subdomain/subdirectory mode
@@ -249,7 +249,7 @@ if [ "${WP_INIT}" = "true" ]; then
         fi
 
         # Verify conversion succeeded
-        if ! wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}sitemeta';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}sitemeta"; then
+        if ! wp_table_exists "sitemeta"; then
           echo "ERROR: Multisite conversion failed - sitemeta table not created!"
           exit 1
         fi
@@ -280,7 +280,7 @@ else
   # Use cached TABLE_PREFIX (set at script start)
 
   # Check if wp_options table exists
-  if ! wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}options';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}options"; then
+  if ! wp_table_exists "options"; then
     echo "========================================="
     echo "ERROR: WordPress database tables not found!"
     echo "========================================="
@@ -323,7 +323,7 @@ fi
 
 if [ "${WP_MULTISITE_ENABLED:-false}" = "true" ]; then
   # Only proceed if wp_sitemeta table exists (multisite is actually set up)
-  if wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}sitemeta';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}sitemeta"; then
+  if wp_table_exists "sitemeta"; then
     # Extract domain from WP_URL for site checks
     DOMAIN_CURRENT_SITE=$(echo "${WP_URL}" | sed -E 's|^https?://||' | sed -E 's|/.*||')
 
@@ -569,7 +569,7 @@ echo "Configuration lock acquired, proceeding with initialization..."
 # ============================================================================
 
 # Only run if wp_options table exists (skip for fresh installs without WP_INIT=true)
-if wp db query "SHOW TABLES LIKE '${TABLE_PREFIX}options';" --skip-column-names 2>/dev/null | grep -q "${TABLE_PREFIX}options"; then
+if wp_table_exists "options"; then
   echo "Disabling WordPress core auto-updates..."
   # Update all 3 settings in one multi-row query (faster than 3 separate queries)
   wp db query "


### PR DESCRIPTION
<!--
Please start the pull request title with the chart name in square brackets, e.g.
`[wordpress] Update default image`
-->

# Summary
This PR improves and fixes https://github.com/SlyBase/helm-charts/issues/297 the wordpress init scripts to get wordpress setup and running. 

I used an external mariadb and the pod got stuck in the bootstrap lock query loop:

```
kubectl logs wordpress-6bbd85fc46-r6zg8 -c wordpress-init -f                                                                                                                      
Starting init script...
Waiting for database...
Database connection established!
Using WordPress table prefix: wp_
WordPress not installed yet, claiming bootstrap lock...
Attempting to claim bootstrap lock (for WordPress installation)...
Bootstrap lock query failed, retrying... (10s)
Bootstrap lock query failed, retrying... (20s)
Bootstrap lock query failed, retrying... (30s)
Bootstrap lock query failed, retrying... (40s)
Bootstrap lock query failed, retrying... (50s)
Bootstrap lock query failed, retrying... (60s)
Bootstrap lock query failed, retrying... (70s)
Bootstrap lock query failed, retrying... (80s)
Bootstrap lock query failed, retrying... (90s)
Bootstrap lock query failed, retrying... (100s)
Bootstrap lock query failed, retrying... (110s)
Bootstrap lock query failed, retrying... (120s)
```
---

## Checklist (required before merge)

- [x] I have updated the `Chart.yaml` version for the affected chart(s) (bumped the `version` field).
- [x] I have added an entry in the chart's `artifacthub.io/changes` annotation (in `Chart.yaml`) describing the change. Use one of the supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
- [x] I have run a quick install/upgrade smoke test where applicable.
- [x] I have updated documentation or samples if necessary.

If your change only affects documentation or images and doesn't change chart behavior, please mention that and skip the Chart version bump if appropriate — but prefer bumping the chart version for clarity.

---

Additional notes:

- See Artifact Hub annotation docs for `artifacthub.io/changes`: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
- When editing multiple charts, ensure each chart's `Chart.yaml` is updated and annotated.
