### PR TITLE
fix(wordpress): pin image tags to digests for supply-chain integrity

### DIFF
--- a/charts/wordpress/samples/advanced.secrets.yaml
+++ b/charts/wordpress/samples/advanced.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/wordpress/samples/backup-s3.secrets.yaml
+++ b/charts/wordpress/samples/backup-s3.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 ## Sample: rclone config secret for S3 backup
 ## Create this Secret before enabling backup.s3:
 ##   kubectl create secret generic my-rclone-config \

--- a/charts/wordpress/samples/customInit.values.yaml
+++ b/charts/wordpress/samples/customInit.values.yaml
@@ -1,3 +1,8 @@
+# WARNING: Sample file for documentation purposes only — contains placeholder
+# credentials. Do not use these values in production. Provision real secrets
+# via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+# External Secrets Operator.
+
 # Example values.yaml for using custom init commands
 # This example shows how to reference a ConfigMap containing
 # custom commands that run after the init.sh script

--- a/charts/wordpress/samples/externalDB.secrets.yaml
+++ b/charts/wordpress/samples/externalDB.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 ## Prerequisites for externalDB.values.yaml
 ## kubectl apply -f externalDB.secrets.yaml
 

--- a/charts/wordpress/samples/mariaDB.secrets.yaml
+++ b/charts/wordpress/samples/mariaDB.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 ## Prerequisites for mariaDB.values.yaml
 ## kubectl apply -f mariaDB.secrets.yaml
 

--- a/charts/wordpress/samples/multisite-subdomain.secrets.yaml
+++ b/charts/wordpress/samples/multisite-subdomain.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 ## Prerequisites for multisite-subdomain.values.yaml
 ## kubectl apply -f multisite-subdomain.secrets.yaml
 

--- a/charts/wordpress/samples/multisite.secrets.yaml
+++ b/charts/wordpress/samples/multisite.secrets.yaml
@@ -1,3 +1,8 @@
+# WARNING: Sample file for documentation purposes only — contains placeholder
+# credentials. Do not use these values in production. Provision real secrets
+# via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+# External Secrets Operator.
+
 # WordPress Multisite Secrets Sample
 # Create this secret before installing the Helm chart
 # kubectl create namespace wordpress-multisite

--- a/charts/wordpress/samples/smtp.secrets.yaml
+++ b/charts/wordpress/samples/smtp.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 ## Sample: SMTP secret
 ## Create this Secret before installing the chart.
 ## kubectl create secret generic gmail-smtp-secret --from-literal=password=my-app-password

--- a/charts/wordpress/samples/token.secrets.yaml
+++ b/charts/wordpress/samples/token.secrets.yaml
@@ -1,3 +1,8 @@
+## WARNING: Sample file for documentation purposes only — contains placeholder
+## credentials. Do not use these values in production. Provision real secrets
+## via `kubectl create secret`, a sealed-secrets/SOPS workflow, or an
+## External Secrets Operator.
+
 ## Prerequisites for token.values.yaml
 ## kubectl apply -f token.secrets.yaml
 

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -25,7 +25,7 @@ image:
   ## @param image.repository string WordPress container image repository
   repository: wordpress
   ## @param image.tag string Image tag (default is the chart appVersion)
-  tag: "7.0.0-php8.3-apache"
+  tag: "7.0.0-php8.3-apache@sha256:d32999a243ee5051babf8580ff22e7254129fe2f209f3d10aacdc81fdcd33959"
   ## @param image.pullPolicy string Image pull policy
   pullPolicy: IfNotPresent
 
@@ -171,7 +171,7 @@ wordpress:
       ## @param wordpress.init.image.repository string Container image repository for init container
       repository: wordpress
       ## @param wordpress.init.image.tag string Image tag for init container
-      tag: "cli-2.12.0-php8.3"
+      tag: "cli-2.12.0-php8.3@sha256:dac35b8f34c6f4f1fafa0b32342642fa9eecd077bb0a8909b486c108874bd7f1"
       ## @param wordpress.init.image.pullPolicy string Image pull policy for init container
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Pin the main `wordpress` image (`7.0.0-php8.3-apache`) and the `wp-cli` init image (`cli-2.12.0-php8.3`) to their current `@sha256` digests, matching the pattern already used for the wireguard/wg-easy and wordpress subchart images.
- `pinDigests: true` in renovate.json means Renovate will keep these digests in sync going forward.
- Add a documentation warning to all `samples/*.secrets.yaml` files and `customInit.values.yaml` clarifying they contain placeholder credentials only and that production secrets should be provisioned via `kubectl`/External Secrets.

This is **Phase 1a** of the chart-audit plan (security hardening / supply-chain).

## Test plan
- [x] `helm template` with `samples/mariaDB.values.yaml` renders both images with the pinned digests
- [x] `./charts/wordpress/samples/verify/verify.sh` — full install, all pods Ready, logs clean, HTTP/metrics smoke tests passed (`ALL CHECKS PASSED`)
- [x] `./charts/wordpress/samples/verify/uninstall.sh` cleanup
- [x] pre-commit hooks (yamllint, helm lint) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)