### PR TITLE
fix(wordpress): skip rwx-permissions init container for StatefulSet

### DIFF
--- a/charts/wordpress/templates/_pod.tpl
+++ b/charts/wordpress/templates/_pod.tpl
@@ -157,12 +157,13 @@
       hostNetwork: {{ .Values.hostNetwork }}
       {{- end }}
       initContainers:
-        {{- if has "ReadWriteMany" .Values.storage.accessModes }}
-        # Fixes PVC ownership for RWX storage (NFS, Longhorn, CephFS, etc.)
+        {{- if and (has "ReadWriteMany" .Values.storage.accessModes) (ne .Values.controllerType "statefulset") }}
+        # Fixes PVC ownership for RWX shared storage (NFS, Longhorn, CephFS, etc.)
         # that doesn't respect Kubernetes fsGroup settings.
         # Requires root user because DAC_OVERRIDE cannot change ownership of root-owned
         # directories (e.g., lost+found) on network storage.
-        # Only enabled for ReadWriteMany - not needed for ReadWriteOnce.
+        # Only for Deployment + ReadWriteMany. StatefulSet provisions fresh per-Pod
+        # RWO volumes where fsGroup is honoured by the CSI driver — no chown needed.
         - name: {{ .Chart.Name }}-rwx-permissions
           image: {{ include "slycharts.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) }}
           securityContext:


### PR DESCRIPTION
## Summary

- The `wordpress-rwx-permissions` init container was previously gated only on `storage.accessModes` containing `ReadWriteMany`
- With `controllerType: statefulset`, each Pod gets a **fresh per-Pod RWO PVC** via `volumeClaimTemplates` — the CSI driver honours `fsGroup` on these volumes, so no `chown` is needed
- Adds an explicit `ne .Values.controllerType "statefulset"` guard to the condition, making the intent unambiguous in code

**Effective change in behaviour:** none for the default configuration (StatefulSet defaults to `ReadWriteOnce` anyway). This is a defensive correctness fix for the edge case where someone would set both `controllerType: statefulset` and `accessModes: [ReadWriteMany]`.

## Test plan

- [ ] `helm template` with `controllerType: deployment` + `accessModes: [ReadWriteMany]` → init container present ✓
- [ ] `helm template` with `controllerType: statefulset` + `accessModes: [ReadWriteOnce]` → init container absent ✓
- [ ] `helm template` with `controllerType: statefulset` + `accessModes: [ReadWriteMany]` → init container absent ✓ (new behaviour)
- [ ] Helm Lint passes ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)