### PR TITLE
feat(wg-easy)!: harden pod/container security defaults

### DIFF
--- a/charts/wg-easy/readme.md
+++ b/charts/wg-easy/readme.md
@@ -48,6 +48,20 @@ You have to set a namespace with privileged security (see sample namespace.yaml)
 kubectl create namespace wg-easy && kubectl label namespace wg-easy pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged --overwrite
 ```
 
+## Security
+
+By default the container runs `privileged: true` with the `NET_ADMIN` and `SYS_MODULE` capabilities. This is required by the [wg-easy](https://github.com/wg-easy/wg-easy) image to create the `wg0` interface and, if not already present on the host, to load the WireGuard kernel module.
+
+As a result:
+- `pod-security.kubernetes.io/enforce: privileged` is required on the namespace (see Prerequisites)
+- the chart **cannot** meet the `restricted` or `baseline` Pod Security Standard with the default `securityContext`
+
+What the chart hardens by default regardless:
+- `seccompProfile: RuntimeDefault` for the pod and the container
+- `serviceAccount.automount: false` — the chart never talks to the Kubernetes API
+
+If the WireGuard kernel module is already loaded on every host node, you can try running without `privileged: true` using `capabilities: {add: [NET_ADMIN, SYS_MODULE], drop: [ALL]}` instead - see the commented example in `values.yaml`. This is untested and not the default.
+
 ## Initialization Mode and Metrics
 
 To provide the secrets and values to set up init mode correctly and optionally enable the Prometheus metrics.

--- a/charts/wg-easy/templates/statefulset.yaml
+++ b/charts/wg-easy/templates/statefulset.yaml
@@ -64,6 +64,8 @@ spec:
                 - NET_ADMIN
                 - SYS_MODULE
             privileged: true
+            seccompProfile:
+              type: RuntimeDefault
           {{- end }}
           image: {{ include "slycharts.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -173,7 +173,7 @@ serviceAccount:
   ## @param serviceAccount.create bool Specifies whether a service account should be created
   create: true
   ## @param serviceAccount.automount bool Automatically mount ServiceAccount API credentials
-  automount: true
+  automount: false
   ## @param serviceAccount.annotations object Annotations to add to the service account
   annotations: {}
   ## @param serviceAccount.name string Name of the service account. If not set and create is true, a name is generated
@@ -225,14 +225,33 @@ podLabels: {}
 ##       - NET_ADMIN
 ##       - SYS_MODULE
 ## ```
+##
+## Alternative without `privileged: true` (only works if the WireGuard kernel
+## module is already loaded on the host node - untested, see readme.md "Security"):
+## ```yaml
+## securityContext:
+##   privileged: false
+##   capabilities:
+##     add:
+##       - NET_ADMIN
+##       - SYS_MODULE
+##     drop:
+##       - ALL
+##   seccompProfile:
+##     type: RuntimeDefault
+## ```
 ## @descriptionEnd
 
 ## @param podSecurityContext object Security context for the pod
-podSecurityContext: {}
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
 
 ## @param securityContext object Security context for the container
 securityContext:
   privileged: true
+  seccompProfile:
+    type: RuntimeDefault
 
 ## @section Service configuration
 service:


### PR DESCRIPTION
## Summary
- Add `seccompProfile: RuntimeDefault` to the default pod and container `securityContext` (mirrors the wireguard chart's Phase 1b hardening)
- Document an untested non-privileged alternative (`privileged: false` + `capabilities: {add: [NET_ADMIN, SYS_MODULE], drop: [ALL]}`) as a commented example in `values.yaml`, for hosts where the WireGuard kernel module is already loaded
- Set `serviceAccount.automount: false` (chart never talks to the Kubernetes API)
- Add a "Security" section to `readme.md` documenting why `privileged: true` is required and that `restricted`/`baseline` Pod Security Standards cannot be met by default

## Why `feat!:`
`serviceAccount.automount` flips from `true` to `false` by default — anyone relying on the auto-mounted ServiceAccount token (unlikely, since this chart doesn't call the Kubernetes API) needs to explicitly set `serviceAccount.automount: true`.

## Validation
- `helm lint` / `helm template` pass with the new defaults
- Live-installed in a temporary namespace (`pod-security.kubernetes.io/enforce=privileged`) on the test cluster: pod schedules, image pulls, and `wg-quick up wg0` reaches the same point with or without these changes
- The `wg-quick up wg0` failure observed (`Module ip_tables not found`, `iptables ... Table does not exist`) was reproduced identically against the **unmodified `main` chart** in a separate namespace — confirmed pre-existing Talos node/kernel limitation (missing `ip_tables`/nat netfilter module), unrelated to this PR's `seccompProfile`/`automount` changes

## Test plan
- [ ] CI: yamllint / helm lint / chart-validate pass
- [ ] On a node with working iptables-nat (e.g. standard kernel), confirm `wg0` comes up and pod becomes Ready with the new `securityContext`