### PR TITLE
charts/wg-easy: fix schema validation when used as a dependency (v0.9.1)

### DIFF
--- a/charts/wg-easy/CHANGELOG.md
+++ b/charts/wg-easy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this chart are documented here.
 
+## 0.9.1 - 2026-05-21
+
+- Fix schema validation failure when chart is used as a Helm dependency: added `global` property to `values.schema.json` so Helm's automatic global values injection no longer conflicts with `additionalProperties: false` at the root level
+
 ## 0.9.0 - 2026-05-18
 
 - Update ghcr.io/wg-easy/wg-easy to 15.3.0

--- a/charts/wg-easy/Chart.yaml
+++ b/charts/wg-easy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wg-easy
 description: Using the offical wg-easy/wg-easy image with almost any environment variables for K8s. Supporting Init Mode.
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: 15.3.0 # renovate: image=ghcr.io/wg-easy/wg-easy
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wg-easy/app.png
 home: https://github.com/slydlake/helm-charts
@@ -22,8 +22,8 @@ annotations:
     - name: slydlake
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update ghcr.io/wg-easy/wg-easy to 15.3.0"
+    - kind: fixed
+      description: "Allow Helm global values injection when chart is used as a dependency"
   artifacthub.io/containsSecurityUpdates: false
   artifacthub.io/images: |
     - name: wg-easy

--- a/charts/wg-easy/values.schema.json
+++ b/charts/wg-easy/values.schema.json
@@ -6,6 +6,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "global": {
+      "title": "Global values",
+      "description": "Global values injected by Helm during dependency coalescing.",
+      "type": "object",
+      "additionalProperties": true
+    },
     "replicaCount": {
       "title": "Replica count",
       "type": "integer",


### PR DESCRIPTION
## Summary

- Adds a `global` property to `values.schema.json` so Helm's automatic global values injection during dependency coalescing no longer conflicts with `additionalProperties: false` at the root level
- Bumps chart version to `0.9.1`

Fixes #338

## Root cause

Helm injects a `global` object into all subchart values before schema validation runs. The `wg-easy` schema had `additionalProperties: false` at the root without a `global` property defined, causing installations to fail with:

```
values don't meet the specifications of the schema(s) in the following chart(s):
wg-easy:
- at '': additional properties 'global' not allowed
```

## Fix

```json
"global": {
  "title": "Global values",
  "description": "Global values injected by Helm during dependency coalescing.",
  "type": "object",
  "additionalProperties": true
}
```

`additionalProperties: false` at the root is preserved — strict validation for all real chart values remains intact.

## Test plan

- [ ] `helm lint charts/wg-easy/` passes
- [ ] `helm install --dry-run` with `wg-easy` as a subchart succeeds without schema errors
- [ ] Invalid wg-easy values (e.g. unknown key) still fail validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)