### PR TITLE
feat(wordpress): Application Passwords + JWT authentication (4.1.0)

### DIFF
--- a/charts/wordpress/CHANGELOG.md
+++ b/charts/wordpress/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this chart are documented here.
 
+## 4.1.0 - 2026-05-23
+
+- Add token-based authentication support for external connectivity (e.g. MCP):
+  - `wordpress.init.jwt.enabled`: auto-installs `jwt-authentication-for-wp-rest-api` in the init container and injects `JWT_AUTH_SECRET_KEY` into `wp-config.php`; signing secret is auto-generated and preserved across upgrades via `lookup`
+  - `wordpress.init.jwt.secret` / `wordpress.init.jwt.existingSecret` + `wordpress.init.jwt.secretKey`: bring your own signing secret (inline or from an existing K8s Secret)
+  - `wordpress.init.applicationPassword` / `wordpress.users[].applicationPassword`: WP-CLI in the init container creates WordPress Application Passwords per user and stores credentials in a Kubernetes Secret (persists after `helm uninstall`)
+  - New template: `app-password-rbac.yaml` (Role + RoleBinding granting the WordPress ServiceAccount write access to the output Secrets)
+
 ## 4.0.0 - 2026-05-22
 
 - Update docker.io/wordpress to 7.0.0

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wordpress
 description: "Using the official WordPress image. This chart provides automation for installation, user management, plugin installation, and metrics."
 type: application
-version: 4.0.0
+version: 4.1.0
 appVersion: "7.0.0" # renovate: image=docker.io/wordpress
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts
@@ -26,8 +26,8 @@ annotations:
     - name: slydlake
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update docker.io/wordpress to 7.0.0"
+    - kind: added
+      description: "Token-based auth: Application Passwords (stored in K8s Secrets) and JWT signing key injection via jwt-authentication-for-wp-rest-api"
   artifacthub.io/images: |
     - name: wordpress
       image: docker.io/wordpress:7.0.0-php8.3-apache

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -115,6 +115,20 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 - Reference multiple ConfigMaps in `wordpress.muPluginsConfigMaps`
 - See `samples/muPlugins.configmap.yaml` and `samples/muPlugins.values.yaml`
 
+### Application Passwords (MCP / REST API access)
+- **Create Application Passwords** during init for the admin user and any additional users
+- The raw password (visible only once after creation) is stored in a Kubernetes Secret and survives `helm uninstall`
+- Idempotent: existing passwords are reused; only re-created when the K8s Secret is gone but the WP entry is missing (or vice-versa)
+- Uses WP-CLI in the init container — no REST API auth required during setup
+- See `samples/token.values.yaml`
+
+### JWT Authentication (MCP / REST API access)
+- **Auto-installs `jwt-authentication-for-wp-rest-api`** in the init container when `wordpress.init.jwt.enabled: true` — no manual entry in `wordpress.plugins` needed
+- The JWT signing secret is auto-generated on first install and preserved across `helm upgrade` via Helm's `lookup`
+- Bring your own secret: set `wordpress.init.jwt.secret` (inline value) or point to an existing K8s Secret via `wordpress.init.jwt.existingSecret` + `wordpress.init.jwt.secretKey` (key name within that Secret, default `JWT_AUTH_SECRET_KEY`)
+- The secret is injected into `wp-config.php` as `define('JWT_AUTH_SECRET_KEY', getenv('JWT_AUTH_SECRET_KEY'))` via the chart-managed Secret
+- See `samples/token.values.yaml`
+
 
 ## Security by default
 
@@ -298,6 +312,151 @@ kubectl apply -f ./samples/muPlugins.configmap.yaml
 helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples/muPlugins.values.yaml
 ```
 
+### Application Passwords + JWT (REST API / MCP access)
+Configure per-user Application Passwords and JWT auth in one step. See `samples/token.values.yaml`.
+
+```yaml
+# samples/token.values.yaml (excerpt)
+wordpress:
+  init:
+    existingSecret: "wordpress-secret"
+
+    # JWT: auto-installs jwt-authentication-for-wp-rest-api, auto-generates signing secret
+    jwt:
+      enabled: true
+      # secret: ""                        # inline signing secret — auto-generated if empty
+      # existingSecret: ""                # alternative: name of an existing K8s Secret
+      # secretKey: "JWT_AUTH_SECRET_KEY"  # key within existingSecret (default: JWT_AUTH_SECRET_KEY)
+
+    # Application Password for the admin user
+    applicationPassword:
+      name: "API Access"
+      outputSecret:
+        name: "wordpress-token-admin"
+        usernameKey: "WP_USERNAME"
+        passwordKey: "WP_APP_PASSWORD"
+        urlKey: "WP_SITE_URL"
+
+  users:
+    - username: "service-account"
+      email: "svc@example.com"
+      role: "editor"
+      sendEmail: false
+      applicationPassword:
+        name: "API Access"
+        outputSecret:
+          name: "wordpress-token-svc"
+          usernameKey: "WP_USERNAME"
+          passwordKey: "WP_APP_PASSWORD"
+          urlKey: "WP_SITE_URL"
+```
+
+```bash
+helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values samples/token.values.yaml
+```
+
+**Read credentials after install:**
+
+```bash
+# Application Password (admin)
+kubectl get secret wordpress-token-admin \
+  -o go-template='user={{ index .data "WP_USERNAME" | base64decode }}  pass={{ index .data "WP_APP_PASSWORD" | base64decode }}{{ "\n" }}'
+
+# Application Password (service account)
+kubectl get secret wordpress-token-svc \
+  -o go-template='user={{ index .data "WP_USERNAME" | base64decode }}  pass={{ index .data "WP_APP_PASSWORD" | base64decode }}{{ "\n" }}'
+```
+
+**Test Application Password against the REST API:**
+
+```bash
+USER=$(kubectl get secret wordpress-token-admin -o jsonpath='{.data.WP_USERNAME}' | base64 -d)
+PASS=$(kubectl get secret wordpress-token-admin -o jsonpath='{.data.WP_APP_PASSWORD}' | base64 -d)
+URL=$(kubectl get secret wordpress-token-admin -o jsonpath='{.data.WP_SITE_URL}' | base64 -d)
+
+curl -su "$USER:$PASS" "$URL/wp-json/wp/v2/users/me" | jq '{id,slug,roles}'
+```
+
+**Test JWT:**
+
+```bash
+WP_PASS=$(kubectl get secret wordpress-secret -o jsonpath='{.data.wordpress\.password}' | base64 -d)
+JWT=$(curl -sf -X POST "$URL/wp-json/jwt-auth/v1/token" \
+  -d "username=$USER&password=$WP_PASS" | jq -r '.token')
+
+curl -sf -H "Authorization: Bearer $JWT" "$URL/wp-json/wp/v2/users/me" | jq '{id,slug}'
+```
+
+> **HTTP sites:** WordPress 5.6+ disables Application Passwords on non-HTTPS sites. Add this filter to an MU-Plugin to allow it on HTTP (e.g. cluster-internal or local):
+> ```php
+> add_filter('wp_is_application_passwords_available', '__return_true');
+> ```
+> In production behind TLS this filter is not needed.
+
+---
+
+### MCP (Model Context Protocol) via WordPress
+
+The [`wordpress/mcp-adapter`](https://github.com/slybase/mcp-adapter) plugin exposes a **Streamable HTTP MCP server** at `/wp-json/mcp/mcp-adapter-default-server`.
+Both Application Password and JWT auth work as `Authorization` headers.
+
+Configure two named connections in your project's `.claude/settings.local.json`:
+
+```json
+{
+  "mcpServers": {
+    "wordpress-app-password": {
+      "type": "http",
+      "url": "https://example.com/wp-json/mcp/mcp-adapter-default-server",
+      "headers": {
+        "Authorization": "Basic <base64(username:app-password)>"
+      }
+    },
+    "wordpress-jwt": {
+      "type": "http",
+      "url": "https://example.com/wp-json/mcp/mcp-adapter-default-server",
+      "headers": {
+        "Authorization": "Bearer <jwt-token>"
+      }
+    }
+  }
+}
+```
+
+Generate the credentials from Kubernetes Secrets:
+
+```bash
+WP_URL=$(kubectl get secret wordpress-token-admin -o jsonpath='{.data.WP_SITE_URL}' | base64 -d)
+USER=$(kubectl get secret wordpress-token-admin -o jsonpath='{.data.WP_USERNAME}' | base64 -d)
+PASS=$(kubectl get secret wordpress-token-admin -o jsonpath='{.data.WP_APP_PASSWORD}' | base64 -d)
+WP_LOGIN_PASS=$(kubectl get secret wordpress-secret -o jsonpath='{.data.wordpress\.password}' | base64 -d)
+
+# Application Password → Basic Auth header value
+echo "Basic $(echo -n "$USER:$PASS" | base64)"
+
+# JWT → Bearer token (expires in ~7 days)
+curl -sf -X POST "$WP_URL/wp-json/jwt-auth/v1/token" \
+  -d "username=$USER&password=$WP_LOGIN_PASS" | jq -r '"Bearer " + .token'
+```
+
+> **Tip:** Application Passwords don't expire — prefer them for long-running automations.
+> JWT tokens expire after ~7 days; refresh by re-running the `jwt-auth/v1/token` request.
+
+Required plugins (add to `wordpress.plugins`):
+```yaml
+wordpress:
+  init:
+    jwt:
+      enabled: true        # auto-installs jwt-authentication-for-wp-rest-api
+  plugins:
+    - name: "wordpress/mcp-adapter"
+      activate: true
+    - name: "enable-abilities-for-mcp"
+      activate: true
+```
+
+---
+
 ### Composer Packages
 Install plugins and themes via Composer that aren't available in WordPress.org. See `samples/composer.values.yaml`.
 
@@ -410,6 +569,16 @@ Without `slug`, URL plugins/themes use `basename` of the URL as a best-effort gu
 - **Network activation** (`networkActivate` / `networkEnable`)
 
 ## Notable changes
+
+### To 4.1.0
+- Added **Application Passwords** (`wordpress.init.applicationPassword`, `wordpress.users[].applicationPassword`): WP-CLI in the init container creates Application Passwords per user and stores them in Kubernetes Secrets (persist after `helm uninstall`).
+- Added **JWT Authentication** (`wordpress.init.jwt`): auto-installs `jwt-authentication-for-wp-rest-api` in the init container, signing secret is auto-generated and preserved across upgrades via `lookup`.
+- New `wordpress.init.jwt.secret`: inline signing secret value (replaces the old `signingKey` field — it is the secret VALUE, not a key name).
+- New `wordpress.init.jwt.secretKey`: key name within `wordpress.init.jwt.existingSecret` (default: `JWT_AUTH_SECRET_KEY`).
+- New template `app-password-rbac.yaml`: Role + RoleBinding so the WordPress ServiceAccount can write Application Password output Secrets.
+
+### To 4.0.0
+- Update WordPress to 7.0.0 (PHP 8.3). WordPress 7.0 uses `$generic$` password hashing for Application Passwords (replaces phpass). Existing Application Passwords remain valid; new ones are created in the updated format automatically.
 
 ### To 3.4.0
 - Complete Memcached object-cache support for WordPress, including runtime bootstrap of `memcache`/`memcached` PHP extensions (no custom image required).

--- a/charts/wordpress/samples/token.values.yaml
+++ b/charts/wordpress/samples/token.values.yaml
@@ -1,0 +1,65 @@
+## Token Authentication Sample
+##
+## Demonstrates both authentication methods for external connectivity (e.g. MCP):
+##   1. JWT via jwt-authentication-for-wp-rest-api (wordpress.init.jwt.enabled)
+##   2. Application Passwords per user (applicationPassword field)
+##
+## After install, retrieve credentials:
+##   # Application Password (admin)
+##   kubectl get secret <release>-token-admin -o jsonpath='{.data.WP_APP_PASSWORD}' | base64 -d
+##
+##   # JWT Signing Key
+##   kubectl get secret <release>-wordpress -o jsonpath='{.data.JWT_AUTH_SECRET_KEY}' | base64 -d
+##
+## Test Application Password:
+##   APP_PASS=$(kubectl get secret <release>-token-admin -o jsonpath='{.data.WP_APP_PASSWORD}' | base64 -d)
+##   curl -sf -u "admin:$APP_PASS" https://<site>/wp-json/wp/v2/users/me
+##
+## Test JWT:
+##   curl -sf -X POST https://<site>/wp-json/jwt-auth/v1/token \
+##     -d "username=admin&password=<adminpass>"
+
+wordpress:
+  url: "https://wordpress.example.com"
+
+  init:
+    enabled: true
+    existingSecret: "wordpress-init-secret"
+
+    ## JWT Authentication via jwt-authentication-for-wp-rest-api (auto-installed, no plugin entry needed)
+    jwt:
+      enabled: true
+      # secret: ""           # auto-generated and preserved across upgrades
+      # existingSecret: ""   # use existing Secret containing the signing key
+      # secretKey: "JWT_AUTH_SECRET_KEY"  # key within existingSecret
+
+    ## Application Password for the admin user
+    applicationPassword:
+      name: "API Access"
+      outputSecret:
+        name: ""              # empty = <release>-token-admin (auto-derived)
+        usernameKey: "WP_USERNAME"
+        passwordKey: "WP_APP_PASSWORD"
+        urlKey: "WP_SITE_URL"
+
+  ## Optional: dedicated service user with its own Application Password
+  users:
+    - username: api-service
+      email: api@example.com
+      displayname: "API Service"
+      role: editor
+      sendEmail: false
+      applicationPassword:
+        name: "API Access"
+        outputSecret:
+          name: "wordpress-token-api-service"
+          usernameKey: "WP_USERNAME"
+          passwordKey: "WP_APP_PASSWORD"
+          urlKey: "WP_SITE_URL"
+
+mariadb:
+  enabled: true
+  auth:
+    database: wordpress
+    username: wordpress
+    existingSecret: wordpress-mariadb-secret

--- a/charts/wordpress/samples/verify/cm.yaml
+++ b/charts/wordpress/samples/verify/cm.yaml
@@ -8,6 +8,10 @@ data:
     post_max_size = 64M
     memory_limit = 256M
   htaccess: |
+    # Pass HTTP Authorization header to PHP
+    # Required for WordPress Application Passwords and JWT authentication
+    SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+
     # Server-status exception
     <IfModule mod_rewrite.c>
     RewriteRule ^server-status - [L]
@@ -274,3 +278,8 @@ data:
 
     // Disable XML-RPC to prevent attacks
     add_filter('xmlrpc_enabled', '__return_false');
+
+    // Allow Application Passwords over HTTP for local/cluster-internal access.
+    // wp_is_application_passwords_available() returns false on non-HTTPS sites; this overrides that.
+    // In production with HTTPS this filter is not needed — WordPress enables it automatically.
+    add_filter('wp_is_application_passwords_available', '__return_true');

--- a/charts/wordpress/samples/verify/install.sh
+++ b/charts/wordpress/samples/verify/install.sh
@@ -11,7 +11,7 @@ echo "==> Applying ConfigMap..."
 kubectl apply -f "${SCRIPT_DIR}/cm.yaml"
 
 echo "==> Installing wordpress-verify..."
-helm install wordpress-verify "${CHART_DIR}" \
+helm upgrade --install wordpress-verify "${CHART_DIR}" \
   --values "${SCRIPT_DIR}/values.yaml"
 
 echo ""

--- a/charts/wordpress/samples/verify/uninstall.sh
+++ b/charts/wordpress/samples/verify/uninstall.sh
@@ -6,6 +6,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 echo "==> Uninstalling wordpress-verify..."
 helm uninstall wordpress-verify || true
 
+echo "==> Waiting for PVC deletion..."
+kubectl wait --for=delete pvc/wordpress-verify --timeout=60s 2>/dev/null || true
+
 echo "==> Deleting ConfigMap..."
 kubectl delete -f "${SCRIPT_DIR}/cm.yaml" --ignore-not-found
 

--- a/charts/wordpress/samples/verify/values.yaml
+++ b/charts/wordpress/samples/verify/values.yaml
@@ -7,6 +7,15 @@ wordpress:
     title: "verify chart"
     customInitConfigMap:
       name: "wordpress-verify-config"
+    jwt:
+      enabled: true
+    applicationPassword:
+      name: "API Access"
+      outputSecret:
+        name: "wordpress-verify-token-johndoe"
+        usernameKey: "WP_USERNAME"
+        passwordKey: "WP_APP_PASSWORD"
+        urlKey: "WP_SITE_URL"
   language: "de_DE"
   muPluginsConfigMaps:
     - name: wordpress-verify-config
@@ -37,6 +46,13 @@ wordpress:
       lastname: "Smith"
       role: "contributor"
       sendEmail: false
+      applicationPassword:
+        name: "API Access"
+        outputSecret:
+          name: "wordpress-verify-token-johnsmith"
+          usernameKey: "WP_USERNAME"
+          passwordKey: "WP_APP_PASSWORD"
+          urlKey: "WP_SITE_URL"
   configExtraSecret:
     name: "wordpress-verify-secret"
   htaccessConfigMap: "wordpress-verify-config"

--- a/charts/wordpress/templates/_init-script.tpl
+++ b/charts/wordpress/templates/_init-script.tpl
@@ -902,6 +902,22 @@ if [ -n "${WORDPRESS_METRICS}" ]; then
 {{- end }}
 fi
 
+{{- if .Values.wordpress.init.jwt.enabled }}
+# JWT Authentication plugin (jwt-authentication-for-wp-rest-api)
+JWT_PLUGIN="jwt-authentication-for-wp-rest-api"
+echo "Checking JWT Authentication plugin..."
+if ! echo "$INSTALLED_PLUGINS" | grep -q "^${JWT_PLUGIN}$"; then
+  echo "Installing ${JWT_PLUGIN}..."
+  run wp plugin install "${JWT_PLUGIN}" --activate
+  PLUGINS_MODIFIED=true
+elif ! echo "$ACTIVE_PLUGINS" | grep -q "^${JWT_PLUGIN}$"; then
+  echo "Activating ${JWT_PLUGIN}..."
+  run wp plugin activate "${JWT_PLUGIN}"
+else
+  echo "${JWT_PLUGIN} already installed and active."
+fi
+{{- end }}
+
 # Handle custom plugins
 {{- if .Values.wordpress.plugins }}
 echo "========================================="
@@ -2278,6 +2294,143 @@ else
 fi
 {{- end }}
 
+
+{{- $hasAdminAppPass := not (empty .Values.wordpress.init.applicationPassword) }}
+{{- $hasUserAppPass := false }}
+{{- range .Values.wordpress.users }}
+{{- if .applicationPassword }}{{- $hasUserAppPass = true }}{{- end }}
+{{- end }}
+{{- if or $hasAdminAppPass $hasUserAppPass }}
+# ============================================================================
+# Application Password Setup
+# ============================================================================
+apk add --no-cache curl > /dev/null 2>&1 || true
+
+KUBE_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token 2>/dev/null || echo "")
+KUBE_NS=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace 2>/dev/null || echo {{ .Release.Namespace | quote }})
+KUBE_API="https://kubernetes.default.svc"
+KUBE_CA="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+ap_k8s_secret_exists() {
+  curl -sf --cacert "$KUBE_CA" \
+    -H "Authorization: Bearer $KUBE_TOKEN" \
+    "${KUBE_API}/api/v1/namespaces/${KUBE_NS}/secrets/${1}" \
+    > /dev/null 2>&1
+}
+
+ap_k8s_secret_write() {
+  local name="$1" wp_user="$2" app_pass="$3" url="$4"
+  local u_key="$5" p_key="$6" l_key="$7"
+  local enc_user enc_pass enc_url payload http_status
+  enc_user=$(printf '%s' "$wp_user"  | base64 | tr -d '\n')
+  enc_pass=$(printf '%s' "$app_pass" | base64 | tr -d '\n')
+  enc_url=$(printf '%s'  "$url"      | base64 | tr -d '\n')
+  payload="{\"apiVersion\":\"v1\",\"kind\":\"Secret\",\"metadata\":{\"name\":\"${name}\",\"namespace\":\"${KUBE_NS}\"},\"data\":{\"${u_key}\":\"${enc_user}\",\"${p_key}\":\"${enc_pass}\",\"${l_key}\":\"${enc_url}\"}}"
+  http_status=$(curl -s --cacert "$KUBE_CA" \
+      -H "Authorization: Bearer $KUBE_TOKEN" \
+      -H "Content-Type: application/json" \
+      -X POST "${KUBE_API}/api/v1/namespaces/${KUBE_NS}/secrets" \
+      -d "$payload" \
+      -o /dev/null -w "%{http_code}")
+  if [ "$http_status" = "201" ]; then
+    return 0
+  fi
+  echo "POST returned ${http_status}, trying PUT..."
+  http_status=$(curl -s --cacert "$KUBE_CA" \
+      -H "Authorization: Bearer $KUBE_TOKEN" \
+      -H "Content-Type: application/json" \
+      -X PUT "${KUBE_API}/api/v1/namespaces/${KUBE_NS}/secrets/${name}" \
+      -d "$payload" \
+      -o /dev/null -w "%{http_code}")
+  if [ "$http_status" = "200" ] || [ "$http_status" = "201" ]; then
+    return 0
+  fi
+  echo "ERROR: Failed to write Secret '${name}' (HTTP ${http_status})"
+  return 1
+}
+
+ap_k8s_secret_delete() {
+  curl -sf --cacert "$KUBE_CA" \
+    -H "Authorization: Bearer $KUBE_TOKEN" \
+    -X DELETE "${KUBE_API}/api/v1/namespaces/${KUBE_NS}/secrets/${1}" \
+    > /dev/null 2>&1 || true
+}
+
+create_app_password() {
+  local wp_user="$1" pass_name="$2" secret_name="$3"
+  local u_key="$4" p_key="$5" l_key="$6"
+  echo "--- Application Password '${pass_name}' for user '${wp_user}' ---"
+
+  local existing_uuid
+  existing_uuid=$(wp user application-password list "$wp_user" --fields=name,uuid --format=json 2>/dev/null | \
+    php -r "
+      \$list = json_decode(file_get_contents('php://stdin'), true) ?: [];
+      \$name = '${pass_name}';
+      foreach (\$list as \$p) {
+        if ((\$p['name'] ?? '') === \$name) { echo \$p['uuid']; exit; }
+      }
+    " 2>/dev/null || echo "")
+
+  local secret_exists=false
+  if ap_k8s_secret_exists "$secret_name"; then
+    secret_exists=true
+  fi
+
+  if [ -n "$existing_uuid" ] && [ "$secret_exists" = "true" ]; then
+    echo "Already configured — skipping."
+    return 0
+  fi
+
+  if [ -n "$existing_uuid" ]; then
+    echo "App password exists but Secret '${secret_name}' missing — recreating both..."
+    wp user application-password delete "$wp_user" "$existing_uuid" 2>/dev/null || true
+  fi
+
+  if [ "$secret_exists" = "true" ]; then
+    echo "Secret '${secret_name}' exists but WP app password missing — deleting stale Secret..."
+    ap_k8s_secret_delete "$secret_name"
+  fi
+
+  local raw_pass wpcli_out
+  wpcli_out=$(wp user application-password create "$wp_user" "$pass_name" --porcelain 2>&1)
+  raw_pass=$(printf '%s' "$wpcli_out" | tr -d '\n ')
+
+  if [ -z "$raw_pass" ]; then
+    echo "ERROR: Failed to create application password for '${wp_user}'"
+    echo "WP-CLI output: ${wpcli_out}"
+    return 1
+  fi
+
+  echo "Created application password, writing to Secret '${secret_name}'..."
+  ap_k8s_secret_write "$secret_name" "$wp_user" "$raw_pass" {{ include "wordpress.normalizedUrl" . | quote }} "$u_key" "$p_key" "$l_key"
+  echo "Credentials stored in Secret '${secret_name}'."
+}
+
+{{- if .Values.wordpress.init.applicationPassword }}
+{{- $ap := .Values.wordpress.init.applicationPassword }}
+{{- $sn := $ap.outputSecret.name | default (printf "%s-token-admin" .Release.Name) }}
+create_app_password \
+  "$WP_ADMIN_USER" \
+  {{ $ap.name | quote }} \
+  {{ $sn | quote }} \
+  {{ $ap.outputSecret.usernameKey | default "WP_USERNAME" | quote }} \
+  {{ $ap.outputSecret.passwordKey | default "WP_APP_PASSWORD" | quote }} \
+  {{ $ap.outputSecret.urlKey | default "WP_SITE_URL" | quote }}
+{{- end }}
+{{- range .Values.wordpress.users }}
+{{- if .applicationPassword }}
+{{- $ap := .applicationPassword }}
+{{- $sn := $ap.outputSecret.name | default (printf "%s-token-%s" $.Release.Name .username) }}
+create_app_password \
+  {{ .username | quote }} \
+  {{ $ap.name | quote }} \
+  {{ $sn | quote }} \
+  {{ $ap.outputSecret.usernameKey | default "WP_USERNAME" | quote }} \
+  {{ $ap.outputSecret.passwordKey | default "WP_APP_PASSWORD" | quote }} \
+  {{ $ap.outputSecret.urlKey | default "WP_SITE_URL" | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 # ============================================================================
 # Final Rewrite Flush (single flush at the end)

--- a/charts/wordpress/templates/app-password-rbac.yaml
+++ b/charts/wordpress/templates/app-password-rbac.yaml
@@ -1,0 +1,50 @@
+{{/* RBAC: allows WordPress pod's ServiceAccount to write Application Password Secrets */}}
+{{- $hasAdminAppPass := not (empty .Values.wordpress.init.applicationPassword) }}
+{{- $hasUserAppPass := false }}
+{{- range .Values.wordpress.users }}
+{{- if .applicationPassword }}{{- $hasUserAppPass = true }}{{- end }}
+{{- end }}
+{{- if or $hasAdminAppPass $hasUserAppPass }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "wordpress.fullname" . }}-apppassword
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      {{- if .Values.wordpress.init.applicationPassword }}
+      {{- $ap := .Values.wordpress.init.applicationPassword }}
+      - {{ $ap.outputSecret.name | default (printf "%s-token-admin" .Release.Name) | quote }}
+      {{- end }}
+      {{- range .Values.wordpress.users }}
+      {{- if .applicationPassword }}
+      {{- $ap := .applicationPassword }}
+      - {{ $ap.outputSecret.name | default (printf "%s-token-%s" $.Release.Name .username) | quote }}
+      {{- end }}
+      {{- end }}
+    verbs: ["get", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "wordpress.fullname" . }}-apppassword
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "wordpress.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "wordpress.fullname" . }}-apppassword
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -400,6 +400,13 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- if and .Values.wordpress.init.jwt.enabled .Values.wordpress.init.jwt.existingSecret }}
+            - name: JWT_AUTH_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.wordpress.init.jwt.existingSecret }}
+                  key: {{ .Values.wordpress.init.jwt.secretKey | default "JWT_AUTH_SECRET_KEY" }}
+            {{- end }}
           {{- if and .Values.wordpress.configExtraConfigMap.name (not .Values.wordpress.configExtraSecret.name) }}
           {{- if .Values.wordpress.configExtraInject }}
           {{/* Combine external ConfigMap + chart-managed inject via K8s env var interpolation */}}
@@ -622,6 +629,13 @@ spec:
                 secretKeyRef:
                   name: {{ include "metrics.wordpress.fullname" . }}
                   key: wordpress.metrics.encryptionKey
+          {{- end }}
+          {{- if and .Values.wordpress.init.jwt.enabled .Values.wordpress.init.jwt.existingSecret }}
+            - name: JWT_AUTH_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.wordpress.init.jwt.existingSecret }}
+                  key: JWT_AUTH_SECRET_KEY
           {{- end }}
           {{- if and .Values.wordpress.configExtraConfigMap.name (not .Values.wordpress.configExtraSecret.name) }}
           {{- if .Values.wordpress.configExtraInject }}

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -1,3 +1,20 @@
+{{/* ============================================================================ */}}
+{{/* JWT signing key resolution (used in secret data + _WP_CONFIG_INJECT)      */}}
+{{/* ============================================================================ */}}
+{{- $jwtKey := "" }}
+{{- if and .Values.wordpress.init.jwt.enabled (not .Values.wordpress.init.jwt.existingSecret) }}
+  {{- if .Values.wordpress.init.jwt.secret }}
+    {{- $jwtKey = .Values.wordpress.init.jwt.secret }}
+  {{- else }}
+    {{/* Preserve existing key across helm upgrades via lookup */}}
+    {{- $existingMainSecret := lookup "v1" "Secret" .Release.Namespace (include "wordpress.fullname" .) }}
+    {{- if and $existingMainSecret (hasKey $existingMainSecret.data "JWT_AUTH_SECRET_KEY") }}
+      {{- $jwtKey = index $existingMainSecret.data "JWT_AUTH_SECRET_KEY" | b64dec }}
+    {{- else }}
+      {{- $jwtKey = randAlphaNum 32 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
@@ -9,12 +26,18 @@ metadata:
 type: Opaque
 data:
   WORDPRESS_TABLE_PREFIX: {{ .Values.wordpress.tablePrefix | b64enc }}
+  {{- if and .Values.wordpress.init.jwt.enabled (not .Values.wordpress.init.jwt.existingSecret) }}
+  JWT_AUTH_SECRET_KEY: {{ $jwtKey | b64enc }}
+  {{- end }}
   {{- if .Values.wordpress.configExtraInject }}
   {{/* Build inject string: WP_HOME, WP_SITEURL, memcached config */}}
   {{- $inject := "" }}
   {{- $url := include "wordpress.normalizedUrl" . }}
   {{/* Always inject WP_HOME and WP_SITEURL (URL is auto-prefixed with http/https if no protocol given) */}}
   {{- $inject = printf "define('WP_HOME', '%s');define('WP_SITEURL', '%s');" $url $url }}
+  {{- if .Values.wordpress.init.jwt.enabled }}
+  {{- $inject = printf "%sdefine('JWT_AUTH_SECRET_KEY', getenv('JWT_AUTH_SECRET_KEY'));" $inject }}
+  {{- end }}
   {{/* Multisite constants (WP_ALLOW_MULTISITE, MULTISITE, SUBDOMAIN_INSTALL, DOMAIN_CURRENT_SITE, etc.) */}}
   {{/* are NOT injected here. They are written directly into wp-config.php by 'wp core multisite-convert' */}}
   {{/* in the init container and persist on the PVC. Injecting them here would cause PHP warnings */}}

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -1,2866 +1,2966 @@
 {
-    "$schema": "https://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "properties": {
-        "replicaCount": {
-            "type": "integer",
-            "description": "Number of replicas for the deployment",
-            "default": 1
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "description": "Number of replicas for the deployment",
+      "default": 1
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "registry": {
+          "type": "string",
+          "description": "WordPress container image registry",
+          "default": "docker.io"
         },
-        "image": {
-            "type": "object",
-            "properties": {
+        "repository": {
+          "type": "string",
+          "description": "WordPress container image repository",
+          "default": "wordpress"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "IfNotPresent",
+            "Always",
+            "Never"
+          ],
+          "description": "Image pull policy",
+          "default": "IfNotPresent"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Overrides the image tag whose default is the chart appVersion",
+          "default": "latest"
+        }
+      },
+      "required": [
+        "repository",
+        "pullPolicy",
+        "tag"
+      ]
+    },
+    "imagePullSecrets": {
+      "title": "Image Pull Secrets",
+      "type": "array",
+      "description": "List of existing Kubernetes secrets used to pull images from private registries.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "title": "Secret name",
+            "type": "string",
+            "description": "Secrets for pulling images from private repositories. See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/"
+          }
+        },
+        "required": []
+      },
+      "default": []
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "String to partially override the chart name",
+      "default": ""
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "String to fully override the chart name",
+      "default": ""
+    },
+    "clusterDomain": {
+      "type": "string",
+      "description": "Kubernetes Cluster Domain",
+      "default": "cluster.local"
+    },
+    "dnsPolicy": {
+      "type": "string",
+      "description": "DNS policy for the pod"
+    },
+    "dnsConfig": {
+      "type": "object",
+      "description": "DNS configuration for the pod"
+    },
+    "hostNetwork": {
+      "type": "boolean",
+      "description": "Expose the service on the host network"
+    },
+    "customLabels": {
+      "type": "object",
+      "description": "Additional labels for deployment",
+      "default": {}
+    },
+    "customAnnotations": {
+      "type": "object",
+      "description": "Additional annotations for deployment",
+      "default": {}
+    },
+    "updateStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "RollingUpdate",
+            "Recreate"
+          ],
+          "description": "Deployment strategy type",
+          "default": "Recreate"
+        },
+        "rollingUpdate": {
+          "type": "object",
+          "properties": {
+            "maxSurge": {
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "maxUnavailable": {
+              "oneOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Init containers to run before the main container",
+      "default": []
+    },
+    "sidecars": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Sidecar containers to run alongside the main container",
+      "default": []
+    },
+    "command": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Override default container command",
+      "default": []
+    },
+    "args": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Override default container args",
+      "default": []
+    },
+    "extraEnvVars": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "description": "Extra environment variables to set in the container",
+      "default": []
+    },
+    "extraEnvVarsSecret": {
+      "type": "string",
+      "description": "Name of existing Secret containing extra env vars",
+      "default": ""
+    },
+    "extraEnvVarsCM": {
+      "type": "string",
+      "description": "Name of existing ConfigMap containing extra env vars",
+      "default": ""
+    },
+    "wordpress": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "properties": {
+        "init": {
+          "type": "object",
+          "properties": {
+            "image": {
+              "type": "object",
+              "properties": {
                 "registry": {
-                    "type": "string",
-                    "description": "WordPress container image registry",
-                    "default": "docker.io"
+                  "type": "string",
+                  "description": "WordPress CLI container image registry",
+                  "default": "docker.io"
                 },
                 "repository": {
-                    "type": "string",
-                    "description": "WordPress container image repository",
-                    "default": "wordpress"
-                },
-                "pullPolicy": {
-                    "type": "string",
-                    "enum": [
-                        "IfNotPresent",
-                        "Always",
-                        "Never"
-                    ],
-                    "description": "Image pull policy",
-                    "default": "IfNotPresent"
+                  "type": "string",
+                  "description": "WordPress CLI container image repository",
+                  "default": "wordpress"
                 },
                 "tag": {
-                    "type": "string",
-                    "description": "Overrides the image tag whose default is the chart appVersion",
-                    "default": "latest"
+                  "type": "string",
+                  "description": "WordPress CLI image tag",
+                  "default": "cli-2.12.0-php8.1"
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "IfNotPresent",
+                    "Always",
+                    "Never"
+                  ],
+                  "description": "WordPress CLI image pull policy",
+                  "default": "IfNotPresent"
                 }
+              }
             },
-            "required": [
-                "repository",
-                "pullPolicy",
-                "tag"
-            ]
-        },
-        "imagePullSecrets": {
-            "title": "Image Pull Secrets",
-            "type": "array",
-            "description": "List of existing Kubernetes secrets used to pull images from private registries.",
-            "items": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "name": {
-                        "title": "Secret name",
-                        "type": "string",
-                        "description": "Secrets for pulling images from private repositories. See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/"
-                    }
-                },
-                "required": []
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable init container for first installation",
+              "default": false
             },
-            "default": []
-        },
-        "nameOverride": {
-            "type": "string",
-            "description": "String to partially override the chart name",
-            "default": ""
-        },
-        "fullnameOverride": {
-            "type": "string",
-            "description": "String to fully override the chart name",
-            "default": ""
-        },
-        "clusterDomain": {
-            "type": "string",
-            "description": "Kubernetes Cluster Domain",
-            "default": "cluster.local"
-        },
-        "dnsPolicy": {
-            "type": "string",
-            "description": "DNS policy for the pod"
-        },
-        "dnsConfig": {
-            "type": "object",
-            "description": "DNS configuration for the pod"
-        },
-        "hostNetwork": {
-            "type": "boolean",
-            "description": "Expose the service on the host network"
-        },
-        "customLabels": {
-            "type": "object",
-            "description": "Additional labels for deployment",
-            "default": {}
-        },
-        "customAnnotations": {
-            "type": "object",
-            "description": "Additional annotations for deployment",
-            "default": {}
-        },
-        "updateStrategy": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "RollingUpdate",
-                        "Recreate"
-                    ],
-                    "description": "Deployment strategy type",
-                    "default": "Recreate"
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing secret for WordPress credentials",
+              "default": ""
+            },
+            "secretKeys": {
+              "type": "object",
+              "description": "Key names for WordPress admin credentials within an existing secret",
+              "properties": {
+                "userUsernameKey": {
+                  "type": "string",
+                  "description": "Key name for the admin username",
+                  "default": "wordpress.username"
                 },
-                "rollingUpdate": {
-                    "type": "object",
-                    "properties": {
-                        "maxSurge": {
-                            "oneOf": [
-                                {
-                                    "type": "integer"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "maxUnavailable": {
-                            "oneOf": [
-                                {
-                                    "type": "integer"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        }
-                    }
+                "userPasswordKey": {
+                  "type": "string",
+                  "description": "Key name for the admin password",
+                  "default": "wordpress.password"
+                },
+                "userEmailKey": {
+                  "type": "string",
+                  "description": "Key name for the admin email",
+                  "default": "wordpress.email"
                 }
-            }
-        },
-        "initContainers": {
-            "type": "array",
-            "items": {
-                "type": "object"
+              }
             },
-            "description": "Init containers to run before the main container",
-            "default": []
-        },
-        "sidecars": {
-            "type": "array",
-            "items": {
-                "type": "object"
+            "username": {
+              "type": "string",
+              "description": "WordPress admin username"
             },
-            "description": "Sidecar containers to run alongside the main container",
-            "default": []
-        },
-        "command": {
-            "type": "array",
-            "items": {
-                "type": "string"
+            "password": {
+              "type": "string",
+              "description": "WordPress admin password"
             },
-            "description": "Override default container command",
-            "default": []
-        },
-        "args": {
-            "type": "array",
-            "items": {
-                "type": "string"
+            "email": {
+              "type": "string",
+              "description": "WordPress admin email"
             },
-            "description": "Override default container args",
-            "default": []
-        },
-        "extraEnvVars": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "type": "string"
-                    },
-                    "value": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "name"
-                ]
+            "firstname": {
+              "type": "string",
+              "description": "WordPress admin first name"
             },
-            "description": "Extra environment variables to set in the container",
-            "default": []
-        },
-        "extraEnvVarsSecret": {
-            "type": "string",
-            "description": "Name of existing Secret containing extra env vars",
-            "default": ""
-        },
-        "extraEnvVarsCM": {
-            "type": "string",
-            "description": "Name of existing ConfigMap containing extra env vars",
-            "default": ""
-        },
-        "wordpress": {
-            "type": "object",
-            "required": [
-                "url"
-            ],
-            "properties": {
-                "init": {
-                    "type": "object",
-                    "properties": {
-                        "image": {
-                            "type": "object",
-                            "properties": {
-                                "registry": {
-                                    "type": "string",
-                                    "description": "WordPress CLI container image registry",
-                                    "default": "docker.io"
-                                },
-                                "repository": {
-                                    "type": "string",
-                                    "description": "WordPress CLI container image repository",
-                                    "default": "wordpress"
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "description": "WordPress CLI image tag",
-                                    "default": "cli-2.12.0-php8.1"
-                                },
-                                "pullPolicy": {
-                                    "type": "string",
-                                    "enum": [
-                                        "IfNotPresent",
-                                        "Always",
-                                        "Never"
-                                    ],
-                                    "description": "WordPress CLI image pull policy",
-                                    "default": "IfNotPresent"
-                                }
-                            }
-                        },
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable init container for first installation",
-                            "default": false
-                        },
-                        "existingSecret": {
-                            "type": "string",
-                            "description": "Existing secret for WordPress credentials",
-                            "default": ""
-                        },
-                        "secretKeys": {
-                            "type": "object",
-                            "description": "Key names for WordPress admin credentials within an existing secret",
-                            "properties": {
-                                "userUsernameKey": {
-                                    "type": "string",
-                                    "description": "Key name for the admin username",
-                                    "default": "wordpress.username"
-                                },
-                                "userPasswordKey": {
-                                    "type": "string",
-                                    "description": "Key name for the admin password",
-                                    "default": "wordpress.password"
-                                },
-                                "userEmailKey": {
-                                    "type": "string",
-                                    "description": "Key name for the admin email",
-                                    "default": "wordpress.email"
-                                }
-                            }
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "WordPress admin username"
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "WordPress admin password"
-                        },
-                        "email": {
-                            "type": "string",
-                            "description": "WordPress admin email"
-                        },
-                        "firstname": {
-                            "type": "string",
-                            "description": "WordPress admin first name"
-                        },
-                        "lastname": {
-                            "type": "string",
-                            "description": "WordPress admin last name"
-                        },
-                        "title": {
-                            "type": "string",
-                            "description": "WordPress blog title"
-                        },
-                        "debug": {
-                            "type": "boolean",
-                            "description": "Enable debug mode in Job setter",
-                            "default": false
-                        },
-                        "customInitScript": {
-                            "type": "string",
-                            "description": "Custom init commands"
-                        },
-                        "customInitConfigMap": {
-                            "type": "object",
-                            "description": "ConfigMap for custom init commands",
-                            "properties": {
-                                "name": {
-                                    "type": "string",
-                                    "description": "Name of existing ConfigMap",
-                                    "default": ""
-                                },
-                                "key": {
-                                    "type": "string",
-                                    "description": "Key in ConfigMap containing custom init commands",
-                                    "default": "commands.sh"
-                                }
-                            }
-                        },
-                        "multiSites": {
-                            "type": "object",
-                            "description": "WordPress Multisite configuration",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable multisite configuration",
-                                    "default": false
-                                },
-                                "title": {
-                                    "type": "string",
-                                    "description": "Title for the multisite network"
-                                },
-                                "subdomain": {
-                                    "type": "boolean",
-                                    "description": "Use subdomain configuration (true) or subdirectory (false)",
-                                    "default": false
-                                },
-                                "prune": {
-                                    "type": "boolean",
-                                    "description": "Remove all sites not defined in wordpress.init.multiSites.sites list",
-                                    "default": false
-                                },
-                                "sites": {
-                                    "type": "array",
-                                    "description": "List of sites to create",
-                                    "items": {
-                                        "type": "object",
-                                        "properties": {
-                                            "name": {
-                                                "type": "string",
-                                                "description": "Site slug"
-                                            },
-                                            "title": {
-                                                "type": "string",
-                                                "description": "Site title"
-                                            },
-                                            "private": {
-                                                "type": "boolean",
-                                                "description": "Not indexed by search engines",
-                                                "default": false
-                                            },
-                                            "active": {
-                                                "type": "boolean",
-                                                "description": "Site is active",
-                                                "default": true
-                                            },
-                                            "archived": {
-                                                "type": "boolean",
-                                                "description": "Site is archived",
-                                                "default": false
-                                            },
-                                            "previousName": {
-                                                "type": "string",
-                                                "description": "Previous site name/slug for rename tracking. The mapping will be migrated from the old name to the new name, and the site URL slug will be updated. Remove this field after one successful deployment."
-                                            }
-                                        },
-                                        "required": [
-                                            "name"
-                                        ]
-                                    },
-                                    "default": []
-                                }
-                            },
-                            "default": {
-                                "enabled": false,
-                                "subdomain": false,
-                                "prune": false,
-                                "sites": []
-                            }
-                        }
-                    }
-                },
-                "permalinks": {
-                    "type": "object",
-                    "properties": {
-                        "structure": {
-                            "type": "string",
-                            "enum": [
-                                "plain",
-                                "dayAndName",
-                                "monthAndName",
-                                "numeric",
-                                "postName"
-                            ],
-                            "description": "Permalink structure",
-                            "default": "postName"
-                        },
-                        "customStructure": {
-                            "type": "string",
-                            "description": "Custom permalink structure"
-                        }
-                    }
-                },
-                "plugins": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Name|zip|URL: Name of the plugin"
-                            },
-                            "version": {
-                                "type": "string",
-                                "description": "Version of the plugin"
-                            },
-                            "activate": {
-                                "type": "boolean",
-                                "description": "Activate the plugin on the main site. Can be combined with sites[] for independent sub-site activation. Ignored when networkActivate is true."
-                            },
-                            "autoupdate": {
-                                "type": "boolean",
-                                "description": "Enable auto-updates for the plugin"
-                            },
-                            "networkActivate": {
-                                "type": "boolean",
-                                "description": "Multisite: activate on all sites (network-wide activation). Takes precedence over activate and sites."
-                            },
-                            "sites": {
-                                "type": "array",
-                                "description": "Multisite: activate on specific sub-sites. Can be combined with activate for main site control. Ignored when networkActivate is true.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "slug": {
-                                "type": "string",
-                                "description": "Override plugin slug (required for URL plugins when using sites, autoupdate or networkActivate). The slug is the plugin directory name after installation."
-                            }
-                        },
-                        "required": [
-                            "name"
-                        ]
-                    },
-                    "description": "WordPress plugins to install",
-                    "default": []
-                },
-                "pluginsPrune": {
-                    "type": "boolean",
-                    "description": "Remove all plugins not defined in wordpress.plugins list",
-                    "default": false
-                },
-                "themes": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Name|zip|URL: Name of the theme"
-                            },
-                            "version": {
-                                "type": "string",
-                                "description": "Version of the theme"
-                            },
-                            "activate": {
-                                "type": "boolean",
-                                "description": "Activate the theme on the main site. Can be combined with sites[] for independent sub-site activation."
-                            },
-                            "autoupdate": {
-                                "type": "boolean",
-                                "description": "Enable auto-updates for the theme"
-                            },
-                            "networkEnable": {
-                                "type": "boolean",
-                                "description": "Multisite: enable theme on network (make available to all sites)"
-                            },
-                            "sites": {
-                                "type": "array",
-                                "description": "Multisite: activate theme on specific sub-sites. Can be combined with activate for main site control.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "slug": {
-                                "type": "string",
-                                "description": "Override theme slug (required for URL themes when using sites, autoupdate or networkEnable). The slug is the theme directory name after installation."
-                            }
-                        },
-                        "required": [
-                            "name"
-                        ]
-                    },
-                    "description": "WordPress themes to install",
-                    "default": []
-                },
-                "themesPrune": {
-                    "type": "boolean",
-                    "description": "Remove all themes not defined in wordpress.themes list",
-                    "default": false
-                },
-                "composer": {
-                    "type": "object",
-                    "properties": {
-                        "repositories": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "type": "string",
-                                        "description": "Repository type (composer, vcs, package, etc.)"
-                                    },
-                                    "url": {
-                                        "type": "string",
-                                        "description": "Repository URL"
-                                    },
-                                    "package": {
-                                        "type": "object",
-                                        "description": "Package definition for package type repositories"
-                                    }
-                                }
-                            },
-                            "description": "Custom Composer repositories to add to composer.json",
-                            "default": []
-                        }
-                    },
-                    "default": {
-                        "repositories": []
-                    }
-                },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "username": {
-                                "type": "string",
-                                "description": "Name of the user"
-                            },
-                            "email": {
-                                "type": "string",
-                                "description": "Email of the user"
-                            },
-                            "displayname": {
-                                "type": "string",
-                                "description": "Display name of the user"
-                            },
-                            "firstname": {
-                                "type": "string",
-                                "description": "First name of the user"
-                            },
-                            "lastname": {
-                                "type": "string",
-                                "description": "Last name of the user"
-                            },
-                            "role": {
-                                "type": "string",
-                                "enum": [
-                                    "administrator",
-                                    "editor",
-                                    "author",
-                                    "contributor",
-                                    "subscriber"
-                                ],
-                                "description": "Role of the user"
-                            },
-                            "sendEmail": {
-                                "type": "boolean",
-                                "description": "Send email to user"
-                            },
-                            "superAdmin": {
-                                "type": "boolean",
-                                "description": "Multisite: grant super-admin privileges"
-                            },
-                            "sites": {
-                                "type": "array",
-                                "description": "Multisite: assign to specific sites with roles",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string",
-                                            "description": "Site slug"
-                                        },
-                                        "role": {
-                                            "type": "string",
-                                            "enum": [
-                                                "administrator",
-                                                "editor",
-                                                "author",
-                                                "contributor",
-                                                "subscriber"
-                                            ],
-                                            "description": "Role of the user on this site"
-                                        }
-                                    },
-                                    "required": [
-                                        "name",
-                                        "role"
-                                    ]
-                                }
-                            }
-                        },
-                        "required": [
-                            "username",
-                            "email"
-                        ]
-                    },
-                    "description": "WordPress users to create",
-                    "default": []
-                },
-                "tablePrefix": {
-                    "type": "string",
-                    "description": "Prefix for WordPress database tables",
-                    "default": "wp_"
-                },
-                "language": {
-                    "type": "string",
-                    "description": "WordPress language (e.g. de_DE)"
-                },
-                "url": {
-                    "type": "string",
-                    "description": "WordPress URL (including protocol, e.g. http://example.com or https://example.com). If no protocol is provided, it is auto-detected from the Ingress TLS config (https:// if TLS is configured, http:// otherwise).",
-                    "minLength": 1
-                },
-                "configExtraInject": {
-                    "type": "boolean",
-                    "description": "Automatically inject WP_HOME, WP_SITEURL and memcached config into WORDPRESS_CONFIG_EXTRA. Combined with configExtra, configExtraConfigMap or configExtraSecret values when set. Multisite constants are managed by the init container.",
-                    "default": true
-                },
-                "configExtra": {
-                    "type": "string",
-                    "description": "Custom values for wp-config.php"
-                },
-                "configExtraConfigMap": {
-                    "type": "object",
-                    "description": "ConfigMap for extra wp-config.php values",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of existing ConfigMap",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Key in ConfigMap containing extra wp-config.php values",
-                            "default": "wordpress.configExtra"
-                        }
-                    }
-                },
-                "configExtraSecret": {
-                    "type": "object",
-                    "description": "Secret for extra wp-config.php values",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of existing Secret",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Key in Secret containing extra wp-config.php values",
-                            "default": "wordpress.configExtra"
-                        }
-                    }
-                },
-                "htaccess": {
-                    "type": "string",
-                    "description": "Custom .htaccess content"
-                },
-                "htaccessConfigMap": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap containing .htaccess file",
-                    "default": ""
-                },
-                "debug": {
-                    "type": "boolean",
-                    "description": "Enable WordPress debug mode",
-                    "default": false
-                },
-                "muPluginsConfigMaps": {
-                    "type": "array",
-                    "description": "List of ConfigMaps containing MU-Plugins files. Each ConfigMap's data keys (or specific key) will be copied as PHP files to wp-content/mu-plugins/",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the ConfigMap containing MU-Plugin files"
-                            },
-                            "key": {
-                                "type": "string",
-                                "description": "Optional: Specific key from ConfigMap to copy. If omitted, all keys will be copied."
-                            }
-                        },
-                        "required": [
-                            "name"
-                        ]
-                    },
-                    "default": []
-                }
-            }
-        },
-        "apache": {
-            "type": "object",
-            "properties": {
-                "serverName": {
-                    "type": "string",
-                    "description": "Apache ServerName (defaults to host from wordpress.url when empty)",
-                    "default": ""
-                },
-                "customDefaultSiteConfig": {
-                    "type": "string",
-                    "description": "Custom Apache default site config"
-                },
-                "customDefaultSiteConfigMap": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap containing default site config",
-                    "default": ""
-                },
-                "customPortsConfig": {
-                    "type": "string",
-                    "description": "Custom Apache ports config"
-                },
-                "customPortsConfigMap": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap containing ports config",
-                    "default": ""
-                },
-                "customPhpConfig": {
-                    "type": "string",
-                    "description": "Custom PHP configuration"
-                },
-                "customPhpConfigMap": {
-                    "type": "string",
-                    "description": "Name of existing ConfigMap containing PHP config",
-                    "default": ""
-                }
-            }
-        },
-        "storage": {
-            "type": "object",
-            "properties": {
-                "existingClaim": {
-                    "type": "string",
-                    "description": "Name of an existing PVC to use"
-                },
-                "storageClass": {
-                    "type": "string",
-                    "description": "Storage class for the PVC",
-                    "default": ""
-                },
-                "size": {
-                    "type": "string",
-                    "description": "Size of the PVC",
-                    "default": "1Gi"
-                },
-                "accessModes": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "ReadWriteOnce",
-                            "ReadOnlyMany",
-                            "ReadWriteMany"
-                        ]
-                    },
-                    "description": "Access modes for the PVC",
-                    "default": [
-                        "ReadWriteOnce"
-                    ]
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations to add to PVC"
-                },
-                "labels": {
-                    "type": "object",
-                    "description": "Labels to add to PVC"
-                },
-                "selector": {
-                    "type": "object",
-                    "description": "Selector to add to PVC"
-                },
-                "resourcePolicy": {
-                    "type": "string",
-                    "enum": [
-                        "keep",
-                        ""
-                    ],
-                    "description": "Resource policy for the PVC",
-                    "default": "keep"
-                }
-            }
-        },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "create": {
-                    "type": "boolean",
-                    "description": "Specifies whether a service account should be created",
-                    "default": true
-                },
-                "automount": {
-                    "type": "boolean",
-                    "description": "Automatically mount a ServiceAccount's API credentials",
-                    "default": true
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Annotations to add to the service account"
-                },
+            "lastname": {
+              "type": "string",
+              "description": "WordPress admin last name"
+            },
+            "title": {
+              "type": "string",
+              "description": "WordPress blog title"
+            },
+            "debug": {
+              "type": "boolean",
+              "description": "Enable debug mode in Job setter",
+              "default": false
+            },
+            "customInitScript": {
+              "type": "string",
+              "description": "Custom init commands"
+            },
+            "customInitConfigMap": {
+              "type": "object",
+              "description": "ConfigMap for custom init commands",
+              "properties": {
                 "name": {
-                    "type": "string",
-                    "description": "The name of the service account to use",
-                    "default": ""
+                  "type": "string",
+                  "description": "Name of existing ConfigMap",
+                  "default": ""
+                },
+                "key": {
+                  "type": "string",
+                  "description": "Key in ConfigMap containing custom init commands",
+                  "default": "commands.sh"
                 }
-            }
-        },
-        "podAnnotations": {
-            "type": "object",
-            "description": "Annotations to add to pods",
-            "default": {}
-        },
-        "podLabels": {
-            "type": "object",
-            "description": "Labels to add to pods",
-            "default": {}
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "properties": {
-                "fsGroup": {
-                    "type": "integer",
-                    "description": "File system group ID",
-                    "default": 33
-                },
-                "fsGroupChangePolicy": {
-                    "type": "string",
-                    "description": "Policy for changing volume ownership/permissions (Always or OnRootMismatch)",
-                    "enum": [
-                        "Always",
-                        "OnRootMismatch"
-                    ],
-                    "default": "Always"
-                },
-                "runAsUser": {
-                    "type": "integer",
-                    "description": "User ID to run containers",
-                    "default": 33
-                },
-                "runAsNonRoot": {
-                    "type": "boolean",
-                    "description": "Run containers as non-root user",
-                    "default": true
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "enum": [
-                                "RuntimeDefault",
-                                "Localhost",
-                                "Unconfined"
-                            ]
-                        }
-                    }
-                }
-            }
-        },
-        "containerSecurityContext": {
-            "type": "object",
-            "description": "Security context for application containers",
-            "properties": {
-                "readOnlyRootFilesystem": {
-                    "type": "boolean",
-                    "description": "Mount root filesystem as read-only",
-                    "default": true
-                },
-                "allowPrivilegeEscalation": {
-                    "type": "boolean",
-                    "description": "Allow privilege escalation",
-                    "default": false
-                },
-                "privileged": {
-                    "type": "boolean",
-                    "description": "Run container in privileged mode",
-                    "default": false
-                },
-                "capabilities": {
-                    "type": "object",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            },
-                            "default": [
-                                "ALL"
-                            ]
-                        },
-                        "add": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "enum": [
-                                "RuntimeDefault",
-                                "Localhost",
-                                "Unconfined"
-                            ]
-                        }
-                    }
-                },
-                "runAsNonRoot": {
-                    "type": "boolean",
-                    "description": "Run container as non-root user",
-                    "default": true
-                }
-            }
-        },
-        "containerPorts": {
-            "type": "object",
-            "properties": {
-                "http": {
-                    "type": "integer",
-                    "description": "HTTP port number",
-                    "default": 8080
-                },
-                "https": {
-                    "type": "integer",
-                    "description": "HTTPS port number",
-                    "default": 8443
-                }
+              }
             },
-            "required": [
-                "http",
-                "https"
-            ]
-        },
-        "service": {
-            "type": "object",
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "ClusterIP",
-                        "NodePort",
-                        "LoadBalancer",
-                        "ExternalName"
-                    ],
-                    "description": "Service type",
-                    "default": "NodePort"
-                },
-                "ports": {
-                    "type": "object",
-                    "properties": {
-                        "http": {
-                            "type": "integer",
-                            "default": 80
-                        },
-                        "https": {
-                            "type": "integer",
-                            "default": 443
-                        }
-                    }
-                },
-                "nodePorts": {
-                    "type": "object",
-                    "properties": {
-                        "http": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ]
-                        },
-                        "https": {
-                            "type": [
-                                "integer",
-                                "null"
-                            ]
-                        }
-                    }
-                },
-                "clusterIP": {
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "description": "Static cluster IP"
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Additional annotations for service"
-                },
-                "labels": {
-                    "type": "object",
-                    "description": "Additional labels for service",
-                    "default": {}
-                }
-            }
-        },
-        "httpRoute": {
-            "type": "object",
-            "description": "HTTPRoute configuration for Gateway API",
-            "properties": {
+            "multiSites": {
+              "type": "object",
+              "description": "WordPress Multisite configuration",
+              "properties": {
                 "enabled": {
-                    "type": "boolean",
-                    "description": "Enable HTTPRoute resource for Gateway API",
-                    "default": false
+                  "type": "boolean",
+                  "description": "Enable multisite configuration",
+                  "default": false
                 },
-                "annotations": {
+                "title": {
+                  "type": "string",
+                  "description": "Title for the multisite network"
+                },
+                "subdomain": {
+                  "type": "boolean",
+                  "description": "Use subdomain configuration (true) or subdirectory (false)",
+                  "default": false
+                },
+                "prune": {
+                  "type": "boolean",
+                  "description": "Remove all sites not defined in wordpress.init.multiSites.sites list",
+                  "default": false
+                },
+                "sites": {
+                  "type": "array",
+                  "description": "List of sites to create",
+                  "items": {
                     "type": "object",
-                    "description": "Annotations for HTTPRoute resource",
-                    "default": {}
-                },
-                "labels": {
-                    "type": "object",
-                    "description": "Additional labels for HTTPRoute resource",
-                    "default": {}
-                },
-                "parentRefs": {
-                    "type": "array",
-                    "description": "Parent references (REQUIRED when enabled - HTTPRoute will not work without this)",
-                    "default": [],
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "name": {
-                                "type": "string",
-                                "description": "Name of the parent gateway"
-                            },
-                            "namespace": {
-                                "type": "string",
-                                "description": "Namespace of the parent gateway"
-                            },
-                            "sectionName": {
-                                "type": "string",
-                                "description": "Section name of the parent gateway listener"
-                            }
-                        },
-                        "required": ["name"]
-                    }
-                },
-                "hostnames": {
-                    "type": "array",
-                    "description": "Hostnames for the HTTPRoute",
-                    "default": [],
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "rules": {
-                    "type": "array",
-                    "description": "Custom routing rules (optional, defaults to path prefix /)",
-                    "default": [],
-                    "items": {
-                        "type": "object"
-                    }
-                }
-            },
-            "if": {
-                "properties": {
-                    "enabled": {
-                        "const": true
-                    }
-                }
-            },
-            "then": {
-                "properties": {
-                    "parentRefs": {
-                        "minItems": 1
-                    }
-                }
-            }
-        },
-        "ingress": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable ingress",
-                    "default": false
-                },
-                "className": {
-                    "type": "string",
-                    "description": "Ingress class name"
-                },
-                "annotations": {
-                    "type": "object",
-                    "description": "Ingress annotations"
-                },
-                "hosts": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "host": {
-                                "type": "string"
-                            },
-                            "paths": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "path": {
-                                            "type": "string"
-                                        },
-                                        "pathType": {
-                                            "type": "string",
-                                            "enum": [
-                                                "Exact",
-                                                "Prefix",
-                                                "ImplementationSpecific"
-                                            ]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "tls": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "secretName": {
-                                "type": "string"
-                            },
-                            "hosts": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "useHttpsBackend": {
-                    "type": "boolean",
-                    "description": "Ingress use https backend\nwhen true, backend uses service.ports.https; otherwise uses service.ports.http",
-                    "default": false
-                },
-                "extraRules": {
-                    "type": "array",
-                    "description": "Additional rules for ingress. See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules",
-                    "items": {
-                        "type": "object"
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Site slug"
+                      },
+                      "title": {
+                        "type": "string",
+                        "description": "Site title"
+                      },
+                      "private": {
+                        "type": "boolean",
+                        "description": "Not indexed by search engines",
+                        "default": false
+                      },
+                      "active": {
+                        "type": "boolean",
+                        "description": "Site is active",
+                        "default": true
+                      },
+                      "archived": {
+                        "type": "boolean",
+                        "description": "Site is archived",
+                        "default": false
+                      },
+                      "previousName": {
+                        "type": "string",
+                        "description": "Previous site name/slug for rename tracking. The mapping will be migrated from the old name to the new name, and the site URL slug will be updated. Remove this field after one successful deployment."
+                      }
                     },
-                    "default": []
+                    "required": [
+                      "name"
+                    ]
+                  },
+                  "default": []
                 }
-            }
-        },
-        "resources": {
-            "type": "object",
-            "description": "Resource limits and requests",
-            "default": {}
-        },
-        "livenessProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable liveness probe",
-                    "default": true
-                },
-                "initialDelaySeconds": {
-                    "type": "integer",
-                    "description": "Initial delay for liveness probe",
-                    "default": 10
-                },
-                "periodSeconds": {
-                    "type": "integer",
-                    "description": "Period for liveness probe",
-                    "default": 20
-                },
-                "timeoutSeconds": {
-                    "type": "integer",
-                    "description": "Timeout for liveness probe",
-                    "default": 5
-                },
-                "failureThreshold": {
-                    "type": "integer",
-                    "description": "Failure threshold for liveness probe",
-                    "default": 3
-                },
-                "successThreshold": {
-                    "type": "integer",
-                    "description": "Success threshold for liveness probe",
-                    "default": 1
-                }
-            }
-        },
-        "readinessProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable readiness probe",
-                    "default": true
-                },
-                "initialDelaySeconds": {
-                    "type": "integer",
-                    "description": "Initial delay for readiness probe",
-                    "default": 5
-                },
-                "periodSeconds": {
-                    "type": "integer",
-                    "description": "Period for readiness probe",
-                    "default": 15
-                },
-                "timeoutSeconds": {
-                    "type": "integer",
-                    "description": "Timeout for readiness probe",
-                    "default": 5
-                },
-                "failureThreshold": {
-                    "type": "integer",
-                    "description": "Failure threshold for readiness probe",
-                    "default": 10
-                },
-                "successThreshold": {
-                    "type": "integer",
-                    "description": "Success threshold for readiness probe",
-                    "default": 1
-                }
-            }
-        },
-        "startupProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable startup probe",
-                    "default": true
-                },
-                "initialDelaySeconds": {
-                    "type": "integer",
-                    "description": "Initial delay for startup probe",
-                    "default": 10
-                },
-                "periodSeconds": {
-                    "type": "integer",
-                    "description": "Period for startup probe",
-                    "default": 10
-                },
-                "timeoutSeconds": {
-                    "type": "integer",
-                    "description": "Timeout for startup probe",
-                    "default": 5
-                },
-                "failureThreshold": {
-                    "type": "integer",
-                    "description": "Failure threshold for startup probe",
-                    "default": 30
-                },
-                "successThreshold": {
-                    "type": "integer",
-                    "description": "Success threshold for startup probe",
-                    "default": 1
-                }
-            }
-        },
-        "customLivenessProbe": {
-            "type": "object",
-            "description": "Override default liveness probe",
-            "default": {}
-        },
-        "customReadinessProbe": {
-            "type": "object",
-            "description": "Override default readiness probe",
-            "default": {}
-        },
-        "customStartupProbe": {
-            "type": "object",
-            "description": "Override default startup probe",
-            "default": {}
-        },
-        "autoscaling": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable autoscaling",
-                    "default": false
-                },
-                "minReplicas": {
-                    "type": "integer",
-                    "description": "Minimum number of replicas",
-                    "default": 1
-                },
-                "maxReplicas": {
-                    "type": "integer",
-                    "description": "Maximum number of replicas",
-                    "default": 100
-                },
-                "targetCPUUtilizationPercentage": {
-                    "type": "integer",
-                    "description": "Target CPU utilization percentage",
-                    "default": 80
-                },
-                "targetMemoryUtilizationPercentage": {
-                    "type": "integer",
-                    "description": "Target memory utilization percentage"
-                }
-            }
-        },
-        "extraVolumes": {
-            "type": "array",
-            "items": {
-                "type": "object"
+              },
+              "default": {
+                "enabled": false,
+                "subdomain": false,
+                "prune": false,
+                "sites": []
+              }
             },
-            "description": "Additional volumes for the deployment",
-            "default": []
-        },
-        "extraVolumeMounts": {
-            "type": "array",
-            "items": {
-                "type": "object"
-            },
-            "description": "Additional volume mounts for the deployment",
-            "default": []
-        },
-        "nodeSelector": {
-            "type": "object",
-            "description": "Node labels for pod assignment",
-            "default": {}
-        },
-        "tolerations": {
-            "type": "array",
-            "items": {
-                "type": "object"
-            },
-            "description": "Tolerations for pod assignment",
-            "default": []
-        },
-        "affinity": {
-            "type": "object",
-            "description": "Affinity for pod assignment",
-            "default": {}
-        },
-        "topologySpreadConstraints": {
-            "type": "array",
-            "items": {
-                "type": "object"
-            },
-            "description": "Topology spread constraints for pods",
-            "default": []
-        },
-        "priorityClassName": {
-            "type": [
-                "string",
-                "null"
-            ],
-            "description": "Priority class name for the pod"
-        },
-        "revisionHistoryLimit": {
-            "type": [
-                "integer",
-                "null"
-            ],
-            "description": "Maximum number of revisions maintained in revision history"
-        },
-        "podDisruptionBudget": {
-            "type": "object",
-            "description": "Pod disruption budget configuration",
-            "default": {}
-        },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "wordpress": {
-                    "type": "object",
-                    "description": "WordPress metrics configuration",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable WordPress metrics",
-                            "default": false
-                        },
-                        "installPlugin": {
-                            "type": "boolean",
-                            "description": "Install WordPress metrics plugin",
-                            "default": true
-                        },
-                        "pluginNameOverride": {
-                            "type": "string",
-                            "description": "Override the plugin name",
-                            "default": ""
-                        },
-                        "networkActivate": {
-                            "type": "boolean",
-                            "description": "Network-activate the metrics plugin in WordPress Multisite. When enabled in a multisite setup, the plugin is activated network-wide instead of only on the main site.",
-                            "default": true
-                        },
-                        "autoupdate": {
-                            "type": "boolean",
-                            "description": "Enable automatic updates for the metrics plugin.",
-                            "default": true
-                        },
-                        "serviceMonitor": {
-                            "type": "object",
-                            "description": "ServiceMonitor configuration for WordPress metrics",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable ServiceMonitor for WordPress metrics",
-                                    "default": true
-                                },
-                                "namespace": {
-                                    "type": "string",
-                                    "description": "Namespace for WordPress ServiceMonitor",
-                                    "default": ""
-                                },
-                                "interval": {
-                                    "type": "string",
-                                    "description": "Scrape interval",
-                                    "default": "30s"
-                                },
-                                "metricsPath": {
-                                    "type": "string",
-                                    "description": "Metrics endpoint path",
-                                    "default": "/slymetrics/metrics"
-                                },
-                                "existingSecret": {
-                                    "type": "string",
-                                    "description": "Existing secret for metrics authentication",
-                                    "default": ""
-                                },
-                                "secretKey": {
-                                    "type": "string",
-                                    "description": "Key in existing secret containing Bearer Token",
-                                    "default": "wordpress.metrics.token"
-                                },
-                                "token": {
-                                    "type": "string",
-                                    "description": "Alternative authentication token",
-                                    "default": ""
-                                },
-                                "ports": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "description": "Ports to scrape metrics from",
-                                    "default": [
-                                        "http"
-                                    ]
-                                },
-                                "labels": {
-                                    "type": "object",
-                                    "description": "Additional labels for ServiceMonitor"
-                                },
-                                "annotations": {
-                                    "type": "object",
-                                    "description": "Additional annotations for ServiceMonitor"
-                                },
-                                "selector": {
-                                    "type": "object",
-                                    "description": "Custom selector for ServiceMonitor"
-                                }
-                            }
-                        },
-                        "grafanaDashboard": {
-                            "type": "object",
-                            "description": "Grafana Dashboard configuration for WordPress metrics",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable Grafana Dashboard ConfigMap deployment",
-                                    "default": false
-                                },
-                                "namespace": {
-                                    "type": "string",
-                                    "description": "Namespace for Grafana Dashboard ConfigMap (defaults to release namespace if empty)",
-                                    "default": ""
-                                },
-                                "customLabels": {
-                                    "type": "object",
-                                    "description": "Additional labels for Grafana Dashboard ConfigMap"
-                                }
-                            }
-                        }
+            "applicationPassword": {
+              "type": "object",
+              "description": "Create an Application Password for MCP access via a Helm hook Job",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Name for the Application Password in WordPress"
+                },
+                "outputSecret": {
+                  "type": "object",
+                  "description": "Kubernetes Secret to store the generated credentials",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Secret name (empty = <release>-token-<username>)",
+                      "default": ""
+                    },
+                    "usernameKey": {
+                      "type": "string",
+                      "description": "Key for the WordPress username",
+                      "default": "WP_USERNAME"
+                    },
+                    "passwordKey": {
+                      "type": "string",
+                      "description": "Key for the Application Password",
+                      "default": "WP_APP_PASSWORD"
+                    },
+                    "urlKey": {
+                      "type": "string",
+                      "description": "Key for the WordPress site URL",
+                      "default": "WP_SITE_URL"
                     }
-                },
-                "apache": {
-                    "type": "object",
-                    "description": "Apache metrics configuration",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable Apache metrics",
-                            "default": false
-                        },
-                        "createConfig": {
-                            "type": "boolean",
-                            "description": "Create Apache config for metrics",
-                            "default": true
-                        },
-                        "image": {
-                            "type": "object",
-                            "properties": {
-                                "registry": {
-                                    "type": "string",
-                                    "description": "Apache exporter image registry",
-                                    "default": "docker.io"
-                                },
-                                "repository": {
-                                    "type": "string",
-                                    "description": "Apache exporter image repository",
-                                    "default": "lusotycoon/apache-exporter"
-                                },
-                                "pullPolicy": {
-                                    "type": "string",
-                                    "enum": [
-                                        "IfNotPresent",
-                                        "Always",
-                                        "Never"
-                                    ],
-                                    "description": "Image pull policy",
-                                    "default": "IfNotPresent"
-                                },
-                                "tag": {
-                                    "type": "string",
-                                    "description": "Apache exporter image tag",
-                                    "default": "v1.0.10"
-                                }
-                            }
-                        },
-                        "livenessProbe": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable liveness probe",
-                                    "default": true
-                                },
-                                "initialDelaySeconds": {
-                                    "type": "integer",
-                                    "description": "Initial delay for liveness probe",
-                                    "default": 15
-                                },
-                                "periodSeconds": {
-                                    "type": "integer",
-                                    "description": "Period for liveness probe",
-                                    "default": 10
-                                },
-                                "timeoutSeconds": {
-                                    "type": "integer",
-                                    "description": "Timeout for liveness probe",
-                                    "default": 5
-                                },
-                                "failureThreshold": {
-                                    "type": "integer",
-                                    "description": "Failure threshold for liveness probe",
-                                    "default": 3
-                                },
-                                "successThreshold": {
-                                    "type": "integer",
-                                    "description": "Success threshold for liveness probe",
-                                    "default": 1
-                                }
-                            }
-                        },
-                        "readinessProbe": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable readiness probe",
-                                    "default": true
-                                },
-                                "initialDelaySeconds": {
-                                    "type": "integer",
-                                    "description": "Initial delay for readiness probe",
-                                    "default": 5
-                                },
-                                "periodSeconds": {
-                                    "type": "integer",
-                                    "description": "Period for readiness probe",
-                                    "default": 10
-                                },
-                                "timeoutSeconds": {
-                                    "type": "integer",
-                                    "description": "Timeout for readiness probe",
-                                    "default": 5
-                                },
-                                "failureThreshold": {
-                                    "type": "integer",
-                                    "description": "Failure threshold for readiness probe",
-                                    "default": 3
-                                },
-                                "successThreshold": {
-                                    "type": "integer",
-                                    "description": "Success threshold for readiness probe",
-                                    "default": 1
-                                }
-                            }
-                        },
-                        "startupProbe": {
-                            "type": "object",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable startup probe",
-                                    "default": true
-                                },
-                                "initialDelaySeconds": {
-                                    "type": "integer",
-                                    "description": "Initial delay for startup probe",
-                                    "default": 10
-                                },
-                                "periodSeconds": {
-                                    "type": "integer",
-                                    "description": "Period for startup probe",
-                                    "default": 10
-                                },
-                                "timeoutSeconds": {
-                                    "type": "integer",
-                                    "description": "Timeout for startup probe",
-                                    "default": 5
-                                },
-                                "failureThreshold": {
-                                    "type": "integer",
-                                    "description": "Failure threshold for startup probe",
-                                    "default": 15
-                                },
-                                "successThreshold": {
-                                    "type": "integer",
-                                    "description": "Success threshold for startup probe",
-                                    "default": 1
-                                }
-                            }
-                        },
-                        "customLivenessProbe": {
-                            "type": "object",
-                            "description": "Override default liveness probe",
-                            "default": {}
-                        },
-                        "customReadinessProbe": {
-                            "type": "object",
-                            "description": "Override default readiness probe",
-                            "default": {}
-                        },
-                        "customStartupProbe": {
-                            "type": "object",
-                            "description": "Override default startup probe",
-                            "default": {}
-                        },
-                        "resources": {
-                            "type": "object",
-                            "description": "Resource limits and requests",
-                            "default": {}
-                        },
-                        "service": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "ClusterIP",
-                                        "NodePort",
-                                        "LoadBalancer",
-                                        "ExternalName"
-                                    ],
-                                    "description": "Service type",
-                                    "default": "ClusterIP"
-                                },
-                                "ports": {
-                                    "type": "object",
-                                    "properties": {
-                                        "metrics": {
-                                            "type": "integer",
-                                            "default": 9117
-                                        }
-                                    }
-                                },
-                                "nodePorts": {
-                                    "type": "object",
-                                    "properties": {
-                                        "metrics": {
-                                            "type": [
-                                                "integer",
-                                                "null"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "clusterIP": {
-                                    "type": "string",
-                                    "description": "Static cluster IP"
-                                },
-                                "annotations": {
-                                    "type": "object",
-                                    "description": "Additional annotations for service"
-                                },
-                                "labels": {
-                                    "type": "object",
-                                    "description": "Additional labels for service",
-                                    "default": {}
-                                }
-                            }
-                        },
-                        "containerSecurityContext": {
-                            "type": "object",
-                            "properties": {
-                                "seLinuxOptions": {
-                                    "type": "object",
-                                    "description": "SELinux options",
-                                    "default": {}
-                                },
-                                "runAsUser": {
-                                    "type": "integer",
-                                    "description": "User ID to run containers",
-                                    "default": 1001
-                                },
-                                "runAsGroup": {
-                                    "type": "integer",
-                                    "description": "Group ID to run containers",
-                                    "default": 1001
-                                },
-                                "runAsNonRoot": {
-                                    "type": "boolean",
-                                    "description": "Run containers as non-root user",
-                                    "default": true
-                                },
-                                "privileged": {
-                                    "type": "boolean",
-                                    "description": "Run container in privileged mode",
-                                    "default": false
-                                },
-                                "readOnlyRootFilesystem": {
-                                    "type": "boolean",
-                                    "description": "Mount root filesystem as read-only",
-                                    "default": true
-                                },
-                                "allowPrivilegeEscalation": {
-                                    "type": "boolean",
-                                    "description": "Allow privilege escalation",
-                                    "default": false
-                                },
-                                "capabilities": {
-                                    "type": "object",
-                                    "properties": {
-                                        "drop": {
-                                            "type": "array",
-                                            "items": {
-                                                "type": "string"
-                                            },
-                                            "default": [
-                                                "ALL"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "seccompProfile": {
-                                    "type": "object",
-                                    "properties": {
-                                        "type": {
-                                            "type": "string",
-                                            "enum": [
-                                                "RuntimeDefault",
-                                                "Localhost",
-                                                "Unconfined"
-                                            ],
-                                            "default": "RuntimeDefault"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "serviceMonitor": {
-                            "type": "object",
-                            "description": "ServiceMonitor configuration for Apache metrics",
-                            "properties": {
-                                "enabled": {
-                                    "type": "boolean",
-                                    "description": "Enable ServiceMonitor for Apache metrics",
-                                    "default": true
-                                },
-                                "namespace": {
-                                    "type": "string",
-                                    "description": "Namespace for Apache ServiceMonitor",
-                                    "default": ""
-                                },
-                                "interval": {
-                                    "type": "string",
-                                    "description": "Scrape interval",
-                                    "default": "30s"
-                                },
-                                "metricsPath": {
-                                    "type": "string",
-                                    "description": "Metrics endpoint path",
-                                    "default": "/metrics"
-                                },
-                                "labels": {
-                                    "type": "object",
-                                    "description": "Additional labels for ServiceMonitor"
-                                },
-                                "annotations": {
-                                    "type": "object",
-                                    "description": "Additional annotations for ServiceMonitor"
-                                },
-                                "selector": {
-                                    "type": "object",
-                                    "description": "Custom selector for ServiceMonitor"
-                                }
-                            }
-                        }
-                    }
+                  }
                 }
-            }
-        },
-        "externalDatabase": {
-            "type": "object",
-            "properties": {
-                "host": {
-                    "type": "string",
-                    "description": "External database host"
-                },
-                "port": {
-                    "type": "integer",
-                    "description": "External database port",
-                    "default": 3306
-                },
-                "database": {
-                    "type": "string",
-                    "description": "External database name"
-                },
-                "username": {
-                    "type": "string",
-                    "description": "External database username"
-                },
-                "password": {
-                    "type": "string",
-                    "description": "External database password"
+              }
+            },
+            "jwt": {
+              "type": "object",
+              "description": "JWT Authentication integration (jwt-authentication-for-wp-rest-api plugin)",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Install jwt-authentication-for-wp-rest-api and inject signing key into wp-config.php",
+                  "default": false
                 },
                 "existingSecret": {
-                    "type": "string",
-                    "description": "Name of existing secret for database credentials",
-                    "default": ""
+                  "type": "string",
+                  "description": "Existing Secret containing JWT_AUTH_SECRET_KEY",
+                  "default": ""
                 },
-                "secretKeys": {
-                    "type": "object",
-                    "description": "Key names for database credentials within an existing secret",
-                    "properties": {
-                        "userUsernameKey": {
-                            "type": "string",
-                            "description": "Key name for the database username",
-                            "default": "db.username"
-                        },
-                        "userPasswordKey": {
-                            "type": "string",
-                            "description": "Key name for the database password",
-                            "default": "db.password"
-                        }
-                    }
+                "secretKey": {
+                  "type": "string",
+                  "description": "Key within existingSecret that holds the JWT signing key",
+                  "default": "JWT_AUTH_SECRET_KEY"
+                },
+                "secret": {
+                  "type": "string",
+                  "description": "Inline JWT signing secret (auto-generated and preserved across upgrades if empty; ignored when existingSecret is set)",
+                  "default": ""
                 }
+              }
             }
+          }
         },
-        "mariadb": {
+        "permalinks": {
+          "type": "object",
+          "properties": {
+            "structure": {
+              "type": "string",
+              "enum": [
+                "plain",
+                "dayAndName",
+                "monthAndName",
+                "numeric",
+                "postName"
+              ],
+              "description": "Permalink structure",
+              "default": "postName"
+            },
+            "customStructure": {
+              "type": "string",
+              "description": "Custom permalink structure"
+            }
+          }
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable MariaDB chart installation",
-                    "default": true
-                },
-                "nameOverride": {
-                    "type": "string",
-                    "description": "String to partially override mariadb.fullname",
-                    "default": ""
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "description": "String to fully override mariadb.fullname",
-                    "default": ""
-                },
-                "commonLabels": {
-                    "type": "object",
-                    "description": "Labels to add to all deployed objects",
-                    "default": {}
-                },
-                "commonAnnotations": {
-                    "type": "object",
-                    "description": "Annotations to add to all deployed objects",
-                    "default": {}
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "MariaDB image registry",
-                            "default": "docker.io"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "MariaDB image repository",
-                            "default": "mariadb"
-                        },
-                        "tag": {
-                            "type": "string",
-                            "description": "MariaDB image tag",
-                            "default": "12.0.2-noble"
-                        },
-                        "imagePullPolicy": {
-                            "type": "string",
-                            "enum": [
-                                "IfNotPresent",
-                                "Always",
-                                "Never"
-                            ],
-                            "description": "MariaDB image pull policy",
-                            "default": "IfNotPresent"
-                        }
-                    }
-                },
-                "auth": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "MariaDB authentication enabled or disabled",
-                            "default": true
-                        },
-                        "rootPassword": {
-                            "type": "string",
-                            "description": "MariaDB root password",
-                            "default": ""
-                        },
-                        "database": {
-                            "type": "string",
-                            "description": "MariaDB custom database"
-                        },
-                        "username": {
-                            "type": "string",
-                            "description": "MariaDB custom user name"
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "MariaDB custom user password",
-                            "default": ""
-                        },
-                        "existingSecret": {
-                            "type": "string",
-                            "description": "Name of existing secret for MariaDB credentials",
-                            "default": ""
-                        },
-                        "allowEmptyRootPassword": {
-                            "type": "string",
-                            "description": "Allow empty root password",
-                            "default": "false"
-                        },
-                        "secretKeys": {
-                            "type": "object",
-                            "properties": {
-                                "rootPasswordKey": {
-                                    "type": "string",
-                                    "description": "Name of key in existing secret for root password",
-                                    "default": "mariadb-root-password"
-                                },
-                                "userPasswordKey": {
-                                    "type": "string",
-                                    "description": "Name of key in existing secret for user password",
-                                    "default": "mariadb-password"
-                                }
-                            }
-                        }
-                    }
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer",
-                                "ExternalName"
-                            ],
-                            "description": "MariaDB service type",
-                            "default": "ClusterIP"
-                        },
-                        "port": {
-                            "type": "integer",
-                            "description": "MariaDB service port",
-                            "default": 3306
-                        },
-                        "nodePort": {
-                            "type": "string",
-                            "description": "Node port for MariaDB service",
-                            "default": ""
-                        },
-                        "clusterIP": {
-                            "type": "string",
-                            "description": "Static cluster IP or 'None' for headless service",
-                            "default": ""
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "description": "Additional custom annotations for MariaDB service",
-                            "default": {}
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "runAsUser": {
-                            "type": "integer",
-                            "description": "Set MariaDB container's Security Context runAsUser",
-                            "default": 999
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Set MariaDB container's Security Context runAsNonRoot",
-                            "default": true
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set MariaDB container's privilege escalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": [
-                                        "ALL"
-                                    ]
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "RuntimeDefault",
-                                        "Localhost",
-                                        "Unconfined"
-                                    ],
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                },
-                "persistence": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable MariaDB data persistence using PVC",
-                            "default": true
-                        },
-                        "storageClass": {
-                            "type": "string",
-                            "description": "PVC Storage Class for MariaDB data volume",
-                            "default": ""
-                        },
-                        "accessModes": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "ReadWriteOnce",
-                                    "ReadOnlyMany",
-                                    "ReadWriteMany"
-                                ]
-                            },
-                            "description": "PVC Access modes",
-                            "default": [
-                                "ReadWriteOnce"
-                            ]
-                        },
-                        "size": {
-                            "type": "string",
-                            "description": "PVC Storage Request for MariaDB data volume",
-                            "default": "1Gi"
-                        },
-                        "annotations": {
-                            "type": "object",
-                            "description": "Additional custom annotations for the PVC",
-                            "default": {}
-                        },
-                        "selector": {
-                            "type": "object",
-                            "description": "Additional labels for the PVC",
-                            "default": {}
-                        }
-                    }
+              "name": {
+                "type": "string",
+                "description": "Name|zip|URL: Name of the plugin"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version of the plugin"
+              },
+              "activate": {
+                "type": "boolean",
+                "description": "Activate the plugin on the main site. Can be combined with sites[] for independent sub-site activation. Ignored when networkActivate is true."
+              },
+              "autoupdate": {
+                "type": "boolean",
+                "description": "Enable auto-updates for the plugin"
+              },
+              "networkActivate": {
+                "type": "boolean",
+                "description": "Multisite: activate on all sites (network-wide activation). Takes precedence over activate and sites."
+              },
+              "sites": {
+                "type": "array",
+                "description": "Multisite: activate on specific sub-sites. Can be combined with activate for main site control. Ignored when networkActivate is true.",
+                "items": {
+                  "type": "string"
                 }
+              },
+              "slug": {
+                "type": "string",
+                "description": "Override plugin slug (required for URL plugins when using sites, autoupdate or networkActivate). The slug is the plugin directory name after installation."
+              }
             },
-            "description": "MariaDB chart configuration"
+            "required": [
+              "name"
+            ]
+          },
+          "description": "WordPress plugins to install",
+          "default": []
         },
-        "memcached": {
+        "pluginsPrune": {
+          "type": "boolean",
+          "description": "Remove all plugins not defined in wordpress.plugins list",
+          "default": false
+        },
+        "themes": {
+          "type": "array",
+          "items": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable Memcached chart installation",
-                    "default": false
-                },
-                "createConfig": {
-                    "type": "boolean",
-                    "description": "Create in wp-config.php the Memcached config",
-                    "default": true
-                },
-                "cacheKeySalt": {
-                    "type": "string",
-                    "description": "Cache key salt for Memcached object cache isolation. If empty, chart generates a random salt on first deploy and reuses it on upgrades.",
-                    "default": ""
-                },
-                "cacheKeySaltSecret": {
-                    "type": "object",
-                    "description": "Existing Secret reference for Memcached cache key salt.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of existing Secret containing cache key salt",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Key in Secret containing cache key salt value",
-                            "default": "WP_CACHE_KEY_SALT"
-                        }
-                    }
-                },
-                "serverGroups": {
-                    "type": "object",
-                    "description": "Optional cache-group mapping to Memcached server lists. If empty, chart falls back to embedded service for group 'default'.",
-                    "default": {},
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "nameOverride": {
-                    "type": "string",
-                    "description": "String to partially override memcached.fullname",
-                    "default": ""
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "description": "String to fully override memcached.fullname",
-                    "default": ""
-                },
-                "commonLabels": {
-                    "type": "object",
-                    "description": "Labels to add to all deployed objects",
-                    "default": {}
-                },
-                "commonAnnotations": {
-                    "type": "object",
-                    "description": "Annotations to add to all deployed objects",
-                    "default": {}
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Memcached image registry",
-                            "default": "docker.io"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Memcached image repository",
-                            "default": "memcached"
-                        },
-                        "tag": {
-                            "type": "string",
-                            "description": "Memcached image tag",
-                            "default": "1.6.39"
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "enum": [
-                                "IfNotPresent",
-                                "Always",
-                                "Never"
-                            ],
-                            "description": "Memcached image pull policy",
-                            "default": "IfNotPresent"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer",
-                    "description": "Number of Memcached replicas to deploy",
-                    "default": 1
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer",
-                                "ExternalName"
-                            ],
-                            "description": "Kubernetes service type",
-                            "default": "ClusterIP"
-                        },
-                        "port": {
-                            "type": "integer",
-                            "description": "Memcached service port",
-                            "default": 11211
-                        }
-                    }
-                },
-                "topologySpreadConstraints": {
-                    "type": "array",
-                    "description": "Topology spread constraints for Redis pods",
-                    "default": []
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "runAsUser": {
-                            "type": "integer",
-                            "description": "User ID to run the container",
-                            "default": 11211
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Run as non-root user",
-                            "default": true
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set Memcached container's privilege escalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": [
-                                        "ALL"
-                                    ]
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "RuntimeDefault",
-                                        "Localhost",
-                                        "Unconfined"
-                                    ],
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
+              "name": {
+                "type": "string",
+                "description": "Name|zip|URL: Name of the theme"
+              },
+              "version": {
+                "type": "string",
+                "description": "Version of the theme"
+              },
+              "activate": {
+                "type": "boolean",
+                "description": "Activate the theme on the main site. Can be combined with sites[] for independent sub-site activation."
+              },
+              "autoupdate": {
+                "type": "boolean",
+                "description": "Enable auto-updates for the theme"
+              },
+              "networkEnable": {
+                "type": "boolean",
+                "description": "Multisite: enable theme on network (make available to all sites)"
+              },
+              "sites": {
+                "type": "array",
+                "description": "Multisite: activate theme on specific sub-sites. Can be combined with activate for main site control.",
+                "items": {
+                  "type": "string"
                 }
+              },
+              "slug": {
+                "type": "string",
+                "description": "Override theme slug (required for URL themes when using sites, autoupdate or networkEnable). The slug is the theme directory name after installation."
+              }
             },
-            "description": "Memcached chart configuration"
+            "required": [
+              "name"
+            ]
+          },
+          "description": "WordPress themes to install",
+          "default": []
         },
-        "redis": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable Redis chart installation",
-                    "default": false
-                },
-                "createConfig": {
-                    "type": "boolean",
-                    "description": "Create in wp-config.php the Redis config",
-                    "default": true
-                },
-                "cacheKeySalt": {
-                    "type": "string",
-                    "description": "Cache key salt for Redis object cache isolation. If empty, chart generates a random salt on first deploy and reuses it on upgrades.",
-                    "default": ""
-                },
-                "cacheKeySaltSecret": {
-                    "type": "object",
-                    "description": "Existing Secret reference for Redis cache key salt.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of existing Secret containing cache key salt",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Key in Secret containing cache key salt value",
-                            "default": "WP_CACHE_KEY_SALT"
-                        }
-                    }
-                },
-                "auth": {
-                    "type": "object",
-                    "description": "Redis authentication settings. If enabled by the Redis chart and no values are set here, Redis may generate a password in its default secret.",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable or disable Redis authentication",
-                            "default": true
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "Explicit Redis password",
-                            "default": ""
-                        },
-                        "existingSecret": {
-                            "type": "string",
-                            "description": "Existing Secret containing Redis password",
-                            "default": ""
-                        },
-                        "existingSecretPasswordKey": {
-                            "type": "string",
-                            "description": "Secret key containing Redis password",
-                            "default": "redis-password"
-                        }
-                    }
-                },
-                "scaling": {
-                    "type": "object",
-                    "description": "Advanced Redis Object Cache scaling topology configuration.",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Scaling mode",
-                            "enum": [
-                                "none",
-                                "replication",
-                                "sharding",
-                                "sentinel",
-                                "cluster"
-                            ],
-                            "default": "none"
-                        },
-                        "servers": {
-                            "type": "array",
-                            "description": "Server URIs for replication/sentinel mode",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "sentinel": {
-                            "type": "string",
-                            "description": "Sentinel master/service name (required for sentinel mode)",
-                            "default": ""
-                        },
-                        "shards": {
-                            "type": "array",
-                            "description": "Server URIs for sharding mode",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "cluster": {
-                            "type": "array",
-                            "description": "Server URIs for cluster mode",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "nameOverride": {
-                    "type": "string",
-                    "description": "String to partially override redis.fullname",
-                    "default": ""
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "description": "String to fully override redis.fullname",
-                    "default": ""
-                },
-                "commonLabels": {
-                    "type": "object",
-                    "description": "Labels to add to all deployed objects",
-                    "default": {}
-                },
-                "commonAnnotations": {
-                    "type": "object",
-                    "description": "Annotations to add to all deployed objects",
-                    "default": {}
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Redis image registry",
-                            "default": "docker.io"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Redis image repository",
-                            "default": "redis"
-                        },
-                        "tag": {
-                            "type": "string",
-                            "description": "Redis image tag",
-                            "default": "8.6.0"
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "enum": [
-                                "IfNotPresent",
-                                "Always",
-                                "Never"
-                            ],
-                            "description": "Redis image pull policy",
-                            "default": "IfNotPresent"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer",
-                    "description": "Number of Redis replicas to deploy",
-                    "default": 1
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer",
-                                "ExternalName"
-                            ],
-                            "description": "Kubernetes service type",
-                            "default": "ClusterIP"
-                        },
-                        "port": {
-                            "type": "integer",
-                            "description": "Redis service port",
-                            "default": 6379
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "runAsUser": {
-                            "type": "integer",
-                            "description": "User ID to run the container",
-                            "default": 999
-                        },
-                        "runAsGroup": {
-                            "type": "integer",
-                            "description": "Group ID to run the container",
-                            "default": 999
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Run as non-root user",
-                            "default": true
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set Redis container's privilege escalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": [
-                                        "ALL"
-                                    ]
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "RuntimeDefault",
-                                        "Localhost",
-                                        "Unconfined"
-                                    ],
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "description": "Redis chart configuration"
+        "themesPrune": {
+          "type": "boolean",
+          "description": "Remove all themes not defined in wordpress.themes list",
+          "default": false
         },
-        "valkey": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean",
-                    "description": "Enable Valkey chart installation",
-                    "default": false
-                },
-                "createConfig": {
-                    "type": "boolean",
-                    "description": "Create in wp-config.php the Valkey config",
-                    "default": true
-                },
-                "cacheKeySalt": {
-                    "type": "string",
-                    "description": "Cache key salt for Valkey object cache isolation. If empty, chart generates a random salt on first deploy and reuses it on upgrades.",
-                    "default": ""
-                },
-                "cacheKeySaltSecret": {
-                    "type": "object",
-                    "description": "Existing Secret reference for Valkey cache key salt.",
-                    "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of existing Secret containing cache key salt",
-                            "default": ""
-                        },
-                        "key": {
-                            "type": "string",
-                            "description": "Key in Secret containing cache key salt value",
-                            "default": "WP_CACHE_KEY_SALT"
-                        }
-                    }
-                },
-                "auth": {
-                    "type": "object",
-                    "description": "Valkey authentication settings. If enabled by the Valkey chart and no values are set here, Valkey may generate a password in its default secret.",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean",
-                            "description": "Enable or disable Valkey authentication",
-                            "default": true
-                        },
-                        "password": {
-                            "type": "string",
-                            "description": "Explicit Valkey password",
-                            "default": ""
-                        },
-                        "existingSecret": {
-                            "type": "string",
-                            "description": "Existing Secret containing Valkey password",
-                            "default": ""
-                        },
-                        "existingSecretPasswordKey": {
-                            "type": "string",
-                            "description": "Secret key containing Valkey password",
-                            "default": "password"
-                        }
-                    }
-                },
-                "scaling": {
-                    "type": "object",
-                    "description": "Advanced Redis Object Cache scaling topology configuration.",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "description": "Scaling mode",
-                            "enum": [
-                                "none",
-                                "replication",
-                                "sharding",
-                                "sentinel",
-                                "cluster"
-                            ],
-                            "default": "none"
-                        },
-                        "servers": {
-                            "type": "array",
-                            "description": "Server URIs for replication/sentinel mode",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "sentinel": {
-                            "type": "string",
-                            "description": "Sentinel master/service name (required for sentinel mode)",
-                            "default": ""
-                        },
-                        "shards": {
-                            "type": "array",
-                            "description": "Server URIs for sharding mode",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "cluster": {
-                            "type": "array",
-                            "description": "Server URIs for cluster mode",
-                            "default": [],
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "nameOverride": {
-                    "type": "string",
-                    "description": "String to partially override valkey.fullname",
-                    "default": ""
-                },
-                "fullnameOverride": {
-                    "type": "string",
-                    "description": "String to fully override valkey.fullname",
-                    "default": ""
-                },
-                "commonLabels": {
-                    "type": "object",
-                    "description": "Labels to add to all deployed objects",
-                    "default": {}
-                },
-                "commonAnnotations": {
-                    "type": "object",
-                    "description": "Annotations to add to all deployed objects",
-                    "default": {}
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "registry": {
-                            "type": "string",
-                            "description": "Valkey image registry",
-                            "default": "docker.io"
-                        },
-                        "repository": {
-                            "type": "string",
-                            "description": "Valkey image repository",
-                            "default": "valkey/valkey"
-                        },
-                        "tag": {
-                            "type": "string",
-                            "description": "Valkey image tag",
-                            "default": "9.0.2-alpine3.23"
-                        },
-                        "pullPolicy": {
-                            "type": "string",
-                            "enum": [
-                                "IfNotPresent",
-                                "Always",
-                                "Never"
-                            ],
-                            "description": "Valkey image pull policy",
-                            "default": "IfNotPresent"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer",
-                    "description": "Number of Valkey replicas to deploy",
-                    "default": 1
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string",
-                            "enum": [
-                                "ClusterIP",
-                                "NodePort",
-                                "LoadBalancer",
-                                "ExternalName"
-                            ],
-                            "description": "Kubernetes service type",
-                            "default": "ClusterIP"
-                        },
-                        "port": {
-                            "type": "integer",
-                            "description": "Valkey service port",
-                            "default": 6379
-                        }
-                    }
-                },
-                "containerSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "runAsUser": {
-                            "type": "integer",
-                            "description": "User ID to run the container",
-                            "default": 999
-                        },
-                        "runAsGroup": {
-                            "type": "integer",
-                            "description": "Group ID to run the container",
-                            "default": 1000
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean",
-                            "description": "Run as non-root user",
-                            "default": true
-                        },
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean",
-                            "description": "Set Valkey container's privilege escalation",
-                            "default": false
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "default": [
-                                        "ALL"
-                                    ]
-                                }
-                            }
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "RuntimeDefault",
-                                        "Localhost",
-                                        "Unconfined"
-                                    ],
-                                    "default": "RuntimeDefault"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "description": "Valkey chart configuration"
-        }
-    },
-    "if": {
-        "properties": {
-            "mariadb": {
+        "composer": {
+          "type": "object",
+          "properties": {
+            "repositories": {
+              "type": "array",
+              "items": {
+                "type": "object",
                 "properties": {
-                    "enabled": {
-                        "const": false
-                    }
+                  "type": {
+                    "type": "string",
+                    "description": "Repository type (composer, vcs, package, etc.)"
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "Repository URL"
+                  },
+                  "package": {
+                    "type": "object",
+                    "description": "Package definition for package type repositories"
+                  }
                 }
+              },
+              "description": "Custom Composer repositories to add to composer.json",
+              "default": []
             }
-        }
-    },
-    "then": {
-        "required": [
-            "externalDatabase"
-        ],
-        "properties": {
-            "externalDatabase": {
-                "required": [
-                    "host",
-                    "database"
-                ]
-            }
-        }
-    },
-    "allOf": [
-        {
-            "not": {
-                "anyOf": [
-                    {
-                        "properties": {
-                            "memcached": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "redis": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            }
-                        }
+          },
+          "default": {
+            "repositories": []
+          }
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "username": {
+                "type": "string",
+                "description": "Name of the user"
+              },
+              "email": {
+                "type": "string",
+                "description": "Email of the user"
+              },
+              "displayname": {
+                "type": "string",
+                "description": "Display name of the user"
+              },
+              "firstname": {
+                "type": "string",
+                "description": "First name of the user"
+              },
+              "lastname": {
+                "type": "string",
+                "description": "Last name of the user"
+              },
+              "role": {
+                "type": "string",
+                "enum": [
+                  "administrator",
+                  "editor",
+                  "author",
+                  "contributor",
+                  "subscriber"
+                ],
+                "description": "Role of the user"
+              },
+              "sendEmail": {
+                "type": "boolean",
+                "description": "Send email to user"
+              },
+              "superAdmin": {
+                "type": "boolean",
+                "description": "Multisite: grant super-admin privileges"
+              },
+              "sites": {
+                "type": "array",
+                "description": "Multisite: assign to specific sites with roles",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "description": "Site slug"
                     },
-                    {
-                        "properties": {
-                            "memcached": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "valkey": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "properties": {
-                            "redis": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            },
-                            "valkey": {
-                                "properties": {
-                                    "enabled": {
-                                        "const": true
-                                    }
-                                }
-                            }
-                        }
+                    "role": {
+                      "type": "string",
+                      "enum": [
+                        "administrator",
+                        "editor",
+                        "author",
+                        "contributor",
+                        "subscriber"
+                      ],
+                      "description": "Role of the user on this site"
                     }
-                ]
+                  },
+                  "required": [
+                    "name",
+                    "role"
+                  ]
+                }
+              },
+              "applicationPassword": {
+                "type": "object",
+                "description": "Create an Application Password for MCP access via a Helm hook Job",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Name for the Application Password in WordPress"
+                  },
+                  "outputSecret": {
+                    "type": "object",
+                    "description": "Kubernetes Secret to store the generated credentials",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Secret name (empty = <release>-token-<username>)",
+                        "default": ""
+                      },
+                      "usernameKey": {
+                        "type": "string",
+                        "description": "Key for the WordPress username",
+                        "default": "WP_USERNAME"
+                      },
+                      "passwordKey": {
+                        "type": "string",
+                        "description": "Key for the Application Password",
+                        "default": "WP_APP_PASSWORD"
+                      },
+                      "urlKey": {
+                        "type": "string",
+                        "description": "Key for the WordPress site URL",
+                        "default": "WP_SITE_URL"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "username",
+              "email"
+            ]
+          },
+          "description": "WordPress users to create",
+          "default": []
+        },
+        "tablePrefix": {
+          "type": "string",
+          "description": "Prefix for WordPress database tables",
+          "default": "wp_"
+        },
+        "language": {
+          "type": "string",
+          "description": "WordPress language (e.g. de_DE)"
+        },
+        "url": {
+          "type": "string",
+          "description": "WordPress URL (including protocol, e.g. http://example.com or https://example.com). If no protocol is provided, it is auto-detected from the Ingress TLS config (https:// if TLS is configured, http:// otherwise).",
+          "minLength": 1
+        },
+        "configExtraInject": {
+          "type": "boolean",
+          "description": "Automatically inject WP_HOME, WP_SITEURL and memcached config into WORDPRESS_CONFIG_EXTRA. Combined with configExtra, configExtraConfigMap or configExtraSecret values when set. Multisite constants are managed by the init container.",
+          "default": true
+        },
+        "configExtra": {
+          "type": "string",
+          "description": "Custom values for wp-config.php"
+        },
+        "configExtraConfigMap": {
+          "type": "object",
+          "description": "ConfigMap for extra wp-config.php values",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of existing ConfigMap",
+              "default": ""
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in ConfigMap containing extra wp-config.php values",
+              "default": "wordpress.configExtra"
             }
+          }
+        },
+        "configExtraSecret": {
+          "type": "object",
+          "description": "Secret for extra wp-config.php values",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of existing Secret",
+              "default": ""
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in Secret containing extra wp-config.php values",
+              "default": "wordpress.configExtra"
+            }
+          }
+        },
+        "htaccess": {
+          "type": "string",
+          "description": "Custom .htaccess content"
+        },
+        "htaccessConfigMap": {
+          "type": "string",
+          "description": "Name of existing ConfigMap containing .htaccess file",
+          "default": ""
+        },
+        "debug": {
+          "type": "boolean",
+          "description": "Enable WordPress debug mode",
+          "default": false
+        },
+        "muPluginsConfigMaps": {
+          "type": "array",
+          "description": "List of ConfigMaps containing MU-Plugins files. Each ConfigMap's data keys (or specific key) will be copied as PHP files to wp-content/mu-plugins/",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the ConfigMap containing MU-Plugin files"
+              },
+              "key": {
+                "type": "string",
+                "description": "Optional: Specific key from ConfigMap to copy. If omitted, all keys will be copied."
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "default": []
         }
-    ]
+      }
+    },
+    "apache": {
+      "type": "object",
+      "properties": {
+        "serverName": {
+          "type": "string",
+          "description": "Apache ServerName (defaults to host from wordpress.url when empty)",
+          "default": ""
+        },
+        "customDefaultSiteConfig": {
+          "type": "string",
+          "description": "Custom Apache default site config"
+        },
+        "customDefaultSiteConfigMap": {
+          "type": "string",
+          "description": "Name of existing ConfigMap containing default site config",
+          "default": ""
+        },
+        "customPortsConfig": {
+          "type": "string",
+          "description": "Custom Apache ports config"
+        },
+        "customPortsConfigMap": {
+          "type": "string",
+          "description": "Name of existing ConfigMap containing ports config",
+          "default": ""
+        },
+        "customPhpConfig": {
+          "type": "string",
+          "description": "Custom PHP configuration"
+        },
+        "customPhpConfigMap": {
+          "type": "string",
+          "description": "Name of existing ConfigMap containing PHP config",
+          "default": ""
+        }
+      }
+    },
+    "storage": {
+      "type": "object",
+      "properties": {
+        "existingClaim": {
+          "type": "string",
+          "description": "Name of an existing PVC to use"
+        },
+        "storageClass": {
+          "type": "string",
+          "description": "Storage class for the PVC",
+          "default": ""
+        },
+        "size": {
+          "type": "string",
+          "description": "Size of the PVC",
+          "default": "1Gi"
+        },
+        "accessModes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ReadWriteOnce",
+              "ReadOnlyMany",
+              "ReadWriteMany"
+            ]
+          },
+          "description": "Access modes for the PVC",
+          "default": [
+            "ReadWriteOnce"
+          ]
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to PVC"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Labels to add to PVC"
+        },
+        "selector": {
+          "type": "object",
+          "description": "Selector to add to PVC"
+        },
+        "resourcePolicy": {
+          "type": "string",
+          "enum": [
+            "keep",
+            ""
+          ],
+          "description": "Resource policy for the PVC",
+          "default": "keep"
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created",
+          "default": true
+        },
+        "automount": {
+          "type": "boolean",
+          "description": "Automatically mount a ServiceAccount's API credentials",
+          "default": true
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use",
+          "default": ""
+        }
+      }
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations to add to pods",
+      "default": {}
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Labels to add to pods",
+      "default": {}
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "properties": {
+        "fsGroup": {
+          "type": "integer",
+          "description": "File system group ID",
+          "default": 33
+        },
+        "fsGroupChangePolicy": {
+          "type": "string",
+          "description": "Policy for changing volume ownership/permissions (Always or OnRootMismatch)",
+          "enum": [
+            "Always",
+            "OnRootMismatch"
+          ],
+          "default": "Always"
+        },
+        "runAsUser": {
+          "type": "integer",
+          "description": "User ID to run containers",
+          "default": 33
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "description": "Run containers as non-root user",
+          "default": true
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "RuntimeDefault",
+                "Localhost",
+                "Unconfined"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "containerSecurityContext": {
+      "type": "object",
+      "description": "Security context for application containers",
+      "properties": {
+        "readOnlyRootFilesystem": {
+          "type": "boolean",
+          "description": "Mount root filesystem as read-only",
+          "default": true
+        },
+        "allowPrivilegeEscalation": {
+          "type": "boolean",
+          "description": "Allow privilege escalation",
+          "default": false
+        },
+        "privileged": {
+          "type": "boolean",
+          "description": "Run container in privileged mode",
+          "default": false
+        },
+        "capabilities": {
+          "type": "object",
+          "properties": {
+            "drop": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "ALL"
+              ]
+            },
+            "add": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "seccompProfile": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "RuntimeDefault",
+                "Localhost",
+                "Unconfined"
+              ]
+            }
+          }
+        },
+        "runAsNonRoot": {
+          "type": "boolean",
+          "description": "Run container as non-root user",
+          "default": true
+        }
+      }
+    },
+    "containerPorts": {
+      "type": "object",
+      "properties": {
+        "http": {
+          "type": "integer",
+          "description": "HTTP port number",
+          "default": 8080
+        },
+        "https": {
+          "type": "integer",
+          "description": "HTTPS port number",
+          "default": 8443
+        }
+      },
+      "required": [
+        "http",
+        "https"
+      ]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer",
+            "ExternalName"
+          ],
+          "description": "Service type",
+          "default": "NodePort"
+        },
+        "ports": {
+          "type": "object",
+          "properties": {
+            "http": {
+              "type": "integer",
+              "default": 80
+            },
+            "https": {
+              "type": "integer",
+              "default": 443
+            }
+          }
+        },
+        "nodePorts": {
+          "type": "object",
+          "properties": {
+            "http": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "https": {
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          }
+        },
+        "clusterIP": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Static cluster IP"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Additional annotations for service"
+        },
+        "labels": {
+          "type": "object",
+          "description": "Additional labels for service",
+          "default": {}
+        }
+      }
+    },
+    "httpRoute": {
+      "type": "object",
+      "description": "HTTPRoute configuration for Gateway API",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable HTTPRoute resource for Gateway API",
+          "default": false
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for HTTPRoute resource",
+          "default": {}
+        },
+        "labels": {
+          "type": "object",
+          "description": "Additional labels for HTTPRoute resource",
+          "default": {}
+        },
+        "parentRefs": {
+          "type": "array",
+          "description": "Parent references (REQUIRED when enabled - HTTPRoute will not work without this)",
+          "default": [],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name of the parent gateway"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Namespace of the parent gateway"
+              },
+              "sectionName": {
+                "type": "string",
+                "description": "Section name of the parent gateway listener"
+              }
+            },
+            "required": [
+              "name"
+            ]
+          }
+        },
+        "hostnames": {
+          "type": "array",
+          "description": "Hostnames for the HTTPRoute",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "type": "array",
+          "description": "Custom routing rules (optional, defaults to path prefix /)",
+          "default": [],
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "if": {
+        "properties": {
+          "enabled": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "parentRefs": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress",
+          "default": false
+        },
+        "className": {
+          "type": "string",
+          "description": "Ingress class name"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Ingress annotations"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": [
+                        "Exact",
+                        "Prefix",
+                        "ImplementationSpecific"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "useHttpsBackend": {
+          "type": "boolean",
+          "description": "Ingress use https backend\nwhen true, backend uses service.ports.https; otherwise uses service.ports.http",
+          "default": false
+        },
+        "extraRules": {
+          "type": "array",
+          "description": "Additional rules for ingress. See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource limits and requests",
+      "default": {}
+    },
+    "livenessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable liveness probe",
+          "default": true
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Initial delay for liveness probe",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Period for liveness probe",
+          "default": 20
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for liveness probe",
+          "default": 5
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Failure threshold for liveness probe",
+          "default": 3
+        },
+        "successThreshold": {
+          "type": "integer",
+          "description": "Success threshold for liveness probe",
+          "default": 1
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable readiness probe",
+          "default": true
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Initial delay for readiness probe",
+          "default": 5
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Period for readiness probe",
+          "default": 15
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for readiness probe",
+          "default": 5
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Failure threshold for readiness probe",
+          "default": 10
+        },
+        "successThreshold": {
+          "type": "integer",
+          "description": "Success threshold for readiness probe",
+          "default": 1
+        }
+      }
+    },
+    "startupProbe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable startup probe",
+          "default": true
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "description": "Initial delay for startup probe",
+          "default": 10
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Period for startup probe",
+          "default": 10
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for startup probe",
+          "default": 5
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Failure threshold for startup probe",
+          "default": 30
+        },
+        "successThreshold": {
+          "type": "integer",
+          "description": "Success threshold for startup probe",
+          "default": 1
+        }
+      }
+    },
+    "customLivenessProbe": {
+      "type": "object",
+      "description": "Override default liveness probe",
+      "default": {}
+    },
+    "customReadinessProbe": {
+      "type": "object",
+      "description": "Override default readiness probe",
+      "default": {}
+    },
+    "customStartupProbe": {
+      "type": "object",
+      "description": "Override default startup probe",
+      "default": {}
+    },
+    "autoscaling": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable autoscaling",
+          "default": false
+        },
+        "minReplicas": {
+          "type": "integer",
+          "description": "Minimum number of replicas",
+          "default": 1
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "description": "Maximum number of replicas",
+          "default": 100
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer",
+          "description": "Target CPU utilization percentage",
+          "default": 80
+        },
+        "targetMemoryUtilizationPercentage": {
+          "type": "integer",
+          "description": "Target memory utilization percentage"
+        }
+      }
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Additional volumes for the deployment",
+      "default": []
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Additional volume mounts for the deployment",
+      "default": []
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node labels for pod assignment",
+      "default": {}
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations for pod assignment",
+      "default": []
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity for pod assignment",
+      "default": {}
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Topology spread constraints for pods",
+      "default": []
+    },
+    "priorityClassName": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Priority class name for the pod"
+    },
+    "revisionHistoryLimit": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "description": "Maximum number of revisions maintained in revision history"
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "description": "Pod disruption budget configuration",
+      "default": {}
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "wordpress": {
+          "type": "object",
+          "description": "WordPress metrics configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable WordPress metrics",
+              "default": false
+            },
+            "installPlugin": {
+              "type": "boolean",
+              "description": "Install WordPress metrics plugin",
+              "default": true
+            },
+            "pluginNameOverride": {
+              "type": "string",
+              "description": "Override the plugin name",
+              "default": ""
+            },
+            "networkActivate": {
+              "type": "boolean",
+              "description": "Network-activate the metrics plugin in WordPress Multisite. When enabled in a multisite setup, the plugin is activated network-wide instead of only on the main site.",
+              "default": true
+            },
+            "autoupdate": {
+              "type": "boolean",
+              "description": "Enable automatic updates for the metrics plugin.",
+              "default": true
+            },
+            "serviceMonitor": {
+              "type": "object",
+              "description": "ServiceMonitor configuration for WordPress metrics",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable ServiceMonitor for WordPress metrics",
+                  "default": true
+                },
+                "namespace": {
+                  "type": "string",
+                  "description": "Namespace for WordPress ServiceMonitor",
+                  "default": ""
+                },
+                "interval": {
+                  "type": "string",
+                  "description": "Scrape interval",
+                  "default": "30s"
+                },
+                "metricsPath": {
+                  "type": "string",
+                  "description": "Metrics endpoint path",
+                  "default": "/slymetrics/metrics"
+                },
+                "existingSecret": {
+                  "type": "string",
+                  "description": "Existing secret for metrics authentication",
+                  "default": ""
+                },
+                "secretKey": {
+                  "type": "string",
+                  "description": "Key in existing secret containing Bearer Token",
+                  "default": "wordpress.metrics.token"
+                },
+                "token": {
+                  "type": "string",
+                  "description": "Alternative authentication token",
+                  "default": ""
+                },
+                "ports": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Ports to scrape metrics from",
+                  "default": [
+                    "http"
+                  ]
+                },
+                "labels": {
+                  "type": "object",
+                  "description": "Additional labels for ServiceMonitor"
+                },
+                "annotations": {
+                  "type": "object",
+                  "description": "Additional annotations for ServiceMonitor"
+                },
+                "selector": {
+                  "type": "object",
+                  "description": "Custom selector for ServiceMonitor"
+                }
+              }
+            },
+            "grafanaDashboard": {
+              "type": "object",
+              "description": "Grafana Dashboard configuration for WordPress metrics",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable Grafana Dashboard ConfigMap deployment",
+                  "default": false
+                },
+                "namespace": {
+                  "type": "string",
+                  "description": "Namespace for Grafana Dashboard ConfigMap (defaults to release namespace if empty)",
+                  "default": ""
+                },
+                "customLabels": {
+                  "type": "object",
+                  "description": "Additional labels for Grafana Dashboard ConfigMap"
+                }
+              }
+            }
+          }
+        },
+        "apache": {
+          "type": "object",
+          "description": "Apache metrics configuration",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable Apache metrics",
+              "default": false
+            },
+            "createConfig": {
+              "type": "boolean",
+              "description": "Create Apache config for metrics",
+              "default": true
+            },
+            "image": {
+              "type": "object",
+              "properties": {
+                "registry": {
+                  "type": "string",
+                  "description": "Apache exporter image registry",
+                  "default": "docker.io"
+                },
+                "repository": {
+                  "type": "string",
+                  "description": "Apache exporter image repository",
+                  "default": "lusotycoon/apache-exporter"
+                },
+                "pullPolicy": {
+                  "type": "string",
+                  "enum": [
+                    "IfNotPresent",
+                    "Always",
+                    "Never"
+                  ],
+                  "description": "Image pull policy",
+                  "default": "IfNotPresent"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Apache exporter image tag",
+                  "default": "v1.0.10"
+                }
+              }
+            },
+            "livenessProbe": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable liveness probe",
+                  "default": true
+                },
+                "initialDelaySeconds": {
+                  "type": "integer",
+                  "description": "Initial delay for liveness probe",
+                  "default": 15
+                },
+                "periodSeconds": {
+                  "type": "integer",
+                  "description": "Period for liveness probe",
+                  "default": 10
+                },
+                "timeoutSeconds": {
+                  "type": "integer",
+                  "description": "Timeout for liveness probe",
+                  "default": 5
+                },
+                "failureThreshold": {
+                  "type": "integer",
+                  "description": "Failure threshold for liveness probe",
+                  "default": 3
+                },
+                "successThreshold": {
+                  "type": "integer",
+                  "description": "Success threshold for liveness probe",
+                  "default": 1
+                }
+              }
+            },
+            "readinessProbe": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable readiness probe",
+                  "default": true
+                },
+                "initialDelaySeconds": {
+                  "type": "integer",
+                  "description": "Initial delay for readiness probe",
+                  "default": 5
+                },
+                "periodSeconds": {
+                  "type": "integer",
+                  "description": "Period for readiness probe",
+                  "default": 10
+                },
+                "timeoutSeconds": {
+                  "type": "integer",
+                  "description": "Timeout for readiness probe",
+                  "default": 5
+                },
+                "failureThreshold": {
+                  "type": "integer",
+                  "description": "Failure threshold for readiness probe",
+                  "default": 3
+                },
+                "successThreshold": {
+                  "type": "integer",
+                  "description": "Success threshold for readiness probe",
+                  "default": 1
+                }
+              }
+            },
+            "startupProbe": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable startup probe",
+                  "default": true
+                },
+                "initialDelaySeconds": {
+                  "type": "integer",
+                  "description": "Initial delay for startup probe",
+                  "default": 10
+                },
+                "periodSeconds": {
+                  "type": "integer",
+                  "description": "Period for startup probe",
+                  "default": 10
+                },
+                "timeoutSeconds": {
+                  "type": "integer",
+                  "description": "Timeout for startup probe",
+                  "default": 5
+                },
+                "failureThreshold": {
+                  "type": "integer",
+                  "description": "Failure threshold for startup probe",
+                  "default": 15
+                },
+                "successThreshold": {
+                  "type": "integer",
+                  "description": "Success threshold for startup probe",
+                  "default": 1
+                }
+              }
+            },
+            "customLivenessProbe": {
+              "type": "object",
+              "description": "Override default liveness probe",
+              "default": {}
+            },
+            "customReadinessProbe": {
+              "type": "object",
+              "description": "Override default readiness probe",
+              "default": {}
+            },
+            "customStartupProbe": {
+              "type": "object",
+              "description": "Override default startup probe",
+              "default": {}
+            },
+            "resources": {
+              "type": "object",
+              "description": "Resource limits and requests",
+              "default": {}
+            },
+            "service": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "ClusterIP",
+                    "NodePort",
+                    "LoadBalancer",
+                    "ExternalName"
+                  ],
+                  "description": "Service type",
+                  "default": "ClusterIP"
+                },
+                "ports": {
+                  "type": "object",
+                  "properties": {
+                    "metrics": {
+                      "type": "integer",
+                      "default": 9117
+                    }
+                  }
+                },
+                "nodePorts": {
+                  "type": "object",
+                  "properties": {
+                    "metrics": {
+                      "type": [
+                        "integer",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "clusterIP": {
+                  "type": "string",
+                  "description": "Static cluster IP"
+                },
+                "annotations": {
+                  "type": "object",
+                  "description": "Additional annotations for service"
+                },
+                "labels": {
+                  "type": "object",
+                  "description": "Additional labels for service",
+                  "default": {}
+                }
+              }
+            },
+            "containerSecurityContext": {
+              "type": "object",
+              "properties": {
+                "seLinuxOptions": {
+                  "type": "object",
+                  "description": "SELinux options",
+                  "default": {}
+                },
+                "runAsUser": {
+                  "type": "integer",
+                  "description": "User ID to run containers",
+                  "default": 1001
+                },
+                "runAsGroup": {
+                  "type": "integer",
+                  "description": "Group ID to run containers",
+                  "default": 1001
+                },
+                "runAsNonRoot": {
+                  "type": "boolean",
+                  "description": "Run containers as non-root user",
+                  "default": true
+                },
+                "privileged": {
+                  "type": "boolean",
+                  "description": "Run container in privileged mode",
+                  "default": false
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean",
+                  "description": "Mount root filesystem as read-only",
+                  "default": true
+                },
+                "allowPrivilegeEscalation": {
+                  "type": "boolean",
+                  "description": "Allow privilege escalation",
+                  "default": false
+                },
+                "capabilities": {
+                  "type": "object",
+                  "properties": {
+                    "drop": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "default": [
+                        "ALL"
+                      ]
+                    }
+                  }
+                },
+                "seccompProfile": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "RuntimeDefault",
+                        "Localhost",
+                        "Unconfined"
+                      ],
+                      "default": "RuntimeDefault"
+                    }
+                  }
+                }
+              }
+            },
+            "serviceMonitor": {
+              "type": "object",
+              "description": "ServiceMonitor configuration for Apache metrics",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "description": "Enable ServiceMonitor for Apache metrics",
+                  "default": true
+                },
+                "namespace": {
+                  "type": "string",
+                  "description": "Namespace for Apache ServiceMonitor",
+                  "default": ""
+                },
+                "interval": {
+                  "type": "string",
+                  "description": "Scrape interval",
+                  "default": "30s"
+                },
+                "metricsPath": {
+                  "type": "string",
+                  "description": "Metrics endpoint path",
+                  "default": "/metrics"
+                },
+                "labels": {
+                  "type": "object",
+                  "description": "Additional labels for ServiceMonitor"
+                },
+                "annotations": {
+                  "type": "object",
+                  "description": "Additional annotations for ServiceMonitor"
+                },
+                "selector": {
+                  "type": "object",
+                  "description": "Custom selector for ServiceMonitor"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "externalDatabase": {
+      "type": "object",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "External database host"
+        },
+        "port": {
+          "type": "integer",
+          "description": "External database port",
+          "default": 3306
+        },
+        "database": {
+          "type": "string",
+          "description": "External database name"
+        },
+        "username": {
+          "type": "string",
+          "description": "External database username"
+        },
+        "password": {
+          "type": "string",
+          "description": "External database password"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Name of existing secret for database credentials",
+          "default": ""
+        },
+        "secretKeys": {
+          "type": "object",
+          "description": "Key names for database credentials within an existing secret",
+          "properties": {
+            "userUsernameKey": {
+              "type": "string",
+              "description": "Key name for the database username",
+              "default": "db.username"
+            },
+            "userPasswordKey": {
+              "type": "string",
+              "description": "Key name for the database password",
+              "default": "db.password"
+            }
+          }
+        }
+      }
+    },
+    "mariadb": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable MariaDB chart installation",
+          "default": true
+        },
+        "nameOverride": {
+          "type": "string",
+          "description": "String to partially override mariadb.fullname",
+          "default": ""
+        },
+        "fullnameOverride": {
+          "type": "string",
+          "description": "String to fully override mariadb.fullname",
+          "default": ""
+        },
+        "commonLabels": {
+          "type": "object",
+          "description": "Labels to add to all deployed objects",
+          "default": {}
+        },
+        "commonAnnotations": {
+          "type": "object",
+          "description": "Annotations to add to all deployed objects",
+          "default": {}
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "MariaDB image registry",
+              "default": "docker.io"
+            },
+            "repository": {
+              "type": "string",
+              "description": "MariaDB image repository",
+              "default": "mariadb"
+            },
+            "tag": {
+              "type": "string",
+              "description": "MariaDB image tag",
+              "default": "12.0.2-noble"
+            },
+            "imagePullPolicy": {
+              "type": "string",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ],
+              "description": "MariaDB image pull policy",
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "MariaDB authentication enabled or disabled",
+              "default": true
+            },
+            "rootPassword": {
+              "type": "string",
+              "description": "MariaDB root password",
+              "default": ""
+            },
+            "database": {
+              "type": "string",
+              "description": "MariaDB custom database"
+            },
+            "username": {
+              "type": "string",
+              "description": "MariaDB custom user name"
+            },
+            "password": {
+              "type": "string",
+              "description": "MariaDB custom user password",
+              "default": ""
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Name of existing secret for MariaDB credentials",
+              "default": ""
+            },
+            "allowEmptyRootPassword": {
+              "type": "string",
+              "description": "Allow empty root password",
+              "default": "false"
+            },
+            "secretKeys": {
+              "type": "object",
+              "properties": {
+                "rootPasswordKey": {
+                  "type": "string",
+                  "description": "Name of key in existing secret for root password",
+                  "default": "mariadb-root-password"
+                },
+                "userPasswordKey": {
+                  "type": "string",
+                  "description": "Name of key in existing secret for user password",
+                  "default": "mariadb-password"
+                }
+              }
+            }
+          }
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer",
+                "ExternalName"
+              ],
+              "description": "MariaDB service type",
+              "default": "ClusterIP"
+            },
+            "port": {
+              "type": "integer",
+              "description": "MariaDB service port",
+              "default": 3306
+            },
+            "nodePort": {
+              "type": "string",
+              "description": "Node port for MariaDB service",
+              "default": ""
+            },
+            "clusterIP": {
+              "type": "string",
+              "description": "Static cluster IP or 'None' for headless service",
+              "default": ""
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Additional custom annotations for MariaDB service",
+              "default": {}
+            }
+          }
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "properties": {
+            "runAsUser": {
+              "type": "integer",
+              "description": "Set MariaDB container's Security Context runAsUser",
+              "default": 999
+            },
+            "runAsNonRoot": {
+              "type": "boolean",
+              "description": "Set MariaDB container's Security Context runAsNonRoot",
+              "default": true
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "description": "Set MariaDB container's privilege escalation",
+              "default": false
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "ALL"
+                  ]
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "RuntimeDefault",
+                    "Localhost",
+                    "Unconfined"
+                  ],
+                  "default": "RuntimeDefault"
+                }
+              }
+            }
+          }
+        },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable MariaDB data persistence using PVC",
+              "default": true
+            },
+            "storageClass": {
+              "type": "string",
+              "description": "PVC Storage Class for MariaDB data volume",
+              "default": ""
+            },
+            "accessModes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "ReadWriteOnce",
+                  "ReadOnlyMany",
+                  "ReadWriteMany"
+                ]
+              },
+              "description": "PVC Access modes",
+              "default": [
+                "ReadWriteOnce"
+              ]
+            },
+            "size": {
+              "type": "string",
+              "description": "PVC Storage Request for MariaDB data volume",
+              "default": "1Gi"
+            },
+            "annotations": {
+              "type": "object",
+              "description": "Additional custom annotations for the PVC",
+              "default": {}
+            },
+            "selector": {
+              "type": "object",
+              "description": "Additional labels for the PVC",
+              "default": {}
+            }
+          }
+        }
+      },
+      "description": "MariaDB chart configuration"
+    },
+    "memcached": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Memcached chart installation",
+          "default": false
+        },
+        "createConfig": {
+          "type": "boolean",
+          "description": "Create in wp-config.php the Memcached config",
+          "default": true
+        },
+        "cacheKeySalt": {
+          "type": "string",
+          "description": "Cache key salt for Memcached object cache isolation. If empty, chart generates a random salt on first deploy and reuses it on upgrades.",
+          "default": ""
+        },
+        "cacheKeySaltSecret": {
+          "type": "object",
+          "description": "Existing Secret reference for Memcached cache key salt.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of existing Secret containing cache key salt",
+              "default": ""
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in Secret containing cache key salt value",
+              "default": "WP_CACHE_KEY_SALT"
+            }
+          }
+        },
+        "serverGroups": {
+          "type": "object",
+          "description": "Optional cache-group mapping to Memcached server lists. If empty, chart falls back to embedded service for group 'default'.",
+          "default": {},
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "nameOverride": {
+          "type": "string",
+          "description": "String to partially override memcached.fullname",
+          "default": ""
+        },
+        "fullnameOverride": {
+          "type": "string",
+          "description": "String to fully override memcached.fullname",
+          "default": ""
+        },
+        "commonLabels": {
+          "type": "object",
+          "description": "Labels to add to all deployed objects",
+          "default": {}
+        },
+        "commonAnnotations": {
+          "type": "object",
+          "description": "Annotations to add to all deployed objects",
+          "default": {}
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "Memcached image registry",
+              "default": "docker.io"
+            },
+            "repository": {
+              "type": "string",
+              "description": "Memcached image repository",
+              "default": "memcached"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Memcached image tag",
+              "default": "1.6.39"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ],
+              "description": "Memcached image pull policy",
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of Memcached replicas to deploy",
+          "default": 1
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer",
+                "ExternalName"
+              ],
+              "description": "Kubernetes service type",
+              "default": "ClusterIP"
+            },
+            "port": {
+              "type": "integer",
+              "description": "Memcached service port",
+              "default": 11211
+            }
+          }
+        },
+        "topologySpreadConstraints": {
+          "type": "array",
+          "description": "Topology spread constraints for Redis pods",
+          "default": []
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "properties": {
+            "runAsUser": {
+              "type": "integer",
+              "description": "User ID to run the container",
+              "default": 11211
+            },
+            "runAsNonRoot": {
+              "type": "boolean",
+              "description": "Run as non-root user",
+              "default": true
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "description": "Set Memcached container's privilege escalation",
+              "default": false
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "ALL"
+                  ]
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "RuntimeDefault",
+                    "Localhost",
+                    "Unconfined"
+                  ],
+                  "default": "RuntimeDefault"
+                }
+              }
+            }
+          }
+        }
+      },
+      "description": "Memcached chart configuration"
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Redis chart installation",
+          "default": false
+        },
+        "createConfig": {
+          "type": "boolean",
+          "description": "Create in wp-config.php the Redis config",
+          "default": true
+        },
+        "cacheKeySalt": {
+          "type": "string",
+          "description": "Cache key salt for Redis object cache isolation. If empty, chart generates a random salt on first deploy and reuses it on upgrades.",
+          "default": ""
+        },
+        "cacheKeySaltSecret": {
+          "type": "object",
+          "description": "Existing Secret reference for Redis cache key salt.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of existing Secret containing cache key salt",
+              "default": ""
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in Secret containing cache key salt value",
+              "default": "WP_CACHE_KEY_SALT"
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "description": "Redis authentication settings. If enabled by the Redis chart and no values are set here, Redis may generate a password in its default secret.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable or disable Redis authentication",
+              "default": true
+            },
+            "password": {
+              "type": "string",
+              "description": "Explicit Redis password",
+              "default": ""
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing Secret containing Redis password",
+              "default": ""
+            },
+            "existingSecretPasswordKey": {
+              "type": "string",
+              "description": "Secret key containing Redis password",
+              "default": "redis-password"
+            }
+          }
+        },
+        "scaling": {
+          "type": "object",
+          "description": "Advanced Redis Object Cache scaling topology configuration.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Scaling mode",
+              "enum": [
+                "none",
+                "replication",
+                "sharding",
+                "sentinel",
+                "cluster"
+              ],
+              "default": "none"
+            },
+            "servers": {
+              "type": "array",
+              "description": "Server URIs for replication/sentinel mode",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
+            "sentinel": {
+              "type": "string",
+              "description": "Sentinel master/service name (required for sentinel mode)",
+              "default": ""
+            },
+            "shards": {
+              "type": "array",
+              "description": "Server URIs for sharding mode",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
+            "cluster": {
+              "type": "array",
+              "description": "Server URIs for cluster mode",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "nameOverride": {
+          "type": "string",
+          "description": "String to partially override redis.fullname",
+          "default": ""
+        },
+        "fullnameOverride": {
+          "type": "string",
+          "description": "String to fully override redis.fullname",
+          "default": ""
+        },
+        "commonLabels": {
+          "type": "object",
+          "description": "Labels to add to all deployed objects",
+          "default": {}
+        },
+        "commonAnnotations": {
+          "type": "object",
+          "description": "Annotations to add to all deployed objects",
+          "default": {}
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "Redis image registry",
+              "default": "docker.io"
+            },
+            "repository": {
+              "type": "string",
+              "description": "Redis image repository",
+              "default": "redis"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Redis image tag",
+              "default": "8.6.0"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ],
+              "description": "Redis image pull policy",
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of Redis replicas to deploy",
+          "default": 1
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer",
+                "ExternalName"
+              ],
+              "description": "Kubernetes service type",
+              "default": "ClusterIP"
+            },
+            "port": {
+              "type": "integer",
+              "description": "Redis service port",
+              "default": 6379
+            }
+          }
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "properties": {
+            "runAsUser": {
+              "type": "integer",
+              "description": "User ID to run the container",
+              "default": 999
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "description": "Group ID to run the container",
+              "default": 999
+            },
+            "runAsNonRoot": {
+              "type": "boolean",
+              "description": "Run as non-root user",
+              "default": true
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "description": "Set Redis container's privilege escalation",
+              "default": false
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "ALL"
+                  ]
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "RuntimeDefault",
+                    "Localhost",
+                    "Unconfined"
+                  ],
+                  "default": "RuntimeDefault"
+                }
+              }
+            }
+          }
+        }
+      },
+      "description": "Redis chart configuration"
+    },
+    "valkey": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable Valkey chart installation",
+          "default": false
+        },
+        "createConfig": {
+          "type": "boolean",
+          "description": "Create in wp-config.php the Valkey config",
+          "default": true
+        },
+        "cacheKeySalt": {
+          "type": "string",
+          "description": "Cache key salt for Valkey object cache isolation. If empty, chart generates a random salt on first deploy and reuses it on upgrades.",
+          "default": ""
+        },
+        "cacheKeySaltSecret": {
+          "type": "object",
+          "description": "Existing Secret reference for Valkey cache key salt.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Name of existing Secret containing cache key salt",
+              "default": ""
+            },
+            "key": {
+              "type": "string",
+              "description": "Key in Secret containing cache key salt value",
+              "default": "WP_CACHE_KEY_SALT"
+            }
+          }
+        },
+        "auth": {
+          "type": "object",
+          "description": "Valkey authentication settings. If enabled by the Valkey chart and no values are set here, Valkey may generate a password in its default secret.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable or disable Valkey authentication",
+              "default": true
+            },
+            "password": {
+              "type": "string",
+              "description": "Explicit Valkey password",
+              "default": ""
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Existing Secret containing Valkey password",
+              "default": ""
+            },
+            "existingSecretPasswordKey": {
+              "type": "string",
+              "description": "Secret key containing Valkey password",
+              "default": "password"
+            }
+          }
+        },
+        "scaling": {
+          "type": "object",
+          "description": "Advanced Redis Object Cache scaling topology configuration.",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Scaling mode",
+              "enum": [
+                "none",
+                "replication",
+                "sharding",
+                "sentinel",
+                "cluster"
+              ],
+              "default": "none"
+            },
+            "servers": {
+              "type": "array",
+              "description": "Server URIs for replication/sentinel mode",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
+            "sentinel": {
+              "type": "string",
+              "description": "Sentinel master/service name (required for sentinel mode)",
+              "default": ""
+            },
+            "shards": {
+              "type": "array",
+              "description": "Server URIs for sharding mode",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            },
+            "cluster": {
+              "type": "array",
+              "description": "Server URIs for cluster mode",
+              "default": [],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "nameOverride": {
+          "type": "string",
+          "description": "String to partially override valkey.fullname",
+          "default": ""
+        },
+        "fullnameOverride": {
+          "type": "string",
+          "description": "String to fully override valkey.fullname",
+          "default": ""
+        },
+        "commonLabels": {
+          "type": "object",
+          "description": "Labels to add to all deployed objects",
+          "default": {}
+        },
+        "commonAnnotations": {
+          "type": "object",
+          "description": "Annotations to add to all deployed objects",
+          "default": {}
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "registry": {
+              "type": "string",
+              "description": "Valkey image registry",
+              "default": "docker.io"
+            },
+            "repository": {
+              "type": "string",
+              "description": "Valkey image repository",
+              "default": "valkey/valkey"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Valkey image tag",
+              "default": "9.0.2-alpine3.23"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": [
+                "IfNotPresent",
+                "Always",
+                "Never"
+              ],
+              "description": "Valkey image pull policy",
+              "default": "IfNotPresent"
+            }
+          }
+        },
+        "replicaCount": {
+          "type": "integer",
+          "description": "Number of Valkey replicas to deploy",
+          "default": 1
+        },
+        "service": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer",
+                "ExternalName"
+              ],
+              "description": "Kubernetes service type",
+              "default": "ClusterIP"
+            },
+            "port": {
+              "type": "integer",
+              "description": "Valkey service port",
+              "default": 6379
+            }
+          }
+        },
+        "containerSecurityContext": {
+          "type": "object",
+          "properties": {
+            "runAsUser": {
+              "type": "integer",
+              "description": "User ID to run the container",
+              "default": 999
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "description": "Group ID to run the container",
+              "default": 1000
+            },
+            "runAsNonRoot": {
+              "type": "boolean",
+              "description": "Run as non-root user",
+              "default": true
+            },
+            "allowPrivilegeEscalation": {
+              "type": "boolean",
+              "description": "Set Valkey container's privilege escalation",
+              "default": false
+            },
+            "capabilities": {
+              "type": "object",
+              "properties": {
+                "drop": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "default": [
+                    "ALL"
+                  ]
+                }
+              }
+            },
+            "seccompProfile": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "RuntimeDefault",
+                    "Localhost",
+                    "Unconfined"
+                  ],
+                  "default": "RuntimeDefault"
+                }
+              }
+            }
+          }
+        }
+      },
+      "description": "Valkey chart configuration"
+    }
+  },
+  "if": {
+    "properties": {
+      "mariadb": {
+        "properties": {
+          "enabled": {
+            "const": false
+          }
+        }
+      }
+    }
+  },
+  "then": {
+    "required": [
+      "externalDatabase"
+    ],
+    "properties": {
+      "externalDatabase": {
+        "required": [
+          "host",
+          "database"
+        ]
+      }
+    }
+  },
+  "allOf": [
+    {
+      "not": {
+        "anyOf": [
+          {
+            "properties": {
+              "memcached": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "redis": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "memcached": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "valkey": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          },
+          {
+            "properties": {
+              "redis": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              },
+              "valkey": {
+                "properties": {
+                  "enabled": {
+                    "const": true
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -207,6 +207,40 @@ wordpress:
       ## ```
       sites: []
 
+    ## @section JWT Authentication configuration
+    ## @descriptionStart
+    ## When enabled, installs the `jwt-authentication-for-wp-rest-api` plugin (wordpress.org/plugins/jwt-authentication-for-wp-rest-api)
+    ## and injects define('JWT_AUTH_SECRET_KEY', ...) into wp-config.php via the main chart secret.
+    ## Requires wordpress.configExtraInject: true (default).
+    ## @descriptionEnd
+    jwt:
+      ## @param wordpress.init.jwt.enabled bool Enable JWT Authentication (installs jwt-authentication-for-wp-rest-api plugin)
+      enabled: false
+      ## @param wordpress.init.jwt.secret string Inline JWT signing secret (auto-generated and preserved across helm upgrades if empty; ignored when existingSecret is set)
+      secret: ""
+      ## @param wordpress.init.jwt.existingSecret string Name of an existing Secret containing the JWT signing key
+      existingSecret: ""
+      ## @param wordpress.init.jwt.secretKey string Key within existingSecret that holds the JWT signing key
+      secretKey: "JWT_AUTH_SECRET_KEY"
+
+    ## @param wordpress.init.applicationPassword object Create an Application Password for the admin user via a Helm hook Job
+    ## @descriptionStart
+    ## When set, a post-install/post-upgrade Job creates an Application Password for the admin user
+    ## and stores username, application password, and site URL in a Kubernetes Secret.
+    ## The Secret persists after helm uninstall.
+    ## E.g.
+    ## ```yaml
+    ## applicationPassword:
+    ##   name: "MCP Access"
+    ##   outputSecret:
+    ##     name: ""            # empty = <release>-token-<adminUsername>
+    ##     usernameKey: "WP_USERNAME"
+    ##     passwordKey: "WP_APP_PASSWORD"
+    ##     urlKey: "WP_SITE_URL"
+    ## ```
+    ## @descriptionEnd
+    applicationPassword: {}
+
     ## @section Custom init script
     customInitScript: ""
     ## @section Custom init commands
@@ -290,7 +324,7 @@ wordpress:
     ## @param wordpress.composer.repositories list Custom Composer repositories to add
     repositories: []
 
-  ## @param wordpress.users list WordPress users to create (username, email, displayname, firstname, lastname, role, sendEmail, superAdmin, sites)
+  ## @param wordpress.users list WordPress users to create (username, email, displayname, firstname, lastname, role, sendEmail, superAdmin, sites, applicationPassword)
   ## E.g.
   ## ```yaml
   ## users:
@@ -307,6 +341,13 @@ wordpress:
   ##         role: editor
   ##       - name: shop
   ##         role: administrator
+  ##     applicationPassword:    # optional: create Application Password, store in K8s Secret
+  ##       name: "MCP Access"
+  ##       outputSecret:
+  ##         name: ""            # empty = <release>-token-<username>
+  ##         usernameKey: "WP_USERNAME"
+  ##         passwordKey: "WP_APP_PASSWORD"
+  ##         urlKey: "WP_SITE_URL"
   ##   - username: author
   ##     email: author@example.com
   ##     role: author


### PR DESCRIPTION
## Summary

- **Application Passwords**: WP-CLI in the init container creates per-user Application Passwords and stores them (username, password, site URL) in Kubernetes Secrets. Idempotent — re-creates only when K8s Secret or WP entry is missing.
- **JWT Authentication**: `wordpress.init.jwt.enabled` auto-installs `jwt-authentication-for-wp-rest-api`, auto-generates a signing secret preserved across upgrades, or accepts an existing K8s Secret via `existingSecret` + `secretKey`.
- **RBAC**: New `app-password-rbac.yaml` grants the WordPress ServiceAccount write access to the output Secrets (split rule: `create` without resourceNames, `get/update/patch/delete` scoped per Secret name).
- **Verify sample**: configures both auth methods end-to-end; `install.sh` uses `upgrade --install`, `uninstall.sh` waits for PVC deletion.

## New values

| Parameter | Default | Description |
|---|---|---|
| `wordpress.init.applicationPassword` | `{}` | Application Password for admin user |
| `wordpress.users[].applicationPassword` | — | Application Password per custom user |
| `wordpress.init.jwt.enabled` | `false` | Enable JWT auth (auto-installs plugin) |
| `wordpress.init.jwt.secret` | `""` | Inline signing secret (auto-generated if empty) |
| `wordpress.init.jwt.existingSecret` | `""` | Existing K8s Secret with signing key |
| `wordpress.init.jwt.secretKey` | `JWT_AUTH_SECRET_KEY` | Key within `existingSecret` |

## Test plan

- [x] `helm lint` passes
- [x] `yamllint` + `helmlint` pre-commit hooks pass
- [x] Fresh install via `verify.sh`: all pods Ready, no init errors
- [x] Application Password auth verified against REST API (`/wp-json/wp/v2/users/me`) for admin (`johndoe`) and contributor (`johnsmith`)
- [x] JWT token endpoint (`/wp-json/jwt-auth/v1/token`) returns valid token; Bearer auth verified
- [x] MCP adapter: `tools/list` returns 3 tools, `mcp-adapter-discover-abilities` returns 46 abilities via both auth methods
- [x] MCP abilities executed: `core/get-site-info`, `ewpa/site-stats`, `ewpa/get-users`, `ewpa/get-active-plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)