### PR TITLE
chore(renovate): add version-specific branch topics

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -120,6 +120,7 @@
                 "charts/**"
             ],
             "groupName": "chart/{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}/{{{depName}}}/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "chart-{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"
@@ -145,6 +146,7 @@
                 "docker.io/linuxserver/wireguard"
             ],
             "groupName": "chart/wireguard/wireguard/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "chart-wireguard-wireguard-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
             "commitMessageAction": "charts/wireguard chore(deps): wireguard",
             "commitMessageTopic": "",
             "commitMessageExtra": " {{#if (equals updateType 'digest')}}digest {{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}"
@@ -158,6 +160,7 @@
                 "charts/**"
             ],
             "groupName": "subchart/{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}/{{{depName}}}/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "subchart-{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"
@@ -180,6 +183,7 @@
                 "charts/wordpress/**"
             ],
             "groupName": "subchart/wordpress/{{{depName}}}/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "subchart-wordpress-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"
@@ -272,6 +276,7 @@
             "matchFileNames": [
                 ".github/workflows/**"
             ],
+            "branchTopic": "github-actions-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"


### PR DESCRIPTION
This updates Renovate package rules to use version-specific branchTopic values for direct chart updates, wordpress subchart updates, wireguard direct updates, and GitHub Actions updates.

Why:
Existing branch reuse allowed stale Renovate branches to be recycled for newer patch/digest PRs. That produced PRs whose title/body advertised a newer update while the actual diff still contained an older already-merged change, as seen with the stale duplicates around #315 and #317.

What changed:
- add branchTopic templates for grouped direct chart updates
- add a dedicated branchTopic template for the wireguard direct update rule
- add branchTopic templates for grouped subchart updates, including wordpress
- add a branchTopic template for GitHub Actions workflow updates

This should force unique Renovate branches per target version/digest and prevent loop-protection-driven stale duplicate PRs.