### PR TITLE
chore(ci): fix automerge safety, app-id deprecation & chart version check

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -155,7 +155,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
-          app-id: ${{ secrets.SLYBASE_APP_ID }}
+          client-id: ${{ secrets.SLYBASE_APP_ID }}
           private-key: ${{ secrets.SLYBASE_APP_PRIVATE_KEY }}
           owner: SlyBase
         continue-on-error: true

--- a/.github/workflows/pr-chart-validate.yml
+++ b/.github/workflows/pr-chart-validate.yml
@@ -64,3 +64,43 @@ jobs:
 
             echo "::endgroup::"
           done
+
+      - name: Check chart version bump
+        shell: bash
+        env:
+          CHARTS_JSON: ${{ steps.charts.outputs.charts_json }}
+        run: |
+          set -euo pipefail
+
+          mapfile -t chart_dirs < <(printf '%s' "$CHARTS_JSON" | jq -r '.[]')
+
+          if [ "${#chart_dirs[@]}" -eq 0 ]; then
+            echo "No chart changes detected, skipping version check"
+            exit 0
+          fi
+
+          failed=0
+          for chart_dir in "${chart_dirs[@]}"; do
+            main_version=$(git show "origin/main:${chart_dir}/Chart.yaml" 2>/dev/null \
+              | awk '/^version:/ { print $2; exit }') || true
+            if [ -z "$main_version" ]; then
+              echo "⏩ ${chart_dir}: new chart, skipping version check"
+              continue
+            fi
+
+            pr_version=$(awk '/^version:/ { print $2; exit }' "${chart_dir}/Chart.yaml")
+
+            if [ "$pr_version" = "$main_version" ]; then
+              echo "❌ ${chart_dir}: chart version not bumped (still ${pr_version})" >&2
+              failed=1
+            else
+              echo "✅ ${chart_dir}: version ${main_version} → ${pr_version}"
+            fi
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "" >&2
+            echo "One or more charts were changed without bumping Chart.yaml version." >&2
+            echo "Ensure postUpgradeTasks ran (self-hosted Renovate) or bump the version manually." >&2
+            exit 1
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
         "41898282+github-actions[bot]@users.noreply.github.com"
     ],
     "platformAutomerge": true,
+    "automergeRequireAllStatusChecks": true,
     "rebaseWhen": "conflicted",
     "semanticCommits": "disabled",
     "enabledManagers": [


### PR DESCRIPTION
Fixes three issues discovered during the investigation of PR #324 (Mend Renovate App creating PRs without `postUpgradeTasks`).

## Changes

### `renovate.json` — automerge safety (Problem 1)
Add `automergeRequireAllStatusChecks: true` globally.  
Previously `platformAutomerge: true` only checked GitHub's *required* status checks. With this setting Renovate waits for **all** status checks to pass before auto-merging, so a failing `chart-validate` or artifact-update check will block the merge.

### `.github/workflows/oci-release.yaml` — deprecation fix (Problem 4)
Rename `app-id:` → `client-id:` in the `actions/create-github-app-token` step.  
The old input name was deprecated in v3 and produced a warning on every OCI release run.

### `.github/workflows/pr-chart-validate.yml` — version bump enforcement (Problem 2+3)
Add a new *"Check chart version bump"* step after the helm-lint step.  
For every changed chart it compares the `version` field in `Chart.yaml` against `origin/main`. If the version was not incremented the step fails with an actionable error message, preventing merges of chart changes that missed the metadata update step.  
New charts (not yet on `main`) are skipped automatically.

## Root cause (for reference)
The Mend Renovate App was running alongside the self-hosted Renovate workflow. The Mend App cannot execute `postUpgradeTasks` with custom commands, so `update-chart-metadata.py` never ran → no chart version bump, no CHANGELOG entry. The Mend App has since been uninstalled.