### PR TITLE
ci: enable live OCI publishing (release-please Phase 1 cut-over)

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -41,9 +41,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   HELM_VERSION: v3.18.3
   ORAS_VERSION: 1.2.0
-  # Phase 0 safety net: tag-triggered runs publish NOTHING while this is "false".
-  # Set to "true" in Phase 1 to enable real OCI releases on release tags.
-  RELEASE_ENABLED: "false"
+  # Tag-triggered releases publish live when this is "true".
+  # Set to "false" to revert to dry-run mode (Phase 0 safety net).
+  RELEASE_ENABLED: "true"
 
 jobs:
   oci-release:


### PR DESCRIPTION
## Summary

- Sets `RELEASE_ENABLED: "true"` in `.github/workflows/oci-release.yaml`
- Tag-triggered `oci-release` runs will now **push, sign, and publish** charts to `ghcr.io/slybase/charts` instead of dry-running
- Updates the surrounding comment to reflect the new steady-state (no more "Phase 0 safety net" language)

## Background

Release-please was migrated to tag-based releases in #369. A Phase 0 safety net (`RELEASE_ENABLED: "false"`) was left in place to validate the pipeline before going live. The `wordpress-v4.6.1` release (#371) confirmed that tag parsing, CHANGELOG generation, and packaging all work correctly — the only missing piece was the final push, which was blocked by the flag.

## After merge

Run `workflow_dispatch` to backfill the missing `wordpress:4.6.1` package:

```bash
gh workflow run oci-release.yaml --ref main \
  -f chart=wordpress \
  -f dry_run=false
```

## Test plan

- [ ] Merge this PR
- [ ] Run `workflow_dispatch` as above; verify run is green with no "DRY RUN" line and push/sign steps succeed
- [ ] `helm pull oci://ghcr.io/slybase/charts/wordpress --version 4.6.1` succeeds
- [ ] Next release-please tag publishes automatically without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)