### PR TITLE
feat(wireguard): feature parity - NetworkPolicy, PDB, commonLabels/Annotations, scheduling

### DIFF
--- a/charts/wireguard/readme.md
+++ b/charts/wireguard/readme.md
@@ -137,3 +137,27 @@ kubectl apply -f ./samples/namespace.yaml
 kubectl apply -f ./samples/clientFullConfig.secret.yaml
 helm install wireguard-client oci://ghcr.io/slybase/charts/wireguard --values ./samples/clientFullConfig.values.yaml -n wireguard
 ```
+
+## Advanced Configuration
+
+### Common Labels and Annotations
+
+`commonLabels` and `commonAnnotations` are applied to every resource created by this chart (Deployment, Service, PVC, ServiceAccount, NetworkPolicy, ...). Useful for GitOps (ArgoCD), cost allocation, and audit. See `samples/commonLabels.values.yaml` for an example.
+
+### NetworkPolicy
+
+The chart can create a `NetworkPolicy` to restrict traffic to/from the WireGuard pod (disabled by default via `networkPolicy.enabled: false`):
+
+- **Ingress** (server mode only): allows UDP traffic to the WireGuard port (`service.port`). By default, traffic is allowed from anywhere; restrict it with `networkPolicy.ingress.from`.
+- **Egress**: always allows DNS lookups to `kube-system`. `networkPolicy.allowExternalEgress` (default `true`) additionally allows UDP egress to `0.0.0.0/0`, required for the server to reach peers and for clients to reach their configured endpoint.
+- `networkPolicy.ingress.extraRules` / `networkPolicy.egress.extraRules` allow appending raw NetworkPolicy rule blocks.
+
+See `samples/networkpolicy.values.yaml` for an example.
+
+### Pod Disruption Budget
+
+Set `podDisruptionBudget.minAvailable` or `podDisruptionBudget.maxUnavailable` to create a `PodDisruptionBudget` for the deployment. Empty (default) disables it.
+
+### Topology Spread Constraints and Priority Class
+
+`topologySpreadConstraints` and `priorityClassName` are passed through to the pod spec for advanced scheduling control.

--- a/charts/wireguard/samples/commonLabels.values.yaml
+++ b/charts/wireguard/samples/commonLabels.values.yaml
@@ -1,0 +1,12 @@
+## Snippet: commonLabels and commonAnnotations — add these values to your existing values file.
+## These are applied to ALL Kubernetes resources created by the chart.
+## Useful for GitOps (ArgoCD), service mesh, cost allocation, and audit.
+
+commonLabels:
+  team: platform
+  environment: production
+  app.kubernetes.io/part-of: my-stack
+
+commonAnnotations:
+  owner: platform-team
+  contact: platform@example.com

--- a/charts/wireguard/samples/networkpolicy.values.yaml
+++ b/charts/wireguard/samples/networkpolicy.values.yaml
@@ -1,0 +1,14 @@
+## Snippet: NetworkPolicy — add these values to your existing values file.
+## Restricts ingress/egress traffic for the WireGuard pod.
+
+networkPolicy:
+  enabled: true
+  # Server mode only: restrict who may reach the WireGuard UDP port.
+  # Empty = allow from anywhere (typical for a VPN endpoint exposed via NodePort/LoadBalancer).
+  ingress:
+    from: []
+    extraRules: []
+  # Allow UDP egress to the public internet (required for peer/server endpoint connectivity)
+  allowExternalEgress: true
+  egress:
+    extraRules: []

--- a/charts/wireguard/templates/_helpers.tpl
+++ b/charts/wireguard/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "wireguard.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/wireguard/templates/deployment.yaml
+++ b/charts/wireguard/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -229,4 +233,11 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/wireguard/templates/hpa.yaml
+++ b/charts/wireguard/templates/hpa.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/wireguard/templates/networkpolicy.yaml
+++ b/charts/wireguard/templates/networkpolicy.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+  {{- $npAnnotations := merge (dict) (.Values.networkPolicy.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $npAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wireguard.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if or .Values.wireguard.server.enabled .Values.networkPolicy.ingress.extraRules }}
+  ingress:
+    {{- if .Values.wireguard.server.enabled }}
+    - ports:
+        - port: {{ .Values.service.port }}
+          protocol: UDP
+      {{- with .Values.networkPolicy.ingress.from }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- with .Values.networkPolicy.ingress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- else }}
+  ingress: []
+  {{- end }}
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- if .Values.networkPolicy.allowExternalEgress }}
+    # WireGuard UDP egress (peer/server endpoint connectivity)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: UDP
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/wireguard/templates/pdb.yaml
+++ b/charts/wireguard/templates/pdb.yaml
@@ -1,0 +1,27 @@
+{{- if and (.Values.podDisruptionBudget) (or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable) }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wireguard.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "wireguard.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/wireguard/templates/pvc.yaml
+++ b/charts/wireguard/templates/pvc.yaml
@@ -4,11 +4,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ include "wireguard.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.wireguard.server.storage.labels }}
+  {{- $pvcLabels := merge (dict) (.Values.wireguard.server.storage.labels | default dict) (.Values.commonLabels | default dict) }}
+  {{- with $pvcLabels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- $ann := .Values.wireguard.server.storage.annotations }}
+  {{- $ann := merge (dict) (.Values.wireguard.server.storage.annotations | default dict) (.Values.commonAnnotations | default dict) }}
   {{- $rp := .Values.wireguard.server.storage.resourcePolicy }}
   {{- if or $ann $rp }}
   annotations:

--- a/charts/wireguard/templates/secrets.yaml
+++ b/charts/wireguard/templates/secrets.yaml
@@ -12,11 +12,14 @@ metadata:
   name: {{ include "wireguard.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    release: {{ include "wireguard.fullname" . }}
+    {{- include "wireguard.labels" . | nindent 4 }}
+  {{- $secretAnnotations := .Values.commonAnnotations | default dict }}
   {{- if $sourceSecret }}
+  {{- $secretAnnotations = merge (dict) $secretAnnotations (dict "checksum/source-secret" ($sourceSecret.data | toJson | sha256sum)) }}
+  {{- end }}
+  {{- with $secretAnnotations }}
   annotations:
-    # Hash of source secret to trigger regeneration on changes
-    checksum/source-secret: {{ $sourceSecret.data | toJson | sha256sum }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 type: Opaque
 stringData:

--- a/charts/wireguard/templates/service.yaml
+++ b/charts/wireguard/templates/service.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wireguard.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/wireguard/templates/serviceaccount.yaml
+++ b/charts/wireguard/templates/serviceaccount.yaml
@@ -3,9 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "wireguard.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wireguard.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $saAnnotations := merge (dict) (.Values.serviceAccount.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $saAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wireguard/values.schema.json
+++ b/charts/wireguard/values.schema.json
@@ -70,6 +70,16 @@
       "title": "Fullname Override",
       "description": "Overrides the full chart name."
     },
+    "commonLabels": {
+      "type": "object",
+      "title": "Common Labels",
+      "description": "Labels applied to all resources created by this chart (Deployment, Service, PVC, ServiceAccount, NetworkPolicy, ...)."
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "title": "Common Annotations",
+      "description": "Annotations applied to all resources created by this chart."
+    },
     "replicaCount": {
       "type": "integer",
       "title": "Replica Count",
@@ -775,6 +785,105 @@
       "type": "object",
       "title": "Affinity",
       "description": "Affinity rules for pod scheduling."
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "title": "Topology Spread Constraints",
+      "description": "Topology spread constraints for pod scheduling.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "priorityClassName": {
+      "type": "string",
+      "title": "Priority Class Name",
+      "description": "Priority class name for the pod."
+    },
+    "networkPolicy": {
+      "type": "object",
+      "title": "Network Policy",
+      "description": "NetworkPolicy for the WireGuard pod. Disabled by default.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled",
+          "description": "Create a NetworkPolicy for the WireGuard pod."
+        },
+        "allowExternalEgress": {
+          "type": "boolean",
+          "title": "Allow External Egress",
+          "description": "Allow UDP egress to the public Internet (needed for peer/server endpoint connectivity)."
+        },
+        "annotations": {
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional annotations for the NetworkPolicy."
+        },
+        "ingress": {
+          "type": "object",
+          "title": "Ingress Rules",
+          "additionalProperties": true,
+          "properties": {
+            "from": {
+              "type": "array",
+              "title": "Allowed Ingress Sources",
+              "description": "Allowed ingress sources for the WireGuard UDP port (server mode only). Empty = allow from anywhere.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "extraRules": {
+              "type": "array",
+              "title": "Extra Ingress Rules",
+              "description": "Extra raw ingress rule blocks appended verbatim.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "egress": {
+          "type": "object",
+          "title": "Egress Rules",
+          "additionalProperties": true,
+          "properties": {
+            "extraRules": {
+              "type": "array",
+              "title": "Extra Egress Rules",
+              "description": "Extra raw egress rule blocks appended verbatim.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "title": "Pod Disruption Budget",
+      "description": "Pod disruption budget configuration (minAvailable or maxUnavailable).",
+      "additionalProperties": true,
+      "properties": {
+        "minAvailable": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "title": "Min Available"
+        },
+        "maxUnavailable": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "title": "Max Unavailable"
+        }
+      }
     }
   },
   "allOf": [

--- a/charts/wireguard/values.yaml
+++ b/charts/wireguard/values.yaml
@@ -19,6 +19,16 @@ nameOverride: ""
 ## @param fullnameOverride string Override the full chart name
 fullnameOverride: ""
 
+## @section Common metadata
+## @descriptionStart
+## Labels and annotations applied to all resources created by this chart.
+## @descriptionEnd
+
+## @param commonLabels object Labels applied to all resources (Deployment, Service, PVC, ServiceAccount, NetworkPolicy, ...)
+commonLabels: {}
+## @param commonAnnotations object Annotations applied to all resources
+commonAnnotations: {}
+
 ## @param replicaCount int Number of replicas for the deployment
 replicaCount: 1
 
@@ -390,3 +400,49 @@ tolerations: []
 
 ## @param affinity object Affinity rules for pod assignment
 affinity: {}
+
+## @param topologySpreadConstraints list Topology spread constraints for pods
+topologySpreadConstraints: []
+
+## @param priorityClassName string Priority class name for the pod
+priorityClassName: ""
+
+## @section NetworkPolicy
+## @descriptionStart
+## NetworkPolicy for the WireGuard pod. Disabled by default.
+## E.g.
+## ```yaml
+## networkPolicy:
+##   enabled: true
+##   ingress:
+##     from:
+##       - ipBlock:
+##           cidr: 0.0.0.0/0
+## ```
+## @descriptionEnd
+networkPolicy:
+  ## @param networkPolicy.enabled bool Create a NetworkPolicy for the WireGuard pod
+  enabled: false
+  ## @param networkPolicy.allowExternalEgress bool Allow UDP egress to the public Internet (needed for peer/server endpoint connectivity)
+  allowExternalEgress: true
+  ## @param networkPolicy.annotations object Additional annotations for the NetworkPolicy
+  annotations: {}
+  ingress:
+    ## @param networkPolicy.ingress.from list Allowed ingress sources for the WireGuard UDP port (server mode only). Empty = allow from anywhere
+    from: []
+    ## @param networkPolicy.ingress.extraRules list Extra raw ingress rule blocks appended verbatim
+    extraRules: []
+  egress:
+    ## @param networkPolicy.egress.extraRules list Extra raw egress rule blocks appended verbatim
+    extraRules: []
+
+## @section Pod Disruption Budget
+## @param podDisruptionBudget object Pod disruption budget configuration (minAvailable or maxUnavailable)
+## E.g.
+## ```yaml
+## podDisruptionBudget:
+##   minAvailable: 1
+##   # or
+##   maxUnavailable: 1
+## ```
+podDisruptionBudget: {}


### PR DESCRIPTION
## Summary

Phase 2 of the chart audit plan: brings the `wireguard` chart to feature parity with `wordpress` for cross-cutting concerns.

- **commonLabels / commonAnnotations**: new `values.yaml` sections, propagated to all resources (Deployment, Service, PVC, ServiceAccount, Secret, HPA, NetworkPolicy, PDB) via the shared `wireguard.labels` helper / `merge` with resource-specific annotations.
- **NetworkPolicy** (`networkPolicy.enabled`, default `false`):
  - Ingress: UDP on `service.port`, server mode only (`networkPolicy.ingress.from` to restrict sources, default = allow from anywhere)
  - Egress: DNS to `kube-system` always allowed; `networkPolicy.allowExternalEgress` (default `true`) allows UDP egress to `0.0.0.0/0` for peer/server endpoint connectivity (no port restriction since the endpoint port is user-defined)
  - `networkPolicy.ingress.extraRules` / `networkPolicy.egress.extraRules` escape hatches
- **PodDisruptionBudget** (`podDisruptionBudget.{minAvailable,maxUnavailable}`, opt-in via non-empty config), 1:1 pattern from wordpress
- **topologySpreadConstraints** / **priorityClassName** passthrough on the pod spec
- Minor consistency fix: `templates/secrets.yaml` now uses the shared `wireguard.labels` helper instead of a standalone `release: <fullname>` label (this label wasn't used by any selector)
- `values.schema.json` updated for all new fields; new sample snippets `samples/commonLabels.values.yaml`, `samples/networkpolicy.values.yaml`; `readme.md` documents the new "Advanced Configuration" options

## Why `feat:`

Purely additive, backwards-compatible new optional features → minor bump.

## Validation

- `helm lint` / `helm lint --strict` clean (default values, server sample, client sample)
- `helm template` rendered for: defaults, server mode + networkPolicy + commonLabels, client mode + networkPolicy + commonLabels, server + PDB (`maxUnavailable`), server + topologySpreadConstraints + priorityClassName
- `kubectl apply --dry-run=server` against a live cluster for the rendered NetworkPolicy and PodDisruptionBudget (server mode and client mode) — both validate cleanly against the K8s API schema
- `values.schema.json` validated as well-formed JSON

## Test plan

- [ ] CI: `pr-chart-validate` (lint/template) green
- [ ] `helm template` diff reviewed — no changes to existing rendered output unless `commonLabels`/`commonAnnotations`/`networkPolicy`/`podDisruptionBudget`/`topologySpreadConstraints`/`priorityClassName` are set