### PR TITLE
feat(wireguard)!: harden pod/container security defaults

### DIFF
--- a/charts/wireguard/readme.md
+++ b/charts/wireguard/readme.md
@@ -46,6 +46,24 @@ You have to set a namespace with privileged security (see sample namespace.yaml)
 kubectl create namespace wireguard && kubectl label namespace wireguard pod-security.kubernetes.io/enforce=privileged --overwrite
 ```
 
+## Security
+
+The container runs as `root` (`runAsUser: 0`) with `privileged: true` and the `NET_ADMIN` capability. This is required by the underlying [linuxserver/wireguard](https://github.com/linuxserver/docker-wireguard) image:
+
+- its s6-overlay init system needs root capabilities beyond `NET_ADMIN` (e.g. `CAP_SETUID`/`CAP_SETGID`) to start up — running with a restricted capability set (`drop: [ALL]`, `add: [NET_ADMIN]`) without `privileged: true` causes the container to crash with `s6-overlay-suexec: fatal: unable to setgid to root`
+- `wg-quick` (interface creation, and in server mode routing/NAT) needs `NET_ADMIN`, and on some host kernels `SYS_MODULE` to load the WireGuard kernel module
+
+As a result:
+- `pod-security.kubernetes.io/enforce: privileged` is required on the namespace (see Prerequisites)
+- the chart **cannot** meet the `restricted` or `baseline` Pod Security Standard
+
+What the chart hardens by default regardless:
+- `seccompProfile: RuntimeDefault` for the pod and the container
+- `capabilities: {drop: [ALL], add: [NET_ADMIN]}` (`SYS_MODULE` is commented out — only needed if the host kernel doesn't already have the WireGuard module loaded)
+- `serviceAccount.automount: false` — the chart never talks to the Kubernetes API
+
+`allowPrivilegeEscalation: false` is intentionally **not** set: Kubernetes rejects the combination `privileged: true` + `allowPrivilegeEscalation: false` (`cannot set allowPrivilegeEscalation to false and privileged to true`), and `privileged: true` is a hard functional requirement as described above.
+
 ## Server mode
 Sample see in TL;DR.
 

--- a/charts/wireguard/templates/deployment.yaml
+++ b/charts/wireguard/templates/deployment.yaml
@@ -48,6 +48,8 @@ spec:
         runAsUser: {{ .Values.wireguard.PUID | default "1000" }}
         runAsGroup: {{ .Values.wireguard.PGID | default "1000" }}
         fsGroup: {{ .Values.wireguard.PGID | default "1000" }}
+        seccompProfile:
+          type: RuntimeDefault
       {{- end}}
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -81,6 +83,8 @@ spec:
             readOnlyRootFilesystem: false
             runAsNonRoot: false
             runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
           {{ else }}
             # Client mode - more secure with minimal capabilities
             capabilities:
@@ -91,8 +95,10 @@ spec:
             privileged: true
             allowPrivilegeEscalation: true
             readOnlyRootFilesystem: false
-            runAsNonRoot: false 
+            runAsNonRoot: false
             runAsUser: 0
+            seccompProfile:
+              type: RuntimeDefault
           {{ end }}
           image: {{ include "slycharts.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/wireguard/values.yaml
+++ b/charts/wireguard/values.yaml
@@ -201,7 +201,7 @@ serviceAccount:
   ## @param serviceAccount.create bool Specifies whether a service account should be created
   create: true
   ## @param serviceAccount.automount bool Automatically mount ServiceAccount API credentials
-  automount: true
+  automount: false
   ## @param serviceAccount.annotations object Annotations to add to the service account
   annotations: {}
   ## @param serviceAccount.name string Name of the service account. If not set and create is true, a name is generated
@@ -228,7 +228,7 @@ podLabels: {}
 ##     add:
 ##       - NET_ADMIN
 ##       - SYS_MODULE
-##   privileged: false
+##   privileged: true # required by the linuxserver/wireguard s6-overlay init, see readme.md "Security"
 ## ```
 ## @descriptionEnd
 


### PR DESCRIPTION
## Summary
- Add `seccompProfile: RuntimeDefault` to the pod and container `securityContext` defaults for both server and client mode.
- Keep `privileged: true` / `allowPrivilegeEscalation: true` / `runAsUser: 0` — these are hard functional requirements of the `linuxserver/wireguard` image (see new "Security" section in `readme.md` for the empirical evidence: dropping `privileged` and restricting capabilities to `NET_ADMIN` crashes the s6-overlay init with `unable to setgid to root`, and Kubernetes outright rejects `privileged: true` + `allowPrivilegeEscalation: false`).
- **BREAKING:** `serviceAccount.automount` now defaults to `false` (the chart never calls the Kubernetes API).

This is **Phase 1b** of the chart-audit plan (security hardening).

## Test plan
- [x] `helm lint` with `samples/server.values.yaml` and `samples/client.values.yaml` passed
- [x] `helm template` renders `seccompProfile: RuntimeDefault` and `automountServiceAccountToken: false` as expected
- [x] Live install (client mode) in a `pod-security.kubernetes.io/enforce: privileged` test namespace: pod starts cleanly, `ip link add dev wg0 type wireguard` succeeds with the new securityContext
- [x] Live install attempt with `privileged: false` + restricted capabilities reproduced the s6-overlay crash, confirming why `privileged: true` must stay (documented in readme.md)
- [x] pre-commit hooks (yamllint, helm lint) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)