### PR TITLE
[wordpress] Add custom CA support for S3 backup

### DIFF
--- a/charts/wordpress/CHANGELOG.md
+++ b/charts/wordpress/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this chart are documented here.
 
+## 4.4.4 - 2026-05-30
+
+- Add `backup.s3.ca.existingSecret` / `existingSecretKey` to support custom CA certificates for S3 backup sync via rclone (thanks to [Julien Sabatier](https://github.com/jusabatier))
+
 ## 4.4.3 - 2026-05-30
 
 - Update docker.io/mariadb digest to 6a4c4bb

--- a/charts/wordpress/Chart.yaml
+++ b/charts/wordpress/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wordpress
 description: "Using the official WordPress image. This chart provides automation for installation, user management, plugin installation, and metrics."
 type: application
-version: 4.4.3
+version: 4.4.4
 appVersion: "7.0.0" # renovate: image=docker.io/wordpress
 icon: https://raw.githubusercontent.com/slydlake/helm-charts/refs/heads/main/charts/wordpress/app.png
 home: https://github.com/slydlake/helm-charts
@@ -26,8 +26,8 @@ annotations:
     - name: slydlake
       email: sly.dlake@gmail.com
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update docker.io/mariadb digest to 6a4c4bb"
+    - kind: added
+      description: Add support for custom CA certificates in S3 backup sync
   artifacthub.io/images: |
     - name: wordpress
       image: docker.io/wordpress:7.0.0-php8.3-apache

--- a/charts/wordpress/templates/backup-cronjob.yaml
+++ b/charts/wordpress/templates/backup-cronjob.yaml
@@ -131,6 +131,10 @@ spec:
                   value: {{ .Values.backup.s3.bucket | quote }}
                 - name: S3_PATH
                   value: {{ .Values.backup.s3.path | quote }}
+                {{- if and .Values.backup.s3.ca.existingSecret .Values.backup.s3.ca.existingSecretKey }}
+                - name: RCLONE_CA_CERT
+                  value: /etc/rclone/custom-ca/ca.crt
+                {{- end }}
               command:
                 - /bin/sh
                 - -c
@@ -156,6 +160,11 @@ spec:
                 - name: rclone-config
                   mountPath: /config
                   readOnly: true
+                {{- if and .Values.backup.s3.ca.existingSecret .Values.backup.s3.ca.existingSecretKey }}
+                - name: rclone-custom-ca
+                  mountPath: /etc/rclone/custom-ca
+                  readOnly: true
+                {{- end }}
                 - name: tmp
                   mountPath: /tmp
             {{- end }}
@@ -174,6 +183,14 @@ spec:
             - name: rclone-config
               secret:
                 secretName: {{ required "backup.s3.existingSecret is required when backup.s3.enabled=true" .Values.backup.s3.existingSecret }}
+            {{- if and .Values.backup.s3.ca.existingSecret .Values.backup.s3.ca.existingSecretKey }}
+            - name: rclone-custom-ca
+              secret:
+                secretName: {{ .Values.backup.s3.ca.existingSecret | quote }}
+                items:
+                  - key: {{ .Values.backup.s3.ca.existingSecretKey | quote }}
+                    path: ca.crt
+            {{- end }}
             {{- end }}
 ---
 {{- if and (not .Values.backup.persistence.existingClaim) .Values.backup.persistence.enabled }}

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -2169,7 +2169,49 @@
         },
         "s3": {
           "type": "object",
-          "additionalProperties": true
+          "additionalProperties": true,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable S3 sync after backup"
+            },
+            "existingSecret": {
+              "type": "string",
+              "description": "Secret containing rclone.conf with the configured remote",
+              "default": ""
+            },
+            "remote": {
+              "type": "string",
+              "description": "rclone remote name (must match rclone.conf)",
+              "default": "s3"
+            },
+            "bucket": {
+              "type": "string",
+              "description": "S3 bucket name",
+              "default": ""
+            },
+            "path": {
+              "type": "string",
+              "description": "Sub-path inside the bucket",
+              "default": "wordpress-backups"
+            },
+            "ca": {
+              "type": "object",
+              "description": "Custom CA certificate for S3 connections",
+              "properties": {
+                "existingSecret": {
+                  "type": "string",
+                  "description": "Name of an existing secret containing the CA certificate",
+                  "default": ""
+                },
+                "existingSecretKey": {
+                  "type": "string",
+                  "description": "Key in the secret that holds the CA certificate (PEM)",
+                  "default": ""
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -1194,6 +1194,12 @@ backup:
     bucket: ""
     ## @param backup.s3.path string Sub-path inside the bucket
     path: "wordpress-backups"
+    ## @section Custom CA certificate for S3 connections
+    ca:
+      ## @param backup.s3.ca.existingSecret string Name of an existing secret containing the CA certificate
+      existingSecret: ""
+      ## @param backup.s3.ca.existingSecretKey string Key in the secret that holds the CA certificate (PEM)
+      existingSecretKey: ""
 
 ## @section External Database configuration
 ## @descriptionStart


### PR DESCRIPTION
# Summary

This PR adds support for using a custom CA certificate when syncing WordPress backups to an S3-compatible endpoint with rclone.

The `wordpress` chart already supports S3 backup sync through the `backup.s3` configuration. This change adds a new optional `backup.s3.customCASecret` setting, allowing users to mount an existing Kubernetes Secret containing a CA certificate and pass it to rclone via `RCLONE_CA_CERT`.

This is useful for S3-compatible services using an internal or private CA, without requiring a custom rclone image or duplicating CA data into the rclone configuration Secret.

Example:

```yaml
backup:
  s3:
    enabled: true
    existingSecret: wordpress-rclone
    customCASecret:
      name: internal-root-ca
      key: ca.crt
````

---

## Checklist (required before merge)

* [x] I have updated the `Chart.yaml` version for the affected chart(s) (bumped the `version` field).
* [x] I have added an entry in the chart's `artifacthub.io/changes` annotation (in `Chart.yaml`) describing the change. Use one of the supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
* [x] I have run a quick install/upgrade smoke test where applicable.
* [x] I have updated documentation or samples if necessary.

Smoke test performed with:

```bash
helm template wordpress . \
  -n geoportail \
  -f /tmp/wp-test-values.yaml \
  | grep -A90 -B20 "name: s3-sync"
```

The rendered CronJob includes:

* `RCLONE_CA_CERT=/etc/rclone/custom-ca/ca.crt`
* the custom CA Secret mounted in the `s3-sync` container
* the Secret key mapped to `ca.crt`