### PR TITLE
chore: add GitHub Sponsors funding.yml and sponsor badge

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: slydlake

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
   <a href="https://artifacthub.io/packages/search?org=slybase">
     <img src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/slybase" alt="Artifact Hub">
   </a>
+  <a href="https://github.com/sponsors/slydlake">
+    <img src="https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?logo=github" alt="Sponsor on GitHub">
+  </a>
 </p>
 
 # 🚀 SlyCharts - Helm charts, the sly way


### PR DESCRIPTION
## Summary
- Adds `.github/FUNDING.yml` with `github: slydlake` to show the Sponsor button on the repo page
- Adds a GitHub Sponsors badge to `README.md`