### PR TITLE
chore: fix PR auto-assign and update PR template checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,7 @@ This PR fixes the startup crash in the `wordpress` chart by using the chart's se
 
 - [ ] I have updated the `Chart.yaml` version for the affected chart(s) (bumped the `version` field).
 - [ ] I have added an entry in the chart's `artifacthub.io/changes` annotation (in `Chart.yaml`) describing the change. Use one of the supported kinds: `added`, `changed`, `deprecated`, `removed`, `fixed`, `security`.
+- [ ] I have appended an entry to the chart's `CHANGELOG.md` describing the change.
 - [ ] I have run a quick install/upgrade smoke test where applicable.
 - [ ] I have updated documentation or samples if necessary.
 
@@ -27,4 +28,4 @@ If your change only affects documentation or images and doesn't change chart beh
 Additional notes:
 
 - See Artifact Hub annotation docs for `artifacthub.io/changes`: https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations
-- When editing multiple charts, ensure each chart's `Chart.yaml` is updated and annotated.
+- When editing multiple charts, ensure each chart's `Chart.yaml` is updated, annotated, and its `CHANGELOG.md` appended.

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,7 +1,7 @@
 name: PR Auto Assign
 
 "on":
-  pull_request:
+  pull_request_target:
     types: [opened]
   issues:
     types: [opened]


### PR DESCRIPTION
## Summary

- Switch `pr-auto-assign.yml` from `pull_request` to `pull_request_target` so the `GITHUB_TOKEN` always has write access — fixes auto-assignment not working (e.g. PR #358)
- Add `CHANGELOG.md` update as a required checklist item in the PR template to match the current release workflow

## Checklist (required before merge)

- [x] No chart changes — skipping Chart version bump and smoke test