### PR TITLE
feat(wordpress): add SMTP, NetworkPolicy, PrometheusRule, secondaryIngress, backup CronJob, commonLabels — chart 4.2.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,17 @@ repos:
       - id: yamllint
         args: [-c=.yamllint.yml]
 
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23
-    hooks:
-      - id: helmlint
-
   # Validate ArtifactHub annotations in Chart.yaml files
   # Catches: invalid YAML in annotations, wrong 'kind' values, missing required fields,
   # and special characters that need quotes: {}:[],&*#?|-<>=!%@
   - repo: local
     hooks:
+      - id: helmlint
+        name: Helm Lint
+        entry: scripts/helmlint.sh
+        language: script
+        pass_filenames: true
+
       - id: validate-artifacthub-annotations
         name: Validate ArtifactHub annotations
         entry: python scripts/validate-artifacthub-annotations.py

--- a/charts/wordpress/CHANGELOG.md
+++ b/charts/wordpress/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this chart are documented here.
 
+## 4.2.0 - 2026-05-25
+
+- Add NetworkPolicy with configurable ingress sources and external egress control
+- Add PrometheusRule with default pod-down and Apache busy-worker alerts
+- Add commonLabels / commonAnnotations applied to all chart resources
+- Add ingress.secondary for independent admin/geo-routed Ingress objects
+- Add wordpress.smtp SMTP config via MU-plugin with existingSecret support
+- Add backup CronJob with PVC storage and optional S3 sync via rclone
+
 ## 4.1.0 - 2026-05-23
 
 - Add token-based authentication support for external connectivity (e.g. MCP):

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wordpress
 description: "Using the official WordPress image. This chart provides automation for installation, user management, plugin installation, and metrics."
 type: application
-version: 4.1.0
+version: 4.2.0
 appVersion: "7.0.0" # renovate: image=docker.io/wordpress
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts
@@ -27,7 +27,17 @@ annotations:
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
     - kind: added
-      description: "Token-based auth: Application Passwords (stored in K8s Secrets) and JWT signing key injection via jwt-authentication-for-wp-rest-api"
+      description: "Add NetworkPolicy with configurable ingress sources and external egress"
+    - kind: added
+      description: "Add PrometheusRule with default pod-down and Apache busy-worker alerts"
+    - kind: added
+      description: "Add commonLabels and commonAnnotations applied to all chart resources"
+    - kind: added
+      description: "Add ingress.secondary for independent admin/geo-routed Ingress objects"
+    - kind: added
+      description: "Add wordpress.smtp SMTP config via MU-plugin (PHPMailer override, existingSecret support)"
+    - kind: added
+      description: "Add backup CronJob with PVC storage and optional S3 sync via rclone"
   artifacthub.io/images: |
     - name: wordpress
       image: docker.io/wordpress:7.0.0-php8.3-apache

--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -18,16 +18,22 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: wordpress-test-secret
+type: Opaque
 stringData:
+  wordpress.username: admin
+  wordpress.password: S3cr3tP@ssw0rd
+  wordpress.email: admin@example.com
   mariadb-root-password: S3cureDBP@ss
   mariadb-password: Sup3rS3cureP@ss
-type: Opaque
-
 ```
 
 ```yaml
 # ./samples/mariaDB.values.yaml
 wordpress:
+  init:
+    enabled: true
+    existingSecret: "wordpress-test-secret"
+    title: "My WordPress Site"
   url: "https://example.com"
 mariadb:
   auth:
@@ -114,6 +120,48 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 - Each ConfigMap data key becomes a PHP file in `wp-content/mu-plugins/`
 - Reference multiple ConfigMaps in `wordpress.muPluginsConfigMaps`
 - See `samples/muPlugins.configmap.yaml` and `samples/muPlugins.values.yaml`
+
+### SMTP
+- **MU-plugin based**: A PHP MU-plugin is generated from chart values and mounted directly into `wp-content/mu-plugins/` — no external plugin installation needed and always current on rolling updates.
+- Forces PHPMailer to use the configured SMTP server for all outgoing WordPress mail.
+- Credentials (password, username, from-address) are read from a Kubernetes Secret at runtime — nothing sensitive in values.
+- See `samples/smtp.values.yaml` and `samples/smtp.secrets.yaml`
+
+### NetworkPolicy
+- **Automatic traffic restriction**: Generates a `NetworkPolicy` for the WordPress pod when `networkPolicy.enabled: true`.
+- DB egress auto-wired to the MariaDB subchart or `externalDatabase.host`.
+- Cache egress auto-wired to whichever backend is active (Memcached, Redis, or Valkey).
+- DNS egress (UDP/TCP 53) always included.
+- Optional internet egress (`allowExternalEgress`) for wp-cli plugin downloads and SMTP.
+- Ingress `from` rules and extra egress rules are fully configurable.
+- See `samples/networkpolicy.values.yaml`
+
+### PrometheusRule
+- **Bundled alerting rules**: Creates a `PrometheusRule` resource when `metrics.prometheusRule.enabled: true` (requires `metrics.apache.enabled` or `metrics.wordpress.enabled`).
+- Default alerts: `WordPressPodDown`, `WordPressApacheExporterScrapeFailing`, `WordPressApacheHighBusyWorkers`.
+- Configurable `additionalLabels` to match your Prometheus Operator `ruleSelector`.
+- Extend with `extraRules` or disable individual default rules via `defaultRules.*`.
+- See `samples/prometheusrule.values.yaml`
+
+### Secondary Ingress
+- **Multiple Ingress objects** from one release: `ingress.secondary[]` generates additional Ingress resources alongside the primary one.
+- Typical use-case: separate `wp-admin` Ingress with IP allowlist and a different TLS certificate.
+- Each secondary entry supports its own `className`, `annotations`, `hosts`, and `tls`.
+- Annotations are merged with `commonAnnotations` (entry-specific wins).
+- See `samples/secondary-ingress.values.yaml`
+
+### Backup CronJob
+- **Scheduled database backup** to a PVC: a `CronJob` runs `mariadb-dump` and compresses the output with gzip.
+- Optional file backup (`backup.includeFiles: true`) tars `wp-content` — only enable when your PVC supports multiple concurrent readers (RWX or VolumeSnapshot). Leave `false` for RWO storage (default).
+- Optional **S3 sync** via rclone sidecar (`backup.s3.enabled`): after the dump completes the rclone container syncs the timestamped folder to any S3-compatible bucket.
+- Backup PVC is annotated `helm.sh/resource-policy: keep` — it survives `helm uninstall`.
+- See `samples/backup.values.yaml` and `samples/backup-s3.secrets.yaml`
+
+### commonLabels / commonAnnotations
+- **Apply labels or annotations to every resource** created by the chart via `commonLabels` and `commonAnnotations`.
+- Resource-specific annotations always win over `commonAnnotations` (merge: specific overrides common).
+- Useful for GitOps tools (ArgoCD), service-mesh sidecar injection, cost-allocation, and audit tags.
+- See `samples/commonLabels.values.yaml`
 
 ### Application Passwords (MCP / REST API access)
 - **Create Application Passwords** during init for the admin user and any additional users
@@ -457,6 +505,135 @@ wordpress:
 
 ---
 
+### SMTP
+Configure outgoing mail via any SMTP server. See `samples/smtp.values.yaml` and `samples/smtp.secrets.yaml`.
+
+```bash
+kubectl apply -f ./samples/smtp.secrets.yaml
+# then add the smtp snippet to your existing values file
+```
+
+```yaml
+# smtp snippet to merge into your values
+wordpress:
+  smtp:
+    enabled: true
+    host: smtp.gmail.com
+    port: 587
+    encryption: tls
+    fromName: "My WordPress Site"
+    auth: true
+    existingSecret: gmail-smtp-secret
+    existingSecretPasswordKey: password
+    existingSecretUsernameKey: username
+    existingSecretFromEmailKey: fromEmail
+```
+
+### NetworkPolicy
+Restrict pod traffic to only the required connections. See `samples/networkpolicy.values.yaml`.
+
+```yaml
+# snippet to merge into your values
+networkPolicy:
+  enabled: true
+  allowExternalEgress: true   # needed for wp-cli downloads and SMTP
+  ingress:
+    from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: ingress-nginx
+```
+
+### PrometheusRule
+Deploy bundled alerting rules. Requires `metrics.apache.enabled` or `metrics.wordpress.enabled`. See `samples/prometheusrule.values.yaml`.
+
+```yaml
+# snippet to merge into your values
+metrics:
+  apache:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack
+```
+
+### Secondary Ingress
+Separate Ingress for `wp-admin` with IP allowlist and its own TLS certificate. See `samples/secondary-ingress.values.yaml`.
+
+```yaml
+# snippet to merge into your values
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: blog.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  secondary:
+    - name: admin
+      enabled: true
+      className: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+      hosts:
+        - host: admin.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: wp-admin-tls
+          hosts: [admin.example.com]
+```
+
+### Backup CronJob
+Daily database backup to a PVC, with optional S3 sync via rclone. See `samples/backup.values.yaml` and `samples/backup-s3.secrets.yaml`.
+
+```bash
+# S3 backup: create the rclone config secret first
+kubectl create secret generic my-rclone-config --from-file=rclone.conf=./rclone.conf
+```
+
+```yaml
+# snippet to merge into your values
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  retentionDays: 14
+  persistence:
+    size: 20Gi
+  # Optional S3 sync after each run:
+  s3:
+    enabled: true
+    existingSecret: my-rclone-config   # Secret with rclone.conf
+    remote: s3
+    bucket: my-wordpress-backups
+    path: wordpress
+```
+
+**Trigger a manual backup run:**
+```bash
+kubectl create job --from=cronjob/<release>-backup manual-backup-1
+kubectl logs -l job-name=manual-backup-1 -c backup -f
+```
+
+> **Note:** `backup.includeFiles: true` tars `wp-content` in addition to the database dump. Only enable this when the WordPress PVC supports concurrent readers (RWX storage or VolumeSnapshot). With standard RWO storage (OpenEBS ZFS, Longhorn RWO, etc.) leave it `false` (default) to avoid mount conflicts.
+
+### commonLabels and commonAnnotations
+Apply uniform labels or annotations to every Kubernetes resource the chart creates. See `samples/commonLabels.values.yaml`.
+
+```yaml
+# snippet to merge into your values
+commonLabels:
+  team: platform
+  environment: production
+
+commonAnnotations:
+  owner: platform-team
+  contact: platform@example.com
+```
+
 ### Composer Packages
 Install plugins and themes via Composer that aren't available in WordPress.org. See `samples/composer.values.yaml`.
 
@@ -569,6 +746,14 @@ Without `slug`, URL plugins/themes use `basename` of the URL as a best-effort gu
 - **Network activation** (`networkActivate` / `networkEnable`)
 
 ## Notable changes
+
+### To 4.2.0
+- Added **SMTP** (`wordpress.smtp`): MU-plugin generated from chart values, mounted directly via subPath — no external plugin needed. Credentials (password, username, from-address) are read from a Kubernetes Secret.
+- Added **NetworkPolicy** (`networkPolicy`): automatically wires DB/cache/DNS egress; optional internet egress via `allowExternalEgress`.
+- Added **PrometheusRule** (`metrics.prometheusRule`): bundled alerts for pod-down, scrape-failing, and high busy-workers; extend via `extraRules`.
+- Added **Secondary Ingress** (`ingress.secondary[]`): generates additional Ingress objects per release (e.g. separate `wp-admin` with IP allowlist).
+- Added **Backup CronJob** (`backup`): daily `mariadb-dump` to PVC; optional rclone S3 sidecar (`backup.s3`). New `backup.includeFiles` flag (default `false`) controls whether `wp-content` is also archived.
+- Added **commonLabels / commonAnnotations**: applied to all chart resources; resource-specific annotations take precedence.
 
 ### To 4.1.0
 - Added **Application Passwords** (`wordpress.init.applicationPassword`, `wordpress.users[].applicationPassword`): WP-CLI in the init container creates Application Passwords per user and stores them in Kubernetes Secrets (persist after `helm uninstall`).

--- a/charts/wordpress/samples/advanced.values.yaml
+++ b/charts/wordpress/samples/advanced.values.yaml
@@ -1,3 +1,8 @@
+## Sample: Advanced install with plugins, themes, users, metrics, and custom PHP/htaccess
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
+##   kubectl apply -f advanced.configmap.yaml
+
 wordpress:
   init:
     enabled: true

--- a/charts/wordpress/samples/advanced2.values.yaml
+++ b/charts/wordpress/samples/advanced2.values.yaml
@@ -1,3 +1,8 @@
+## Sample: Advanced setup with replicaCount > 1 (requires RWX storage)
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
+##   kubectl apply -f advanced.configmap.yaml
+
 replicaCount: 2
 
 wordpress:

--- a/charts/wordpress/samples/backup-s3.secrets.yaml
+++ b/charts/wordpress/samples/backup-s3.secrets.yaml
@@ -1,0 +1,18 @@
+## Sample: rclone config secret for S3 backup
+## Create this Secret before enabling backup.s3:
+##   kubectl create secret generic my-rclone-config \
+##     --from-file=rclone.conf=./rclone.conf
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-rclone-config
+type: Opaque
+stringData:
+  rclone.conf: |
+    [s3]
+    type = s3
+    provider = AWS
+    region = eu-central-1
+    access_key_id = AKIA...
+    secret_access_key = ...

--- a/charts/wordpress/samples/backup.values.yaml
+++ b/charts/wordpress/samples/backup.values.yaml
@@ -1,4 +1,4 @@
-## Sample: Backup CronJob
+## Snippet: Backup CronJob — add these values to your existing values file.
 ## Creates a daily backup of the database to a PVC.
 ## Set includeFiles: true to also tar wp-content — only works when the
 ## wordpress PVC supports multiple readers (RWX) or you use VolumeSnapshots.

--- a/charts/wordpress/samples/backup.values.yaml
+++ b/charts/wordpress/samples/backup.values.yaml
@@ -1,10 +1,14 @@
 ## Sample: Backup CronJob
-## Creates a daily backup of the database and wp-content to a PVC.
+## Creates a daily backup of the database to a PVC.
+## Set includeFiles: true to also tar wp-content — only works when the
+## wordpress PVC supports multiple readers (RWX) or you use VolumeSnapshots.
+## With RWO storage (OpenEBS ZFS, Longhorn in RWO mode, etc.) leave this false.
 
 backup:
   enabled: true
   schedule: "0 2 * * *"
   retentionDays: 14
+  includeFiles: false
   persistence:
     enabled: true
     size: 20Gi

--- a/charts/wordpress/samples/backup.values.yaml
+++ b/charts/wordpress/samples/backup.values.yaml
@@ -1,0 +1,11 @@
+## Sample: Backup CronJob
+## Creates a daily backup of the database and wp-content to a PVC.
+
+backup:
+  enabled: true
+  schedule: "0 2 * * *"
+  retentionDays: 14
+  persistence:
+    enabled: true
+    size: 20Gi
+    storageClass: ""

--- a/charts/wordpress/samples/commonLabels.values.yaml
+++ b/charts/wordpress/samples/commonLabels.values.yaml
@@ -1,0 +1,12 @@
+## Sample: commonLabels and commonAnnotations
+## These are applied to ALL Kubernetes resources created by the chart.
+## Useful for GitOps (ArgoCD), service mesh, cost allocation, and audit.
+
+commonLabels:
+  team: platform
+  environment: production
+  app.kubernetes.io/part-of: my-stack
+
+commonAnnotations:
+  owner: platform-team
+  contact: platform@example.com

--- a/charts/wordpress/samples/commonLabels.values.yaml
+++ b/charts/wordpress/samples/commonLabels.values.yaml
@@ -1,4 +1,4 @@
-## Sample: commonLabels and commonAnnotations
+## Snippet: commonLabels and commonAnnotations — add these values to your existing values file.
 ## These are applied to ALL Kubernetes resources created by the chart.
 ## Useful for GitOps (ArgoCD), service mesh, cost allocation, and audit.
 

--- a/charts/wordpress/samples/composer.values.yaml
+++ b/charts/wordpress/samples/composer.values.yaml
@@ -1,5 +1,6 @@
-# Example configuration for using Composer packages with WordPress
-# This demonstrates how to install plugins and themes via Composer that are not available in the WordPress.org repository
+## Sample: WordPress plugins/themes via Composer (wpackagist, GitHub, private repos)
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
 
 wordpress:
   init:
@@ -9,7 +10,7 @@ wordpress:
     firstname: "John"
     lastname: "Doe"
     title: "John Does's Blog"
-  url: "http://192.168.178.31:30111"
+  url: "https://example.com"
 
   permalinks:
     structure: postName

--- a/charts/wordpress/samples/composer2.values.yaml
+++ b/charts/wordpress/samples/composer2.values.yaml
@@ -1,5 +1,7 @@
-# Example configuration for using Composer packages with WordPress
-# This demonstrates how to install plugins and themes via Composer that are not available in the WordPress.org repository
+## Sample: Composer plugins/themes with replicaCount > 1 (requires RWX storage)
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
+
 replicaCount: 2
 
 # Storage configuration for multi-replica setup

--- a/charts/wordpress/samples/customInit.values.yaml
+++ b/charts/wordpress/samples/customInit.values.yaml
@@ -28,4 +28,5 @@ mariadb:
   auth:
     database: "wordpress_db"
     username: "wordpress_user"
-    existingSecret: "wordpress-test-secret"
+    rootPassword: "S3cureRootP@ss"
+    password: "S3cureDBP@ss"

--- a/charts/wordpress/samples/externalDB.secrets.yaml
+++ b/charts/wordpress/samples/externalDB.secrets.yaml
@@ -1,8 +1,14 @@
+## Prerequisites for externalDB.values.yaml
+## kubectl apply -f externalDB.secrets.yaml
+
 apiVersion: v1
 kind: Secret
 metadata:
   name: wordpress-test-secret
-stringData:
-  db.password: S3cureDBP@ss
-  db.username: dbuser
 type: Opaque
+stringData:
+  wordpress.username: admin
+  wordpress.password: S3cr3tP@ssw0rd
+  wordpress.email: admin@example.com
+  db.username: dbuser
+  db.password: S3cureDBP@ss

--- a/charts/wordpress/samples/externalDB.values.yaml
+++ b/charts/wordpress/samples/externalDB.values.yaml
@@ -1,5 +1,16 @@
+## Sample: WordPress with an external (pre-existing) database
+## Prerequisites:
+##   kubectl apply -f externalDB.secrets.yaml
+##
+## The secret must contain the keys matching externalDatabase.secretKeys
+## (defaults: db.username, db.password).
+
 wordpress:
   url: "https://example.com"
+  init:
+    enabled: true
+    existingSecret: "wordpress-test-secret"
+    title: "My WordPress Site"
 externalDatabase:
   host: "db-server"
   database: "wordpress_db"

--- a/charts/wordpress/samples/mariaDB.secrets.yaml
+++ b/charts/wordpress/samples/mariaDB.secrets.yaml
@@ -1,8 +1,14 @@
+## Prerequisites for mariaDB.values.yaml
+## kubectl apply -f mariaDB.secrets.yaml
+
 apiVersion: v1
 kind: Secret
 metadata:
   name: wordpress-test-secret
+type: Opaque
 stringData:
+  wordpress.username: admin
+  wordpress.password: S3cr3tP@ssw0rd
+  wordpress.email: admin@example.com
   mariadb-root-password: S3cureDBP@ss
   mariadb-password: Sup3rS3cureP@ss
-type: Opaque

--- a/charts/wordpress/samples/mariaDB.values.yaml
+++ b/charts/wordpress/samples/mariaDB.values.yaml
@@ -1,9 +1,14 @@
+## Sample: Minimal install with MariaDB subchart
+## Prerequisites:
+##   kubectl apply -f mariaDB.secrets.yaml
+
 wordpress:
   init:
+    enabled: true
     existingSecret: "wordpress-test-secret"
     firstname: "John"
     lastname: "Doe"
-    title: "John Does's Blog"
+    title: "John Doe's Blog"
   url: "https://example.com"
 mariadb:
   auth:

--- a/charts/wordpress/samples/memcached.values.yaml
+++ b/charts/wordpress/samples/memcached.values.yaml
@@ -1,3 +1,8 @@
+## Sample: Memcached object cache
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
+##   kubectl apply -f advanced.configmap.yaml
+
 wordpress:
   init:
     enabled: true

--- a/charts/wordpress/samples/muPlugins.values.yaml
+++ b/charts/wordpress/samples/muPlugins.values.yaml
@@ -31,4 +31,5 @@ mariadb:
   auth:
     database: "wordpress_db"
     username: "wordpress_user"
-    existingSecret: "wordpress-test-secret"
+    rootPassword: "S3cureRootP@ss"
+    password: "S3cureDBP@ss"

--- a/charts/wordpress/samples/multisite-subdomain.secrets.yaml
+++ b/charts/wordpress/samples/multisite-subdomain.secrets.yaml
@@ -1,0 +1,14 @@
+## Prerequisites for multisite-subdomain.values.yaml
+## kubectl apply -f multisite-subdomain.secrets.yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-multisite-subdomain-secret
+type: Opaque
+stringData:
+  wordpress.username: networkadmin
+  wordpress.password: NetworkAdminP@ss123
+  wordpress.email: admin@example.com
+  mariadb-root-password: RootDBP@ssword123
+  mariadb-password: WordPress_DB_P@ss123

--- a/charts/wordpress/samples/multisite-subdomain.values.yaml
+++ b/charts/wordpress/samples/multisite-subdomain.values.yaml
@@ -1,6 +1,6 @@
-# WordPress Multisite Sample Configuration (Subdomain Mode)
-# This example demonstrates a subdomain-based multisite setup
-# Sites: blog.example.com, shop.example.com
+## Sample: WordPress Multisite (subdomain mode)
+## Prerequisites:
+##   kubectl apply -f multisite-subdomain.secrets.yaml
 
 wordpress:
   init:

--- a/charts/wordpress/samples/multisite.values.yaml
+++ b/charts/wordpress/samples/multisite.values.yaml
@@ -1,6 +1,6 @@
-# WordPress Multisite Sample Configuration
-# This example demonstrates a full multisite setup with 3 sites (main, company-blog, shop)
-# using subdirectory configuration
+## Sample: WordPress Multisite (subdirectory mode, 3 sites)
+## Prerequisites:
+##   kubectl apply -f multisite.secrets.yaml
 
 wordpress:
   init:

--- a/charts/wordpress/samples/networkpolicy.values.yaml
+++ b/charts/wordpress/samples/networkpolicy.values.yaml
@@ -1,4 +1,4 @@
-## Sample: NetworkPolicy
+## Snippet: NetworkPolicy — add these values to your existing values file.
 ## Restricts ingress/egress traffic for the WordPress pod.
 
 networkPolicy:

--- a/charts/wordpress/samples/networkpolicy.values.yaml
+++ b/charts/wordpress/samples/networkpolicy.values.yaml
@@ -1,0 +1,17 @@
+## Sample: NetworkPolicy
+## Restricts ingress/egress traffic for the WordPress pod.
+
+networkPolicy:
+  enabled: true
+  # Allow internet egress for wp-cli plugin downloads and SMTP
+  allowExternalEgress: true
+  smtpPorts: [587]
+  ingress:
+    # Allow only from the nginx-ingress namespace
+    from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: ingress-nginx
+    extraRules: []
+  egress:
+    extraRules: []

--- a/charts/wordpress/samples/prometheusrule.values.yaml
+++ b/charts/wordpress/samples/prometheusrule.values.yaml
@@ -1,0 +1,15 @@
+## Sample: PrometheusRule
+## Requires metrics.apache.enabled or metrics.wordpress.enabled.
+## additionalLabels must match your Prometheus Operator's ruleSelector.
+
+metrics:
+  apache:
+    enabled: true
+  prometheusRule:
+    enabled: true
+    additionalLabels:
+      release: kube-prometheus-stack
+    defaultRules:
+      podDown: true
+      apacheScrapeFailing: true
+    extraRules: []

--- a/charts/wordpress/samples/prometheusrule.values.yaml
+++ b/charts/wordpress/samples/prometheusrule.values.yaml
@@ -1,4 +1,4 @@
-## Sample: PrometheusRule
+## Snippet: PrometheusRule — add these values to your existing values file.
 ## Requires metrics.apache.enabled or metrics.wordpress.enabled.
 ## additionalLabels must match your Prometheus Operator's ruleSelector.
 

--- a/charts/wordpress/samples/redis.values.yaml
+++ b/charts/wordpress/samples/redis.values.yaml
@@ -1,3 +1,8 @@
+## Sample: Redis object cache
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
+##   kubectl apply -f advanced.configmap.yaml
+
 wordpress:
   init:
     enabled: true

--- a/charts/wordpress/samples/secondary-ingress.values.yaml
+++ b/charts/wordpress/samples/secondary-ingress.values.yaml
@@ -1,0 +1,29 @@
+## Sample: Secondary Ingress
+## Separate ingress for wp-admin with IP whitelist and different TLS cert.
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: blog.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: wp-public-tls
+      hosts: [blog.example.com]
+  secondary:
+    - name: admin
+      enabled: true
+      className: nginx
+      annotations:
+        nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8,192.168.0.0/16"
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+      hosts:
+        - host: admin.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+      tls:
+        - secretName: wp-admin-tls
+          hosts: [admin.example.com]

--- a/charts/wordpress/samples/secondary-ingress.values.yaml
+++ b/charts/wordpress/samples/secondary-ingress.values.yaml
@@ -1,4 +1,4 @@
-## Sample: Secondary Ingress
+## Snippet: Secondary Ingress — add these values to your existing values file.
 ## Separate ingress for wp-admin with IP whitelist and different TLS cert.
 
 ingress:

--- a/charts/wordpress/samples/smtp.secrets.yaml
+++ b/charts/wordpress/samples/smtp.secrets.yaml
@@ -9,3 +9,5 @@ metadata:
 type: Opaque
 stringData:
   password: "your-smtp-password-here"
+  username: "noreply@example.com"
+  fromEmail: "noreply@example.com"

--- a/charts/wordpress/samples/smtp.secrets.yaml
+++ b/charts/wordpress/samples/smtp.secrets.yaml
@@ -1,0 +1,11 @@
+## Sample: SMTP secret
+## Create this Secret before installing the chart.
+## kubectl create secret generic gmail-smtp-secret --from-literal=password=my-app-password
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gmail-smtp-secret
+type: Opaque
+stringData:
+  password: "your-smtp-password-here"

--- a/charts/wordpress/samples/smtp.values.yaml
+++ b/charts/wordpress/samples/smtp.values.yaml
@@ -10,9 +10,9 @@ wordpress:
     host: smtp.gmail.com
     port: 587
     encryption: tls
-    fromEmail: noreply@example.com
     fromName: "My WordPress Site"
     auth: true
-    username: noreply@example.com
     existingSecret: gmail-smtp-secret
     existingSecretPasswordKey: password
+    existingSecretUsernameKey: username
+    existingSecretFromEmailKey: fromEmail

--- a/charts/wordpress/samples/smtp.values.yaml
+++ b/charts/wordpress/samples/smtp.values.yaml
@@ -1,8 +1,8 @@
-## Sample: SMTP configuration
+## Snippet: SMTP configuration — add these values to your existing values file.
 ## The MU-plugin is mounted directly into wp-content/mu-plugins/ and
 ## forces PHPMailer to use the configured SMTP server.
-##
-## For production, use existingSecret instead of password.
+## Prerequisites:
+##   kubectl apply -f smtp.secrets.yaml
 
 wordpress:
   smtp:

--- a/charts/wordpress/samples/smtp.values.yaml
+++ b/charts/wordpress/samples/smtp.values.yaml
@@ -1,0 +1,18 @@
+## Sample: SMTP configuration
+## The MU-plugin is mounted directly into wp-content/mu-plugins/ and
+## forces PHPMailer to use the configured SMTP server.
+##
+## For production, use existingSecret instead of password.
+
+wordpress:
+  smtp:
+    enabled: true
+    host: smtp.gmail.com
+    port: 587
+    encryption: tls
+    fromEmail: noreply@example.com
+    fromName: "My WordPress Site"
+    auth: true
+    username: noreply@example.com
+    existingSecret: gmail-smtp-secret
+    existingSecretPasswordKey: password

--- a/charts/wordpress/samples/token.secrets.yaml
+++ b/charts/wordpress/samples/token.secrets.yaml
@@ -1,0 +1,21 @@
+## Prerequisites for token.values.yaml
+## kubectl apply -f token.secrets.yaml
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-init-secret
+type: Opaque
+stringData:
+  wordpress.username: admin
+  wordpress.password: S3cr3tP@ssw0rd
+  wordpress.email: admin@example.com
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wordpress-mariadb-secret
+type: Opaque
+stringData:
+  mariadb-root-password: S3cureRootP@ss
+  mariadb-password: S3cureDBP@ss

--- a/charts/wordpress/samples/token.values.yaml
+++ b/charts/wordpress/samples/token.values.yaml
@@ -1,4 +1,6 @@
-## Token Authentication Sample
+## Sample: Token Authentication (JWT + Application Passwords)
+## Prerequisites:
+##   kubectl apply -f token.secrets.yaml
 ##
 ## Demonstrates both authentication methods for external connectivity (e.g. MCP):
 ##   1. JWT via jwt-authentication-for-wp-rest-api (wordpress.init.jwt.enabled)

--- a/charts/wordpress/samples/valkey.values.yaml
+++ b/charts/wordpress/samples/valkey.values.yaml
@@ -1,3 +1,8 @@
+## Sample: Valkey object cache (drop-in Redis-compatible)
+## Prerequisites:
+##   kubectl apply -f advanced.secrets.yaml
+##   kubectl apply -f advanced.configmap.yaml
+
 wordpress:
   init:
     enabled: true

--- a/charts/wordpress/samples/verify/uninstall.sh
+++ b/charts/wordpress/samples/verify/uninstall.sh
@@ -9,6 +9,12 @@ helm uninstall wordpress-verify || true
 echo "==> Waiting for PVC deletion..."
 kubectl wait --for=delete pvc/wordpress-verify --timeout=60s 2>/dev/null || true
 
+echo "==> Deleting StatefulSet PVCs (not tracked by Helm)..."
+kubectl delete pvc \
+  data-wordpress-verify-mariadb-0 \
+  data-wordpress-verify-valkey-0 \
+  --ignore-not-found
+
 echo "==> Deleting ConfigMap..."
 kubectl delete -f "${SCRIPT_DIR}/cm.yaml" --ignore-not-found
 

--- a/charts/wordpress/samples/verify/values.yaml
+++ b/charts/wordpress/samples/verify/values.yaml
@@ -57,6 +57,17 @@ wordpress:
     name: "wordpress-verify-secret"
   htaccessConfigMap: "wordpress-verify-config"
   url: "http://192.168.178.21:30911"
+  smtp:
+    enabled: true
+    host: smtp.gmail.com
+    port: 587
+    encryption: tls
+    fromName: "Wordpress Verify"
+    auth: true
+    existingSecret: wordpress-verify-secret
+    existingSecretPasswordKey: smtp.password
+    existingSecretUsernameKey: smtp.username
+    existingSecretFromEmailKey: smtp.fromEmail
 service:
   nodePorts:
     http: 30911

--- a/charts/wordpress/samples/verify/values.yaml
+++ b/charts/wordpress/samples/verify/values.yaml
@@ -68,37 +68,11 @@ wordpress:
     existingSecretPasswordKey: smtp.password
     existingSecretUsernameKey: smtp.username
     existingSecretFromEmailKey: smtp.fromEmail
-networkPolicy:
-  enabled: true
-  allowExternalEgress: true
-ingress:
-  secondary:
-    - name: verify-secondary
-      enabled: true
-      className: ""
-      annotations:
-        nginx.ingress.kubernetes.io/rewrite-target: /
-      hosts:
-        - host: verify-secondary.local
-          paths:
-            - path: /
-              pathType: Prefix
 service:
   nodePorts:
     http: 30911
 storage:
   resourcePolicy: "" # Delete PVC on helm uninstall
-backup:
-  enabled: true
-  schedule: "0 3 * * *"
-  persistence:
-    size: 5Gi
-  s3:
-    enabled: true
-    existingSecret: "wordpress-verify-rclone"
-    remote: "garage"
-    bucket: "wordpress-verify-backup"
-    path: "verify"
 apache:
   customPhpConfigMap: "wordpress-verify-config"
 metrics:

--- a/charts/wordpress/samples/verify/values.yaml
+++ b/charts/wordpress/samples/verify/values.yaml
@@ -116,9 +116,6 @@ mariadb:
     database: "wordpress_db"
     username: "wordpress_db_user"
     existingSecret: "wordpress-verify-secret"
-  persistence:
-    annotations:
-      helm.sh/resource-policy: "" # Delete PVC on helm uninstall
 valkey:
   enabled: true
   createConfig: true

--- a/charts/wordpress/samples/verify/values.yaml
+++ b/charts/wordpress/samples/verify/values.yaml
@@ -68,11 +68,37 @@ wordpress:
     existingSecretPasswordKey: smtp.password
     existingSecretUsernameKey: smtp.username
     existingSecretFromEmailKey: smtp.fromEmail
+networkPolicy:
+  enabled: true
+  allowExternalEgress: true
+ingress:
+  secondary:
+    - name: verify-secondary
+      enabled: true
+      className: ""
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+      hosts:
+        - host: verify-secondary.local
+          paths:
+            - path: /
+              pathType: Prefix
 service:
   nodePorts:
     http: 30911
 storage:
   resourcePolicy: "" # Delete PVC on helm uninstall
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  persistence:
+    size: 5Gi
+  s3:
+    enabled: true
+    existingSecret: "wordpress-verify-rclone"
+    remote: "garage"
+    bucket: "wordpress-verify-backup"
+    path: "verify"
 apache:
   customPhpConfigMap: "wordpress-verify-config"
 metrics:

--- a/charts/wordpress/samples/verify/verify.sh
+++ b/charts/wordpress/samples/verify/verify.sh
@@ -128,9 +128,45 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
-# ── 10. WordPress metrics endpoint ────────────────────────────────────────────
+# ── 10. NetworkPolicy smoke test ──────────────────────────────────────────────
 bold ""
-bold "==> Step 10: WordPress metrics endpoint"
+bold "==> Step 10: NetworkPolicy smoke test"
+NP_NAME="${RELEASE}"
+NP_SELECTOR=$(kubectl get networkpolicy "${NP_NAME}" -n default \
+  -o jsonpath='{.spec.podSelector.matchLabels}' 2>/dev/null || true)
+if [[ -n "${NP_SELECTOR}" ]]; then
+  green "  [OK] NetworkPolicy '${NP_NAME}' exists (podSelector: ${NP_SELECTOR})"
+else
+  red "  [FAIL] NetworkPolicy '${NP_NAME}' not found in default namespace"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── 11. Secondary Ingress smoke test ──────────────────────────────────────────
+bold ""
+bold "==> Step 11: Secondary Ingress smoke test"
+INGRESS_COUNT=$(kubectl get ingress -n default \
+  -l "app.kubernetes.io/instance=${RELEASE}" \
+  --no-headers 2>/dev/null | wc -l | tr -d ' ')
+if [[ "${INGRESS_COUNT}" -ge 1 ]]; then
+  green "  [OK] Found ${INGRESS_COUNT} Ingress object(s) for release '${RELEASE}'"
+  kubectl get ingress -n default -l "app.kubernetes.io/instance=${RELEASE}" \
+    --no-headers 2>/dev/null | awk '{print "    -", $1}'
+else
+  echo "  [SKIP] No Ingress controller in this environment — object-existence check only"
+  # Check the secondary ingress object exists as a K8s resource
+  SEC_INGRESS=$(kubectl get ingress "${RELEASE}-verify-secondary" -n default \
+    --no-headers 2>/dev/null | wc -l | tr -d ' ')
+  if [[ "${SEC_INGRESS}" -ge 1 ]]; then
+    green "  [OK] Secondary Ingress object '${RELEASE}-verify-secondary' exists"
+  else
+    red "  [FAIL] Secondary Ingress object '${RELEASE}-verify-secondary' not found"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+# ── 12. WordPress metrics endpoint ────────────────────────────────────────────
+bold ""
+bold "==> Step 12: WordPress metrics endpoint"
 # Uses /slymetrics/metrics (Apache rewrite path served by the slymetrics plugin)
 METRICS_CODE=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 \
   -H "Authorization: Bearer f5634d6a966856848e2f3f4a139e534b844805f7561d86642adb19060719e95d" \
@@ -139,6 +175,25 @@ if [[ "${METRICS_CODE}" =~ ^(200|401)$ ]]; then
   green "  [OK] Metrics endpoint reachable (HTTP ${METRICS_CODE})"
 else
   red "  [WARN] Metrics endpoint returned HTTP ${METRICS_CODE}"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── 13. Backup CronJob smoke test ─────────────────────────────────────────────
+bold ""
+bold "==> Step 13: Backup CronJob smoke test"
+CRONJOB_NAME="${RELEASE}-backup"
+if kubectl get cronjob "${CRONJOB_NAME}" -n default --no-headers 2>/dev/null | grep -q "${CRONJOB_NAME}"; then
+  green "  [OK] CronJob '${CRONJOB_NAME}' exists"
+  # Check backup PVC
+  PVC_NAME="${RELEASE}-backup"
+  if kubectl get pvc "${PVC_NAME}" -n default --no-headers 2>/dev/null | grep -q "${PVC_NAME}"; then
+    green "  [OK] Backup PVC '${PVC_NAME}' exists"
+  else
+    red "  [FAIL] Backup PVC '${PVC_NAME}' not found"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  red "  [FAIL] CronJob '${CRONJOB_NAME}' not found"
   ERRORS=$((ERRORS + 1))
 fi
 

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: "{{ include "wordpress.chart" . }}"
 app.kubernetes.io/version: "{{ .Chart.AppVersion }}"
 {{- end }}
 app.kubernetes.io/managed-by: "{{ .Release.Service }}"
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/wordpress/templates/backup-cronjob.yaml
+++ b/charts/wordpress/templates/backup-cronjob.yaml
@@ -54,10 +54,13 @@ spec:
                     secretKeyRef:
                       {{- if .Values.mariadb.enabled }}
                       name: {{ .Values.mariadb.auth.existingSecret | default (printf "%s-mariadb" .Release.Name) }}
-                      key: mariadb-password
+                      key: {{ .Values.mariadb.auth.secretKeys.userPasswordKey | default "mariadb-password" }}
+                      {{- else if .Values.externalDatabase.existingSecret }}
+                      name: {{ .Values.externalDatabase.existingSecret }}
+                      key: {{ .Values.externalDatabase.secretKeys.userPasswordKey | default "db.password" }}
                       {{- else }}
-                      name: {{ .Values.externalDatabase.existingSecret | default $fullName }}
-                      key: mariadb-password
+                      name: {{ $fullName }}
+                      key: WORDPRESS_DB_PASSWORD
                       {{- end }}
                 - name: RETENTION_DAYS
                   value: {{ .Values.backup.retentionDays | quote }}
@@ -134,7 +137,14 @@ spec:
                 - |
                   set -e
                   echo "==> waiting for backup to complete..."
-                  until [ -f /backup/.backup_complete ]; do sleep 5; done
+                  DEADLINE=$(( $(date +%s) + 3600 ))
+                  until [ -f /backup/.backup_complete ]; do
+                    sleep 5
+                    if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+                      echo "==> timeout: backup did not complete within 1h" >&2
+                      exit 1
+                    fi
+                  done
                   TS=$(cat /backup/.backup_complete)
                   echo "==> syncing $TS to ${S3_REMOTE}:${S3_BUCKET}/${S3_PATH}/${TS}/"
                   rclone copy "/backup/${TS}" "${S3_REMOTE}:${S3_BUCKET}/${S3_PATH}/${TS}/" --transfers=2
@@ -163,7 +173,7 @@ spec:
             {{- if .Values.backup.s3.enabled }}
             - name: rclone-config
               secret:
-                secretName: {{ .Values.backup.s3.existingSecret }}
+                secretName: {{ required "backup.s3.existingSecret is required when backup.s3.enabled=true" .Values.backup.s3.existingSecret }}
             {{- end }}
 ---
 {{- if and (not .Values.backup.persistence.existingClaim) .Values.backup.persistence.enabled }}

--- a/charts/wordpress/templates/backup-cronjob.yaml
+++ b/charts/wordpress/templates/backup-cronjob.yaml
@@ -1,0 +1,180 @@
+{{- if .Values.backup.enabled }}
+{{- $fullName := include "wordpress.fullname" . -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $fullName }}-backup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: {{ .Values.backup.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.backup.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: {{ .Values.backup.backoffLimit }}
+      template:
+        metadata:
+          labels:
+            {{- include "wordpress.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
+          {{- with .Values.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: backup
+              image: {{ include "slycharts.image" (dict "image" .Values.backup.image) }}
+              imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+              {{- with .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              env:
+                - name: DB_HOST
+                  value: {{ ternary (include "wordpress.mariadb.fullname" .) .Values.externalDatabase.host .Values.mariadb.enabled | quote }}
+                - name: DB_PORT
+                  value: {{ ternary (.Values.mariadb.service.port | toString) (.Values.externalDatabase.port | toString) .Values.mariadb.enabled | quote }}
+                - name: DB_NAME
+                  value: {{ ternary .Values.mariadb.auth.database .Values.externalDatabase.database .Values.mariadb.enabled | quote }}
+                - name: DB_USER
+                  value: {{ ternary .Values.mariadb.auth.username .Values.externalDatabase.username .Values.mariadb.enabled | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      {{- if .Values.mariadb.enabled }}
+                      name: {{ .Values.mariadb.auth.existingSecret | default (printf "%s-mariadb" .Release.Name) }}
+                      key: mariadb-password
+                      {{- else }}
+                      name: {{ .Values.externalDatabase.existingSecret | default $fullName }}
+                      key: mariadb-password
+                      {{- end }}
+                - name: RETENTION_DAYS
+                  value: {{ .Values.backup.retentionDays | quote }}
+                {{- if .Values.backup.s3.enabled }}
+                - name: S3_ENABLED
+                  value: "1"
+                - name: S3_REMOTE
+                  value: {{ .Values.backup.s3.remote | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PATH
+                  value: {{ .Values.backup.s3.path | quote }}
+                {{- end }}
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -euo pipefail
+                  TS=$(date +%Y%m%d-%H%M%S)
+                  OUT=/backup/${TS}
+                  mkdir -p "$OUT"
+                  echo "==> mysqldump"
+                  mariadb-dump \
+                    -h "$DB_HOST" -P "$DB_PORT" \
+                    -u "$DB_USER" -p"$DB_PASSWORD" \
+                    --single-transaction --quick --routines --triggers \
+                    "$DB_NAME" | gzip > "$OUT/${DB_NAME}.sql.gz"
+                  echo "==> tar wp-content"
+                  tar -czf "$OUT/wp-content.tar.gz" -C /var/www/html/wp-content .
+                  echo "==> prune older than ${RETENTION_DAYS}d"
+                  find /backup -maxdepth 1 -mindepth 1 -type d -mtime +${RETENTION_DAYS} -exec rm -rf {} +
+                  echo "==> done: $OUT"
+                  ls -lh "$OUT"
+                  # Signal s3-sync container if S3 is enabled
+                  if [ "${S3_ENABLED:-0}" = "1" ]; then
+                    echo "$TS" > /backup/.backup_complete
+                  fi
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+                - name: wordpress
+                  mountPath: /var/www/html
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+              {{- with .Values.backup.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+            {{- if .Values.backup.s3.enabled }}
+            - name: s3-sync
+              image: {{ .Values.backup.s3.image.repository }}:{{ .Values.backup.s3.image.tag }}
+              imagePullPolicy: {{ .Values.backup.s3.image.pullPolicy | default "IfNotPresent" }}
+              env:
+                - name: RCLONE_CONFIG
+                  value: /config/rclone.conf
+                - name: S3_REMOTE
+                  value: {{ .Values.backup.s3.remote | quote }}
+                - name: S3_BUCKET
+                  value: {{ .Values.backup.s3.bucket | quote }}
+                - name: S3_PATH
+                  value: {{ .Values.backup.s3.path | quote }}
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  echo "==> waiting for backup to complete..."
+                  until [ -f /backup/.backup_complete ]; do sleep 5; done
+                  TS=$(cat /backup/.backup_complete)
+                  echo "==> syncing $TS to ${S3_REMOTE}:${S3_BUCKET}/${S3_PATH}/${TS}/"
+                  rclone copy "/backup/${TS}" "${S3_REMOTE}:${S3_BUCKET}/${S3_PATH}/${TS}/" --transfers=2
+                  rm -f /backup/.backup_complete
+                  echo "==> S3 sync complete"
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+                - name: rclone-config
+                  mountPath: /config
+                  readOnly: true
+            {{- end }}
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: {{ .Values.backup.persistence.existingClaim | default (printf "%s-backup" $fullName) }}
+            - name: wordpress
+              persistentVolumeClaim:
+                claimName: {{ .Values.storage.existingClaim | default $fullName }}
+            - name: tmp
+              emptyDir: {}
+            {{- if .Values.backup.s3.enabled }}
+            - name: rclone-config
+              secret:
+                secretName: {{ .Values.backup.s3.existingSecret }}
+            {{- end }}
+---
+{{- if and (not .Values.backup.persistence.existingClaim) .Values.backup.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ $fullName }}-backup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.backup.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.persistence.size }}
+  {{- with .Values.backup.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/wordpress/templates/backup-cronjob.yaml
+++ b/charts/wordpress/templates/backup-cronjob.yaml
@@ -85,8 +85,10 @@ spec:
                     -u "$DB_USER" -p"$DB_PASSWORD" \
                     --single-transaction --quick --routines --triggers \
                     "$DB_NAME" | gzip > "$OUT/${DB_NAME}.sql.gz"
+                  {{- if .Values.backup.includeFiles }}
                   echo "==> tar wp-content"
                   tar -czf "$OUT/wp-content.tar.gz" -C /var/www/html/wp-content .
+                  {{- end }}
                   echo "==> prune older than ${RETENTION_DAYS}d"
                   find /backup -maxdepth 1 -mindepth 1 -type d -mtime +${RETENTION_DAYS} -exec rm -rf {} +
                   echo "==> done: $OUT"
@@ -98,9 +100,11 @@ spec:
               volumeMounts:
                 - name: backup
                   mountPath: /backup
+                {{- if .Values.backup.includeFiles }}
                 - name: wordpress
                   mountPath: /var/www/html
                   readOnly: true
+                {{- end }}
                 - name: tmp
                   mountPath: /tmp
               {{- with .Values.backup.resources }}
@@ -111,6 +115,10 @@ spec:
             - name: s3-sync
               image: {{ .Values.backup.s3.image.repository }}:{{ .Values.backup.s3.image.tag }}
               imagePullPolicy: {{ .Values.backup.s3.image.pullPolicy | default "IfNotPresent" }}
+              {{- with .Values.containerSecurityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               env:
                 - name: RCLONE_CONFIG
                   value: /config/rclone.conf
@@ -138,14 +146,18 @@ spec:
                 - name: rclone-config
                   mountPath: /config
                   readOnly: true
+                - name: tmp
+                  mountPath: /tmp
             {{- end }}
           volumes:
             - name: backup
               persistentVolumeClaim:
                 claimName: {{ .Values.backup.persistence.existingClaim | default (printf "%s-backup" $fullName) }}
+            {{- if .Values.backup.includeFiles }}
             - name: wordpress
               persistentVolumeClaim:
                 claimName: {{ .Values.storage.existingClaim | default $fullName }}
+            {{- end }}
             - name: tmp
               emptyDir: {}
             {{- if .Values.backup.s3.enabled }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -722,11 +722,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.wordpress.smtp.existingSecret }}
                   key: {{ .Values.wordpress.smtp.existingSecretPasswordKey }}
-              {{- else }}
+              {{- else if .Values.wordpress.smtp.password }}
               valueFrom:
                 secretKeyRef:
                   name: {{ include "wordpress.fullname" . }}
                   key: WP_SMTP_PASSWORD
+              {{- else }}
+              value: ""
               {{- end }}
           {{- end }}
           envFrom:

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -8,7 +8,8 @@ metadata:
     {{- with .Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.customAnnotations }}
+  {{- $depAnnotations := merge (dict) (.Values.customAnnotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $depAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -127,6 +128,9 @@ spec:
         {{- end }}
         {{- if gt (len $muChecks) 0 }}
         checksum/wordpress-muPlugins-combined: {{ include "wordpress.checksum.combine" (list $muChecks) }}
+        {{- end }}
+        {{- if .Values.wordpress.smtp.enabled }}
+        checksum/smtp-config: {{ toJson .Values.wordpress.smtp | sha256sum }}
         {{- end }}
 
         {{- /* combined configmaps checksum */}}
@@ -683,6 +687,34 @@ spec:
                   key: {{ .Values.wordpress.configExtraSecret.key | default "wordpress.configExtra" }}
           {{- end }}
           {{- end }}
+          {{- if .Values.wordpress.smtp.enabled }}
+            - name: WP_SMTP_HOST
+              value: {{ .Values.wordpress.smtp.host | quote }}
+            - name: WP_SMTP_PORT
+              value: {{ .Values.wordpress.smtp.port | quote }}
+            - name: WP_SMTP_ENCRYPTION
+              value: {{ .Values.wordpress.smtp.encryption | quote }}
+            - name: WP_SMTP_AUTH
+              value: {{ .Values.wordpress.smtp.auth | quote }}
+            - name: WP_SMTP_USERNAME
+              value: {{ .Values.wordpress.smtp.username | quote }}
+            - name: WP_SMTP_FROM_EMAIL
+              value: {{ .Values.wordpress.smtp.fromEmail | quote }}
+            - name: WP_SMTP_FROM_NAME
+              value: {{ .Values.wordpress.smtp.fromName | quote }}
+            - name: WP_SMTP_PASSWORD
+              {{- if .Values.wordpress.smtp.existingSecret }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.wordpress.smtp.existingSecret }}
+                  key: {{ .Values.wordpress.smtp.existingSecretPasswordKey }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "wordpress.fullname" . }}
+                  key: WP_SMTP_PASSWORD
+              {{- end }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ include "wordpress.fullname" . }}
@@ -765,6 +797,12 @@ spec:
             {{- end }}
             {{- if .Values.extraVolumeMounts }}
             {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+            {{- if .Values.wordpress.smtp.enabled }}
+            - name: smtp-mu-plugin
+              mountPath: /var/www/html/wp-content/mu-plugins/smtp-override.php
+              subPath: smtp-override.php
+              readOnly: true
             {{- end }}
             - name: {{ include "wordpress.fullname" . }}-configfiles
               mountPath: /etc/apache2/sites-enabled/000-default.conf
@@ -943,6 +981,12 @@ spec:
       - name: mu-plugins-{{ .name }}
         configMap:
           name: {{ .name }}
+          defaultMode: 0644
+      {{- end }}
+      {{- if .Values.wordpress.smtp.enabled }}
+      - name: smtp-mu-plugin
+        configMap:
+          name: {{ include "wordpress.fullname" . }}-smtp-mu-plugin
           defaultMode: 0644
       {{- end }}
       {{- if .Values.extraVolumes }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -404,12 +404,17 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
-            {{- if and .Values.wordpress.init.jwt.enabled .Values.wordpress.init.jwt.existingSecret }}
+            {{- if .Values.wordpress.init.jwt.enabled }}
             - name: JWT_AUTH_SECRET_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.wordpress.init.jwt.existingSecret }}
                   name: {{ .Values.wordpress.init.jwt.existingSecret }}
                   key: {{ .Values.wordpress.init.jwt.secretKey | default "JWT_AUTH_SECRET_KEY" }}
+                  {{- else }}
+                  name: {{ include "wordpress.fullname" . }}-jwt
+                  key: JWT_AUTH_SECRET_KEY
+                  {{- end }}
             {{- end }}
           {{- if and .Values.wordpress.configExtraConfigMap.name (not .Values.wordpress.configExtraSecret.name) }}
           {{- if .Values.wordpress.configExtraInject }}
@@ -634,12 +639,17 @@ spec:
                   name: {{ include "metrics.wordpress.fullname" . }}
                   key: wordpress.metrics.encryptionKey
           {{- end }}
-          {{- if and .Values.wordpress.init.jwt.enabled .Values.wordpress.init.jwt.existingSecret }}
+          {{- if .Values.wordpress.init.jwt.enabled }}
             - name: JWT_AUTH_SECRET_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.wordpress.init.jwt.existingSecret }}
                   name: {{ .Values.wordpress.init.jwt.existingSecret }}
+                  key: {{ .Values.wordpress.init.jwt.secretKey | default "JWT_AUTH_SECRET_KEY" }}
+                  {{- else }}
+                  name: {{ include "wordpress.fullname" . }}-jwt
                   key: JWT_AUTH_SECRET_KEY
+                  {{- end }}
           {{- end }}
           {{- if and .Values.wordpress.configExtraConfigMap.name (not .Values.wordpress.configExtraSecret.name) }}
           {{- if .Values.wordpress.configExtraInject }}

--- a/charts/wordpress/templates/deployment.yaml
+++ b/charts/wordpress/templates/deployment.yaml
@@ -697,9 +697,23 @@ spec:
             - name: WP_SMTP_AUTH
               value: {{ .Values.wordpress.smtp.auth | quote }}
             - name: WP_SMTP_USERNAME
+              {{- if and .Values.wordpress.smtp.existingSecret .Values.wordpress.smtp.existingSecretUsernameKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.wordpress.smtp.existingSecret }}
+                  key: {{ .Values.wordpress.smtp.existingSecretUsernameKey }}
+              {{- else }}
               value: {{ .Values.wordpress.smtp.username | quote }}
+              {{- end }}
             - name: WP_SMTP_FROM_EMAIL
+              {{- if and .Values.wordpress.smtp.existingSecret .Values.wordpress.smtp.existingSecretFromEmailKey }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.wordpress.smtp.existingSecret }}
+                  key: {{ .Values.wordpress.smtp.existingSecretFromEmailKey }}
+              {{- else }}
               value: {{ .Values.wordpress.smtp.fromEmail | quote }}
+              {{- end }}
             - name: WP_SMTP_FROM_NAME
               value: {{ .Values.wordpress.smtp.fromName | quote }}
             - name: WP_SMTP_PASSWORD

--- a/charts/wordpress/templates/hpa.yaml
+++ b/charts/wordpress/templates/hpa.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "wordpress.fullname" . }}
   labels:
     {{- include "wordpress.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/wordpress/templates/ingress.yaml
+++ b/charts/wordpress/templates/ingress.yaml
@@ -45,7 +45,6 @@ spec:
     {{- with .Values.ingress.extraRules }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- end }}
 {{- range $idx, $sec := .Values.ingress.secondary }}
 {{- if $sec.enabled }}
 ---
@@ -96,5 +95,6 @@ spec:
     {{- with $sec.extraRules }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/wordpress/templates/ingress.yaml
+++ b/charts/wordpress/templates/ingress.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wordpress.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- $ingressAnnotations := merge (dict) (.Values.ingress.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $ingressAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -44,4 +45,56 @@ spec:
     {{- with .Values.ingress.extraRules }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}
+{{- range $idx, $sec := .Values.ingress.secondary }}
+{{- if $sec.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "wordpress.fullname" $ }}-{{ $sec.name | default (printf "secondary-%d" $idx) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: ingress-{{ $sec.name | default (printf "secondary-%d" $idx) }}
+  {{- $secAnnotations := merge (dict) ($sec.annotations | default dict) ($.Values.commonAnnotations | default dict) }}
+  {{- with $secAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $sec.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $sec.tls }}
+  tls:
+    {{- range . }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $sec.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "wordpress.fullname" $ }}
+                port:
+                  number: {{ if $sec.useHttpsBackend }}{{ $.Values.service.ports.https }}{{ else }}{{ $.Values.service.ports.http }}{{ end }}
+          {{- end }}
+    {{- end }}
+    {{- with $sec.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/wordpress/templates/networkpolicy.yaml
+++ b/charts/wordpress/templates/networkpolicy.yaml
@@ -25,7 +25,7 @@ spec:
         - port: {{ .Values.containerPorts.http }}
           protocol: TCP
         {{- if .Values.metrics.apache.enabled }}
-        - port: 9117
+        - port: {{ .Values.metrics.apache.service.ports.metrics }}
           protocol: TCP
         {{- end }}
       {{- with .Values.networkPolicy.ingress.from }}
@@ -38,10 +38,9 @@ spec:
   egress:
     # DNS
     - to:
-        - namespaceSelector: {}
-          podSelector:
+        - namespaceSelector:
             matchLabels:
-              k8s-app: kube-dns
+              kubernetes.io/metadata.name: kube-system
       ports:
         - port: 53
           protocol: UDP

--- a/charts/wordpress/templates/networkpolicy.yaml
+++ b/charts/wordpress/templates/networkpolicy.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.networkPolicy.enabled }}
+{{- $fullName := include "wordpress.fullname" . -}}
+{{- $cacheBackends := (include "wordpress.cache.backends" . | fromYaml) -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+  {{- $npAnnotations := merge (dict) (.Values.networkPolicy.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $npAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wordpress.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: {{ .Values.containerPorts.http }}
+          protocol: TCP
+        {{- if .Values.metrics.apache.enabled }}
+        - port: 9117
+          protocol: TCP
+        {{- end }}
+      {{- with .Values.networkPolicy.ingress.from }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.networkPolicy.ingress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    # Database
+    {{- if .Values.mariadb.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: mariadb
+      ports:
+        - port: {{ .Values.mariadb.service.port | default 3306 }}
+          protocol: TCP
+    {{- else if .Values.externalDatabase.host }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16
+      ports:
+        - port: {{ .Values.externalDatabase.port | default 3306 }}
+          protocol: TCP
+    {{- end }}
+    # Cache backend
+    {{- if eq $cacheBackends.selected "memcached" }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: memcached
+      ports:
+        - port: 11211
+          protocol: TCP
+    {{- else if or (eq $cacheBackends.selected "redis") (eq $cacheBackends.selected "valkey") }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/name: {{ $cacheBackends.selected }}
+      ports:
+        - port: 6379
+          protocol: TCP
+    {{- end }}
+    # Internet egress (wp-cli downloads, SMTP)
+    {{- if .Values.networkPolicy.allowExternalEgress }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+      ports:
+        - port: 80
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+        {{- range .Values.networkPolicy.smtpPorts }}
+        - port: {{ . }}
+          protocol: TCP
+        {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/wordpress/templates/pdp.yaml
+++ b/charts/wordpress/templates/pdp.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ include "wordpress.fullname" . }}
   labels:
     {{- include "wordpress.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.podDisruptionBudget.minAvailable }}
   minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}

--- a/charts/wordpress/templates/prometheusrule.yaml
+++ b/charts/wordpress/templates/prometheusrule.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.metrics.prometheusRule.enabled (or .Values.metrics.apache.enabled .Values.metrics.wordpress.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "wordpress.fullname" . }}
+  namespace: {{ .Values.metrics.prometheusRule.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    {{- with .Values.metrics.prometheusRule.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- $prAnnotations := merge (dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $prAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  groups:
+    - name: {{ include "wordpress.fullname" . }}.rules
+      rules:
+        {{- if .Values.metrics.prometheusRule.defaultRules.podDown }}
+        - alert: WordPressPodDown
+          annotations:
+            summary: "WordPress pod {{`{{ $labels.pod }}`}} is down"
+            description: "Pod has been unavailable for more than 5m."
+          expr: |
+            kube_pod_status_ready{condition="true",namespace="{{ .Release.Namespace }}",pod=~"{{ include "wordpress.fullname" . }}-.*"} == 0
+          for: 5m
+          labels:
+            severity: critical
+        {{- end }}
+        {{- if and .Values.metrics.apache.enabled .Values.metrics.prometheusRule.defaultRules.apacheScrapeFailing }}
+        - alert: WordPressApacheExporterScrapeFailing
+          annotations:
+            summary: "Apache exporter scrape failing for {{`{{ $labels.instance }}`}}"
+          expr: |
+            up{job=~".*{{ include "metrics.apache.fullname" . }}.*"} == 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: WordPressApacheHighBusyWorkers
+          annotations:
+            summary: "Apache workers >= 90% busy"
+          expr: |
+            (apache_workers{state="busy"} / apache_scoreboard_total) > 0.9
+          for: 10m
+          labels:
+            severity: warning
+        {{- end }}
+        {{- with .Values.metrics.prometheusRule.extraRules }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+{{- end }}

--- a/charts/wordpress/templates/prometheusrule.yaml
+++ b/charts/wordpress/templates/prometheusrule.yaml
@@ -42,7 +42,7 @@ spec:
           annotations:
             summary: "Apache workers >= 90% busy"
           expr: |
-            (apache_workers{state="busy"} / apache_scoreboard_total) > 0.9
+            (apache_workers{state="busy",job=~".*{{ include "metrics.apache.fullname" . }}.*"} / apache_scoreboard_total{job=~".*{{ include "metrics.apache.fullname" . }}.*"}) > 0.9
           for: 10m
           labels:
             severity: warning

--- a/charts/wordpress/templates/pvc.yaml
+++ b/charts/wordpress/templates/pvc.yaml
@@ -8,16 +8,12 @@ metadata:
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- $ann := .Values.storage.annotations }}
+  {{- $pvcAnnotations := merge (dict) (.Values.storage.annotations | default dict) (.Values.commonAnnotations | default dict) }}
   {{- $rp := .Values.storage.resourcePolicy }}
-  {{- if or $ann $rp }}
+  {{- if $rp }}{{- $_ := set $pvcAnnotations "helm.sh/resource-policy" $rp }}{{- end }}
+  {{- with $pvcAnnotations }}
   annotations:
-    {{- if $ann }}
-    {{- toYaml $ann | nindent 4 }}
-    {{- end }}
-    {{- if $rp }}
-    helm.sh/resource-policy: {{ $rp | quote }}
-    {{- end }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   accessModes:

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -7,9 +7,9 @@
     {{- $jwtKey = .Values.wordpress.init.jwt.secret }}
   {{- else }}
     {{/* Preserve existing key across helm upgrades via lookup */}}
-    {{- $existingMainSecret := lookup "v1" "Secret" .Release.Namespace (include "wordpress.fullname" .) }}
-    {{- if and $existingMainSecret (hasKey $existingMainSecret.data "JWT_AUTH_SECRET_KEY") }}
-      {{- $jwtKey = index $existingMainSecret.data "JWT_AUTH_SECRET_KEY" | b64dec }}
+    {{- $existingJwtSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-jwt" (include "wordpress.fullname" .)) }}
+    {{- if and $existingJwtSecret (hasKey $existingJwtSecret.data "JWT_AUTH_SECRET_KEY") }}
+      {{- $jwtKey = index $existingJwtSecret.data "JWT_AUTH_SECRET_KEY" | b64dec }}
     {{- else }}
       {{- $jwtKey = randAlphaNum 32 }}
     {{- end }}
@@ -26,9 +26,6 @@ metadata:
 type: Opaque
 data:
   WORDPRESS_TABLE_PREFIX: {{ .Values.wordpress.tablePrefix | b64enc }}
-  {{- if and .Values.wordpress.init.jwt.enabled (not .Values.wordpress.init.jwt.existingSecret) }}
-  JWT_AUTH_SECRET_KEY: {{ $jwtKey | b64enc }}
-  {{- end }}
   {{- if .Values.wordpress.configExtraInject }}
   {{/* Build inject string: WP_HOME, WP_SITEURL, memcached config */}}
   {{- $inject := "" }}
@@ -167,6 +164,19 @@ data:
   {{- end }}
 {{- if and .Values.wordpress.smtp.enabled (not .Values.wordpress.smtp.existingSecret) .Values.wordpress.smtp.password }}
   WP_SMTP_PASSWORD: {{ .Values.wordpress.smtp.password | b64enc }}
+{{- end }}
+{{- if and .Values.wordpress.init.jwt.enabled (not .Values.wordpress.init.jwt.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "wordpress.fullname" . }}-jwt
+  namespace: {{ .Release.Namespace }}
+  labels:
+    release: {{ include "wordpress.fullname" . }}
+type: Opaque
+data:
+  JWT_AUTH_SECRET_KEY: {{ $jwtKey | b64enc }}
 {{- end }}
 {{- if and .Values.wordpress.init.enabled (empty .Values.wordpress.init.existingSecret) }}
 ---

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -165,6 +165,9 @@ data:
   {{- end }}
   {{- end }}
   {{- end }}
+{{- if and .Values.wordpress.smtp.enabled (not .Values.wordpress.smtp.existingSecret) .Values.wordpress.smtp.password }}
+  WP_SMTP_PASSWORD: {{ .Values.wordpress.smtp.password | b64enc }}
+{{- end }}
 {{- if and .Values.wordpress.init.enabled (empty .Values.wordpress.init.existingSecret) }}
 ---
 apiVersion: v1

--- a/charts/wordpress/templates/service.yaml
+++ b/charts/wordpress/templates/service.yaml
@@ -57,10 +57,10 @@ spec:
   type: {{ .Values.metrics.apache.service.type }}
   ports:
     - port: {{ .Values.metrics.apache.service.ports.metrics }}
-      targetPort: 9117
+      targetPort: {{ .Values.metrics.apache.service.ports.metrics }}
       protocol: TCP
       name: metrics
-      {{- if eq .Values.metrics.apache.service.type "NodePort" }}
+      {{- if and (eq .Values.metrics.apache.service.type "NodePort") .Values.metrics.apache.service.nodePorts.metrics }}
       nodePort: {{ .Values.metrics.apache.service.nodePorts.metrics }}
       {{- end }}
   {{- if .Values.metrics.apache.service.clusterIP }}

--- a/charts/wordpress/templates/service.yaml
+++ b/charts/wordpress/templates/service.yaml
@@ -9,7 +9,8 @@ metadata:
     {{- with .Values.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.service.annotations }}
+  {{- $svcAnnotations := merge (dict) (.Values.service.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $svcAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -47,7 +48,8 @@ metadata:
     {{- with .Values.metrics.apache.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.metrics.apache.service.annotations }}
+  {{- $apacheSvcAnnotations := merge (dict) (.Values.metrics.apache.service.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $apacheSvcAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wordpress/templates/serviceaccount.yaml
+++ b/charts/wordpress/templates/serviceaccount.yaml
@@ -5,7 +5,8 @@ metadata:
   name: {{ include "wordpress.serviceAccountName" . }}
   labels:
     {{- include "wordpress.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $saAnnotations := merge (dict) (.Values.serviceAccount.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $saAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wordpress/templates/servicemonitor.yaml
+++ b/charts/wordpress/templates/servicemonitor.yaml
@@ -5,14 +5,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "metrics.wordpress.fullname" . }}
   namespace: {{ .Release.Namespace }}
-{{ with .Values.metrics.wordpress.serviceMonitor.labels }}
+  {{- with .Values.metrics.wordpress.serviceMonitor.labels }}
   labels:
-  {{ toYaml | nindent 4 }}
-{{ end }}
-{{ if .Values.metrics.wordpress.serviceMonitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $smAnnotations := merge (dict) (.Values.metrics.wordpress.serviceMonitor.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $smAnnotations }}
   annotations:
-{{ toYaml .Values.metrics.wordpress.serviceMonitor.annotations | nindent 4 }}
-{{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   namespaceSelector:
     matchNames:
@@ -46,14 +47,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "metrics.apache.fullname" . }}
   namespace: {{ if .Values.metrics.apache.serviceMonitor.namespace }}{{ .Values.metrics.apache.serviceMonitor.namespace }}{{ else }}{{ .Release.Namespace }}{{ end }}
-{{ with .Values.metrics.apache.serviceMonitor.labels }}
+  {{- with .Values.metrics.apache.serviceMonitor.labels }}
   labels:
-  {{ toYaml | nindent 4 }}
-{{ end }}
-{{ if .Values.metrics.apache.serviceMonitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- $apacheSmAnnotations := merge (dict) (.Values.metrics.apache.serviceMonitor.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $apacheSmAnnotations }}
   annotations:
-{{ toYaml .Values.metrics.apache.serviceMonitor.annotations | nindent 4 }}
-{{ end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/wordpress/templates/smtp-configmap.yaml
+++ b/charts/wordpress/templates/smtp-configmap.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.wordpress.smtp.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wordpress.fullname" . }}-smtp-mu-plugin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  smtp-override.php: |
+    <?php
+    /**
+     * Plugin Name: K8s SMTP Override
+     * Description: Forces SMTP settings from environment variables (managed by Helm).
+     */
+    add_action('phpmailer_init', function ($phpmailer) {
+        $host = getenv('WP_SMTP_HOST');
+        if (!$host) { return; }
+        $phpmailer->isSMTP();
+        $phpmailer->Host       = $host;
+        $phpmailer->Port       = (int) getenv('WP_SMTP_PORT') ?: 587;
+        $phpmailer->SMTPSecure = getenv('WP_SMTP_ENCRYPTION') ?: '';
+        $phpmailer->SMTPAuth   = filter_var(getenv('WP_SMTP_AUTH'), FILTER_VALIDATE_BOOLEAN);
+        if ($phpmailer->SMTPAuth) {
+            $phpmailer->Username = getenv('WP_SMTP_USERNAME');
+            $phpmailer->Password = getenv('WP_SMTP_PASSWORD');
+        }
+        $from = getenv('WP_SMTP_FROM_EMAIL');
+        if ($from) {
+            $phpmailer->From     = $from;
+            $phpmailer->Sender   = $from;
+        }
+        $fromName = getenv('WP_SMTP_FROM_NAME');
+        if ($fromName) { $phpmailer->FromName = $fromName; }
+    }, 10, 1);
+{{- end }}

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -97,6 +97,20 @@
       "description": "Additional annotations for deployment",
       "default": {}
     },
+    "commonLabels": {
+      "type": "object",
+      "description": "Labels applied to ALL resources",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "description": "Annotations applied to ALL resources",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "updateStrategy": {
       "type": "object",
       "properties": {
@@ -806,6 +820,46 @@
             ]
           },
           "default": []
+        },
+        "smtp": {
+          "type": "object",
+          "description": "SMTP configuration via MU-plugin",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "host": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "encryption": {
+              "type": "string"
+            },
+            "fromEmail": {
+              "type": "string"
+            },
+            "fromName": {
+              "type": "string"
+            },
+            "auth": {
+              "type": "boolean"
+            },
+            "username": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "existingSecretPasswordKey": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -1268,6 +1322,111 @@
             "type": "object"
           },
           "default": []
+        },
+        "secondary": {
+          "type": "array",
+          "description": "Additional named Ingress objects",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "className": {
+                "type": "string"
+              },
+              "annotations": {
+                "type": "object",
+                "additionalProperties": true
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "tls": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              },
+              "useHttpsBackend": {
+                "type": "boolean"
+              },
+              "extraRules": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "description": "NetworkPolicy configuration",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "allowExternalEgress": {
+          "type": "boolean"
+        },
+        "smtpPorts": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "from": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "extraRules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "egress": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "extraRules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
         }
       }
     },
@@ -1928,6 +2087,83 @@
               }
             }
           }
+        },
+        "prometheusRule": {
+          "type": "object",
+          "description": "PrometheusRule configuration",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "additionalLabels": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "defaultRules": {
+              "type": "object",
+              "additionalProperties": true,
+              "properties": {
+                "podDown": {
+                  "type": "boolean"
+                },
+                "apacheScrapeFailing": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "extraRules": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "backup": {
+      "type": "object",
+      "description": "Backup CronJob configuration",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "type": "string"
+        },
+        "retentionDays": {
+          "type": "integer"
+        },
+        "successfulJobsHistoryLimit": {
+          "type": "integer"
+        },
+        "failedJobsHistoryLimit": {
+          "type": "integer"
+        },
+        "backoffLimit": {
+          "type": "integer"
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "resources": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "persistence": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "s3": {
+          "type": "object",
+          "additionalProperties": true
         }
       }
     },

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -858,6 +858,12 @@
             },
             "existingSecretPasswordKey": {
               "type": "string"
+            },
+            "existingSecretUsernameKey": {
+              "type": "string"
+            },
+            "existingSecretFromEmailKey": {
+              "type": "string"
             }
           }
         }

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -50,11 +50,17 @@ clusterDomain: cluster.local
 
 ## @section Deployment parameters
 
-## @param customLabels object Additional labels for deployment
+## @param customLabels object Additional labels for deployment (Deployment only — use commonLabels for all resources)
 customLabels: {}
 
-## @param customAnnotations object Additional annotations for deployment
+## @param customAnnotations object Additional annotations for deployment (Deployment only — use commonAnnotations for all resources)
 customAnnotations: {}
+
+## @section Common metadata
+## @param commonLabels object Labels applied to ALL resources (Service, Ingress, PVC, ServiceMonitor, HPA, PDB, ...)
+commonLabels: {}
+## @param commonAnnotations object Annotations applied to ALL resources
+commonAnnotations: {}
 
 ## @section Deployment strategy
 ## @descriptionStart
@@ -430,6 +436,53 @@ wordpress:
   ##   - name: another-mu-plugin  # mounts all keys from ConfigMap
   ## ```
   muPluginsConfigMaps: []
+
+  ## @section SMTP / Mail
+  ## @descriptionStart
+  ## Configures WordPress mail delivery via a mu-plugin that overrides PHPMailer settings
+  ## directly from environment variables. The password is mounted from existingSecret
+  ## or set inline via password (not recommended for production).
+  ##
+  ## Example with Gmail:
+  ## ```yaml
+  ## wordpress:
+  ##   smtp:
+  ##     enabled: true
+  ##     host: smtp.gmail.com
+  ##     port: 587
+  ##     encryption: tls
+  ##     fromEmail: noreply@example.com
+  ##     fromName: "My Site"
+  ##     auth: true
+  ##     username: noreply@example.com
+  ##     existingSecret: gmail-smtp
+  ##     existingSecretPasswordKey: password
+  ## ```
+  ## @descriptionEnd
+  smtp:
+    ## @param wordpress.smtp.enabled bool Enable SMTP configuration via MU-plugin
+    enabled: false
+    ## @param wordpress.smtp.host string SMTP server hostname
+    host: ""
+    ## @param wordpress.smtp.port int SMTP server port (25, 465, 587)
+    port: 587
+    ## @param wordpress.smtp.encryption string Encryption method (tls, ssl, or empty for none)
+    encryption: tls
+    ## @param wordpress.smtp.fromEmail string From address
+    fromEmail: ""
+    ## @param wordpress.smtp.fromName string Display name in From header
+    fromName: ""
+    ## @param wordpress.smtp.auth bool Use SMTP authentication
+    auth: true
+    ## @param wordpress.smtp.username string SMTP auth username
+    username: ""
+    ## @param wordpress.smtp.password string SMTP auth password (use existingSecret in production)
+    password: ""
+    ## @param wordpress.smtp.existingSecret string Name of existing Secret containing the SMTP password
+    existingSecret: ""
+    ## @param wordpress.smtp.existingSecretPasswordKey string Key in existingSecret holding the SMTP password
+    existingSecretPasswordKey: "password"
+
 ## @section Apache parameters
 ## @descriptionStart
 ## Custom Apache configuration for site, ports, and PHP.
@@ -661,6 +714,47 @@ ingress:
   useHttpsBackend: false
   ## @param ingress.extraRules list Additional ingress rules
   extraRules: []
+  ## @param ingress.secondary list Additional named Ingress objects with independent className, annotations, and TLS.
+  ## Useful for admin-only or geo-routed hostnames.
+  ## E.g.
+  ## ```yaml
+  ## ingress:
+  ##   secondary:
+  ##     - name: admin
+  ##       enabled: true
+  ##       className: nginx
+  ##       annotations:
+  ##         nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8"
+  ##         cert-manager.io/cluster-issuer: letsencrypt-prod
+  ##       hosts:
+  ##         - host: admin.example.com
+  ##           paths:
+  ##             - path: /
+  ##               pathType: Prefix
+  ##       tls:
+  ##         - secretName: wp-admin-tls
+  ##           hosts: [admin.example.com]
+  ## ```
+  secondary: []
+
+## @section NetworkPolicy parameters
+networkPolicy:
+  ## @param networkPolicy.enabled bool Create a NetworkPolicy for the WordPress pod
+  enabled: false
+  ## @param networkPolicy.allowExternalEgress bool Allow egress to public Internet (needed for wp-cli plugin/theme downloads and SMTP)
+  allowExternalEgress: true
+  ## @param networkPolicy.smtpPorts list TCP ports opened on external egress for SMTP
+  smtpPorts: [587]
+  ## @param networkPolicy.annotations object Additional annotations for the NetworkPolicy
+  annotations: {}
+  ingress:
+    ## @param networkPolicy.ingress.from list Ingress sources (empty = allow all). Use podSelector/namespaceSelector for nginx-ingress etc.
+    from: []
+    ## @param networkPolicy.ingress.extraRules list Extra raw ingress rule blocks appended verbatim
+    extraRules: []
+  egress:
+    ## @param networkPolicy.egress.extraRules list Extra raw egress rule blocks appended verbatim
+    extraRules: []
 
 ## @section Resource parameters
 ## @descriptionStart
@@ -1019,6 +1113,81 @@ metrics:
       metricsPath: /metrics
       ## @param metrics.apache.serviceMonitor.namespace string Namespace for ServiceMonitor (defaults to release namespace)
       namespace: ""
+
+## @section PrometheusRule
+  prometheusRule:
+    ## @param metrics.prometheusRule.enabled bool Create a PrometheusRule (requires metrics.apache or metrics.wordpress enabled)
+    enabled: false
+    ## @param metrics.prometheusRule.namespace string Namespace where the PrometheusRule is created (default: release namespace)
+    namespace: ""
+    ## @param metrics.prometheusRule.additionalLabels object Labels for Prometheus Operator selector (e.g. release: kube-prometheus-stack)
+    additionalLabels: {}
+    defaultRules:
+      ## @param metrics.prometheusRule.defaultRules.podDown bool Enable WordPressPodDown alert
+      podDown: true
+      ## @param metrics.prometheusRule.defaultRules.apacheScrapeFailing bool Enable scrape-failure and busy-worker alerts (requires metrics.apache.enabled)
+      apacheScrapeFailing: true
+    ## @param metrics.prometheusRule.extraRules list Additional alerting rules appended verbatim
+    extraRules: []
+
+## @section Backup
+backup:
+  ## @param backup.enabled bool Create a CronJob that backs up DB and wp-content to a PVC
+  enabled: false
+  ## @param backup.schedule string Cron schedule (UTC)
+  schedule: "0 2 * * *"
+  ## @param backup.retentionDays int Delete local backups older than N days
+  retentionDays: 14
+  ## @param backup.successfulJobsHistoryLimit int Number of successful job records to keep
+  successfulJobsHistoryLimit: 3
+  ## @param backup.failedJobsHistoryLimit int Number of failed job records to keep
+  failedJobsHistoryLimit: 1
+  ## @param backup.backoffLimit int Number of retries before marking the backup job failed
+  backoffLimit: 2
+  ## @section Backup image
+  image:
+    ## @param backup.image.registry string Image registry
+    registry: docker.io
+    ## @param backup.image.repository string Image repository
+    repository: mariadb
+    ## @param backup.image.tag string Image tag
+    tag: "11"
+    ## @param backup.image.pullPolicy string Image pull policy
+    pullPolicy: IfNotPresent
+  ## @param backup.resources object Resource requests/limits for the backup container
+  resources: {}
+  ## @section Backup PVC
+  persistence:
+    ## @param backup.persistence.enabled bool Create a PVC for backup storage
+    enabled: true
+    ## @param backup.persistence.existingClaim string Use an existing PVC instead of creating one
+    existingClaim: ""
+    ## @param backup.persistence.size string Size of the backup PVC
+    size: 10Gi
+    ## @param backup.persistence.accessModes list Access modes for the backup PVC
+    accessModes: [ReadWriteOnce]
+    ## @param backup.persistence.storageClass string Storage class for the backup PVC
+    storageClass: ""
+  ## @section Backup S3 (rclone)
+  s3:
+    ## @param backup.s3.enabled bool Push backups to S3 via rclone after each run
+    enabled: false
+    ## @section Backup S3 image
+    image:
+      ## @param backup.s3.image.repository string rclone image repository
+      repository: rclone/rclone
+      ## @param backup.s3.image.tag string rclone image tag
+      tag: "1.69"
+      ## @param backup.s3.image.pullPolicy string Pull policy for rclone image
+      pullPolicy: IfNotPresent
+    ## @param backup.s3.existingSecret string Secret containing key rclone.conf with the configured remote
+    existingSecret: ""
+    ## @param backup.s3.remote string rclone remote name (must match rclone.conf)
+    remote: "s3"
+    ## @param backup.s3.bucket string S3 bucket name
+    bucket: ""
+    ## @param backup.s3.path string Sub-path inside the bucket
+    path: "wordpress-backups"
 
 ## @section External Database configuration
 ## @descriptionStart

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -468,20 +468,24 @@ wordpress:
     port: 587
     ## @param wordpress.smtp.encryption string Encryption method (tls, ssl, or empty for none)
     encryption: tls
-    ## @param wordpress.smtp.fromEmail string From address
+    ## @param wordpress.smtp.fromEmail string From address (use existingSecretFromEmailKey to avoid plain-text in values)
     fromEmail: ""
     ## @param wordpress.smtp.fromName string Display name in From header
     fromName: ""
     ## @param wordpress.smtp.auth bool Use SMTP authentication
     auth: true
-    ## @param wordpress.smtp.username string SMTP auth username
+    ## @param wordpress.smtp.username string SMTP auth username (use existingSecretUsernameKey to avoid plain-text in values)
     username: ""
     ## @param wordpress.smtp.password string SMTP auth password (use existingSecret in production)
     password: ""
-    ## @param wordpress.smtp.existingSecret string Name of existing Secret containing the SMTP password
+    ## @param wordpress.smtp.existingSecret string Name of existing Secret containing SMTP credentials
     existingSecret: ""
-    ## @param wordpress.smtp.existingSecretPasswordKey string Key in existingSecret holding the SMTP password
+    ## @param wordpress.smtp.existingSecretPasswordKey string Key in existingSecret for the SMTP password
     existingSecretPasswordKey: "password"
+    ## @param wordpress.smtp.existingSecretUsernameKey string Key in existingSecret for the SMTP username (overrides username when set)
+    existingSecretUsernameKey: ""
+    ## @param wordpress.smtp.existingSecretFromEmailKey string Key in existingSecret for the From address (overrides fromEmail when set)
+    existingSecretFromEmailKey: ""
 
 ## @section Apache parameters
 ## @descriptionStart

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -1136,8 +1136,10 @@ metrics:
 
 ## @section Backup
 backup:
-  ## @param backup.enabled bool Create a CronJob that backs up DB and wp-content to a PVC
+  ## @param backup.enabled bool Create a CronJob that backs up the database (and optionally wp-content) to a PVC
   enabled: false
+  ## @param backup.includeFiles bool Also tar wp-content into the backup (requires a RWX PVC or snapshotting — set false when using RWO storage)
+  includeFiles: false
   ## @param backup.schedule string Cron schedule (UTC)
   schedule: "0 2 * * *"
   ## @param backup.retentionDays int Delete local backups older than N days

--- a/scripts/helmlint.sh
+++ b/scripts/helmlint.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Runs `helm lint` on any chart that contains a changed file.
+# Replicates gruntwork-io/pre-commit helmlint logic but adds /opt/homebrew/bin
+# to PATH so it works on Apple Silicon Macs where Homebrew lives there.
+set -e
+
+export PATH=/opt/homebrew/bin:/usr/local/bin:$PATH
+
+readonly cwd_abspath="$(realpath "$PWD")"
+
+contains_element() {
+  local -r match="$1"; shift
+  for e in "$@"; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
+chart_path() {
+  local -r f="$(realpath "$1")"
+  local -r d="$(dirname "$f")"
+
+  [[ "$f" == "$cwd_abspath" ]] && echo "" && return 0
+  [[ "$(basename "$f")" == "Chart.yaml" ]] && echo "$d" && return 0
+  [[ -f "$f/Chart.yaml" ]] && echo "$f" && return 0
+  [[ -f "$d/Chart.yaml" ]] && echo "$d" && return 0
+
+  chart_path "$d"
+}
+
+seen_chart_paths=()
+
+for file in "$@"; do
+  file_chart_path=$(chart_path "$file")
+  [[ -z "$file_chart_path" ]] && continue
+  contains_element "$file_chart_path" "${seen_chart_paths[@]}" && continue
+
+  if [[ -f "$file_chart_path/linter_values.yaml" ]]; then
+    helm lint -f "$file_chart_path/values.yaml" -f "$file_chart_path/linter_values.yaml" "$file_chart_path"
+  else
+    helm lint "$file_chart_path"
+  fi
+  seen_chart_paths+=("$file_chart_path")
+done


### PR DESCRIPTION
## Summary

Six new features for the WordPress chart, bumping the version to **4.2.0** (on top of the 4.1.0 Application Passwords / JWT commit already in main).

### New features

| Feature | Key values |
|---|---|
| **SMTP** | `wordpress.smtp.*` — MU-plugin mounted via subPath, credentials from Secret |
| **NetworkPolicy** | `networkPolicy.*` — auto-wired DB/cache/DNS egress, optional internet egress |
| **PrometheusRule** | `metrics.prometheusRule.*` — bundled pod-down + Apache alerts, extend via `extraRules` |
| **Secondary Ingress** | `ingress.secondary[]` — additional Ingress objects per release (e.g. separate wp-admin) |
| **Backup CronJob** | `backup.*` — daily `mariadb-dump` to PVC; optional rclone S3 sidecar; `backup.includeFiles` flag |
| **commonLabels / commonAnnotations** | Applied to all chart resources; resource-specific annotations win |

### Other changes

- **JWT secret isolation**: `JWT_AUTH_SECRET_KEY` is now stored in a dedicated `<fullname>-jwt` Secret instead of the main WordPress Secret — prevents accidental overwrites on `helm upgrade`. Both init and main containers reference the new secret; `existingSecret` path unchanged. Lookup preserves the key across upgrades.
- **SMTP security**: `existingSecretUsernameKey` / `existingSecretFromEmailKey` keep email addresses out of values files — only in K8s Secrets
- **Sample YAMLs**: all samples now self-contained with correct prerequisite comments; two new secret files (`token.secrets.yaml`, `multisite-subdomain.secrets.yaml`); fixed `mariaDB`, `externalDB`, `customInit`, `muPlugins` (missing credentials, wrong init.enabled)
- **README**: full documentation for all 6 new features with install snippets and notable-changes entry
- **verify.sh**: 3 new smoke-test steps (NetworkPolicy, secondaryIngress, backup CronJob + PVC)

### Template fixes (in final commit)

- `backup-cronjob.yaml`: honour `secretKeys.userPasswordKey`, add external-DB branch, 1h timeout on s3-sync, `required()` for `backup.s3.existingSecret`
- `deployment.yaml`: SMTP password falls back to `value: ""` when neither secret nor inline value is set
- `ingress.yaml`: fix scoping bug — secondary ingresses were only rendered when primary ingress was also enabled
- `networkpolicy.yaml`: DNS egress uses `namespaceSelector` (metadata.name) instead of pod-label selector; apache metrics port uses configured value
- `prometheusrule.yaml`: scope `WordPressApacheHighBusyWorkers` expr to release-specific job
- `service.yaml`: apache metrics targetPort and NodePort guard

## Test plan

- [x] `helm template` renders without errors
- [x] `helm lint` passes
- [x] `yamllint` passes on all sample files
- [x] Full `verify.sh` run: **ALL 13 CHECKS PASSED** (install → pods ready → logs → HTTP → NetworkPolicy → secondaryIngress → metrics → backup CronJob)
- [x] Manual backup job: DB dump landed in PVC and synced to Garage S3 bucket `wordpress-verify-backup`
- [x] Backup PVC uses `WaitForFirstConsumer` binding — binds on first job run (expected)
- [x] `backup.includeFiles: false` (default) avoids RWO PVC mount conflict on OpenEBS ZFS
- [x] JWT secret created as `<fullname>-jwt`; key preserved across upgrades via lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)