### PR TITLE
feat(wg-easy): feature parity - NetworkPolicy, PDB, commonLabels/Annotations, scheduling

### DIFF
--- a/charts/wg-easy/readme.md
+++ b/charts/wg-easy/readme.md
@@ -100,3 +100,27 @@ kubectl apply -f ./samples/namespace.yaml
 kubectl apply -f ./samples/advanced.secrets.yaml
 helm install wgeasy oci://ghcr.io/slybase/charts/wg-easy --values ./samples/advanced.values.yaml -n wg-easy
 ```
+
+## Advanced Configuration
+
+### Common Labels and Annotations
+
+`commonLabels` and `commonAnnotations` are applied to every resource created by this chart (StatefulSet, Services, PVC, ServiceAccount, NetworkPolicy, ...). Useful for GitOps (ArgoCD), cost allocation, and audit. See `samples/commonLabels.values.yaml` for an example.
+
+### NetworkPolicy
+
+The chart can create a `NetworkPolicy` to restrict traffic to/from the wg-easy pod (disabled by default via `networkPolicy.enabled: false`):
+
+- **Ingress**: allows UDP traffic to the WireGuard port (`service.wireguard.port`) and TCP traffic to the Web UI/metrics port (`service.ui.port`). By default, traffic is allowed from anywhere; restrict it with `networkPolicy.ingress.from`.
+- **Egress**: always allows DNS lookups to `kube-system`. `networkPolicy.allowExternalEgress` (default `true`) additionally allows UDP egress to `0.0.0.0/0`, required for peer connectivity.
+- `networkPolicy.ingress.extraRules` / `networkPolicy.egress.extraRules` allow appending raw NetworkPolicy rule blocks.
+
+See `samples/networkpolicy.values.yaml` for an example.
+
+### Pod Disruption Budget
+
+Set `podDisruptionBudget.minAvailable` or `podDisruptionBudget.maxUnavailable` to create a `PodDisruptionBudget` for the StatefulSet. Empty (default) disables it.
+
+### Topology Spread Constraints and Priority Class
+
+`topologySpreadConstraints` and `priorityClassName` are passed through to the pod spec for advanced scheduling control.

--- a/charts/wg-easy/samples/commonLabels.values.yaml
+++ b/charts/wg-easy/samples/commonLabels.values.yaml
@@ -1,0 +1,12 @@
+## Snippet: commonLabels and commonAnnotations — add these values to your existing values file.
+## These are applied to ALL Kubernetes resources created by the chart.
+## Useful for GitOps (ArgoCD), service mesh, cost allocation, and audit.
+
+commonLabels:
+  team: platform
+  environment: production
+  app.kubernetes.io/part-of: my-stack
+
+commonAnnotations:
+  owner: platform-team
+  contact: platform@example.com

--- a/charts/wg-easy/samples/networkpolicy.values.yaml
+++ b/charts/wg-easy/samples/networkpolicy.values.yaml
@@ -1,0 +1,14 @@
+## Snippet: NetworkPolicy — add these values to your existing values file.
+## Restricts ingress/egress traffic for the wg-easy pod.
+
+networkPolicy:
+  enabled: true
+  # Restrict who may reach the WireGuard UDP port and the Web UI/metrics port.
+  # Empty = allow from anywhere (typical for a VPN endpoint exposed via NodePort/LoadBalancer).
+  ingress:
+    from: []
+    extraRules: []
+  # Allow UDP egress to the public internet (required for peer connectivity)
+  allowExternalEgress: true
+  egress:
+    extraRules: []

--- a/charts/wg-easy/templates/_helpers.tpl
+++ b/charts/wg-easy/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "wg-easy.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/wg-easy/templates/hpa.yaml
+++ b/charts/wg-easy/templates/hpa.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/wg-easy/templates/ingress.yaml
+++ b/charts/wg-easy/templates/ingress.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wg-easy.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+  {{- $ingAnnotations := merge (dict) (.Values.ingress.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $ingAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wg-easy/templates/networkpolicy.yaml
+++ b/charts/wg-easy/templates/networkpolicy.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "wg-easy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- $npAnnotations := merge (dict) (.Values.networkPolicy.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $npAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "wg-easy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: {{ .Values.service.wireguard.port }}
+          protocol: UDP
+        - port: {{ .Values.service.ui.port }}
+          protocol: TCP
+      {{- with .Values.networkPolicy.ingress.from }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.networkPolicy.ingress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- if .Values.networkPolicy.allowExternalEgress }}
+    # WireGuard UDP egress (peer connectivity)
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: UDP
+    {{- end }}
+    {{- with .Values.networkPolicy.egress.extraRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/wg-easy/templates/pdb.yaml
+++ b/charts/wg-easy/templates/pdb.yaml
@@ -1,0 +1,27 @@
+{{- if and (.Values.podDisruptionBudget) (or .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable) }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "wg-easy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "wg-easy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/wg-easy/templates/pvc.yaml
+++ b/charts/wg-easy/templates/pvc.yaml
@@ -4,11 +4,12 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ include "wg-easy.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.storage.labels }}
+  {{- $pvcLabels := merge (dict) (.Values.storage.labels | default dict) (.Values.commonLabels | default dict) }}
+  {{- with $pvcLabels }}
   labels:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- $ann := .Values.storage.annotations }}
+  {{- $ann := merge (dict) (.Values.storage.annotations | default dict) (.Values.commonAnnotations | default dict) }}
   {{- $rp := .Values.storage.resourcePolicy }}
   {{- if or $ann $rp }}
   annotations:

--- a/charts/wg-easy/templates/service.yaml
+++ b/charts/wg-easy/templates/service.yaml
@@ -5,7 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wg-easy.labels" . | nindent 4 }}
-  {{- with .Values.service.ui.annotations }}
+  {{- $uiAnnotations := merge (dict) (.Values.service.ui.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $uiAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -30,7 +31,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wg-easy.labels" . | nindent 4 }}
-  {{- with .Values.service.wireguard.annotations }}
+  {{- $wgAnnotations := merge (dict) (.Values.service.wireguard.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $wgAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wg-easy/templates/serviceaccount.yaml
+++ b/charts/wg-easy/templates/serviceaccount.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wg-easy.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- $saAnnotations := merge (dict) (.Values.serviceAccount.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+  {{- with $saAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/wg-easy/templates/servicemonitor.yaml
+++ b/charts/wg-easy/templates/servicemonitor.yaml
@@ -4,13 +4,15 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "wg-easy.fullname" . }}
   namespace: {{ .Release.Namespace }}
-{{ if .Values.serviceMonitor.labels }}
+  {{- $smLabels := merge (dict) (.Values.serviceMonitor.labels | default dict) (.Values.commonLabels | default dict) }}
+{{ if $smLabels }}
   labels:
-{{ toYaml .Values.serviceMonitor.labels | nindent 4 }}
+{{ toYaml $smLabels | nindent 4 }}
 {{ end }}
-{{ if .Values.serviceMonitor.annotations }}
+  {{- $smAnnotations := merge (dict) (.Values.serviceMonitor.annotations | default dict) (.Values.commonAnnotations | default dict) }}
+{{ if $smAnnotations }}
   annotations:
-{{ toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+{{ toYaml $smAnnotations | nindent 4 }}
 {{ end }}
 spec:
   {{ if .Values.serviceMonitor.selector }}

--- a/charts/wg-easy/templates/statefulset.yaml
+++ b/charts/wg-easy/templates/statefulset.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "wg-easy.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
@@ -206,4 +210,11 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/charts/wg-easy/values.schema.json
+++ b/charts/wg-easy/values.schema.json
@@ -100,6 +100,16 @@
       "type": "string",
       "description": "Override the full resource name used for Kubernetes objects."
     },
+    "commonLabels": {
+      "type": "object",
+      "title": "Common Labels",
+      "description": "Labels applied to all resources created by this chart (StatefulSet, Services, PVC, ServiceAccount, NetworkPolicy, ...)."
+    },
+    "commonAnnotations": {
+      "type": "object",
+      "title": "Common Annotations",
+      "description": "Annotations applied to all resources created by this chart."
+    },
     "initContainers": {
       "type": "array",
       "title": "Init Containers",
@@ -939,6 +949,105 @@
       "title": "Affinity",
       "type": "object",
       "description": "Affinity and anti-affinity rules for pod scheduling."
+    },
+    "topologySpreadConstraints": {
+      "type": "array",
+      "title": "Topology Spread Constraints",
+      "description": "Topology spread constraints for pod scheduling.",
+      "items": {
+        "type": "object"
+      }
+    },
+    "priorityClassName": {
+      "type": "string",
+      "title": "Priority Class Name",
+      "description": "Priority class name for the pod."
+    },
+    "networkPolicy": {
+      "type": "object",
+      "title": "Network Policy",
+      "description": "NetworkPolicy for the wg-easy pod. Disabled by default.",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "title": "Enabled",
+          "description": "Create a NetworkPolicy for the wg-easy pod."
+        },
+        "allowExternalEgress": {
+          "type": "boolean",
+          "title": "Allow External Egress",
+          "description": "Allow UDP egress to the public Internet (needed for peer connectivity)."
+        },
+        "annotations": {
+          "type": "object",
+          "title": "Annotations",
+          "description": "Additional annotations for the NetworkPolicy."
+        },
+        "ingress": {
+          "type": "object",
+          "title": "Ingress Rules",
+          "additionalProperties": true,
+          "properties": {
+            "from": {
+              "type": "array",
+              "title": "Allowed Ingress Sources",
+              "description": "Allowed ingress sources for the WireGuard UDP and Web UI/metrics ports. Empty = allow from anywhere.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "extraRules": {
+              "type": "array",
+              "title": "Extra Ingress Rules",
+              "description": "Extra raw ingress rule blocks appended verbatim.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "egress": {
+          "type": "object",
+          "title": "Egress Rules",
+          "additionalProperties": true,
+          "properties": {
+            "extraRules": {
+              "type": "array",
+              "title": "Extra Egress Rules",
+              "description": "Extra raw egress rule blocks appended verbatim.",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        }
+      }
+    },
+    "podDisruptionBudget": {
+      "type": "object",
+      "title": "Pod Disruption Budget",
+      "description": "Pod disruption budget configuration (minAvailable or maxUnavailable).",
+      "additionalProperties": true,
+      "properties": {
+        "minAvailable": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "title": "Min Available"
+        },
+        "maxUnavailable": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "title": "Max Unavailable"
+        }
+      }
     }
   },
   "allOf": [

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -21,6 +21,16 @@ nameOverride: ""
 ## @param fullnameOverride string Override the full chart name
 fullnameOverride: ""
 
+## @section Common metadata
+## @descriptionStart
+## Labels and annotations applied to all resources created by this chart.
+## @descriptionEnd
+
+## @param commonLabels object Labels applied to all resources (StatefulSet, Services, PVC, ServiceAccount, NetworkPolicy, ...)
+commonLabels: {}
+## @param commonAnnotations object Annotations applied to all resources
+commonAnnotations: {}
+
 ## @section DNS configuration
 ## @descriptionStart
 ## DNS policy and configuration of the pod.
@@ -431,3 +441,49 @@ tolerations: []
 
 ## @param affinity object Affinity rules for pod assignment
 affinity: {}
+
+## @param topologySpreadConstraints list Topology spread constraints for pods
+topologySpreadConstraints: []
+
+## @param priorityClassName string Priority class name for the pod
+priorityClassName: ""
+
+## @section NetworkPolicy
+## @descriptionStart
+## NetworkPolicy for the wg-easy pod. Disabled by default.
+## E.g.
+## ```yaml
+## networkPolicy:
+##   enabled: true
+##   ingress:
+##     from:
+##       - ipBlock:
+##           cidr: 0.0.0.0/0
+## ```
+## @descriptionEnd
+networkPolicy:
+  ## @param networkPolicy.enabled bool Create a NetworkPolicy for the wg-easy pod
+  enabled: false
+  ## @param networkPolicy.allowExternalEgress bool Allow UDP egress to the public Internet (needed for peer connectivity)
+  allowExternalEgress: true
+  ## @param networkPolicy.annotations object Additional annotations for the NetworkPolicy
+  annotations: {}
+  ingress:
+    ## @param networkPolicy.ingress.from list Allowed ingress sources for the WireGuard UDP and Web UI/metrics ports. Empty = allow from anywhere
+    from: []
+    ## @param networkPolicy.ingress.extraRules list Extra raw ingress rule blocks appended verbatim
+    extraRules: []
+  egress:
+    ## @param networkPolicy.egress.extraRules list Extra raw egress rule blocks appended verbatim
+    extraRules: []
+
+## @section Pod Disruption Budget
+## @param podDisruptionBudget object Pod disruption budget configuration (minAvailable or maxUnavailable)
+## E.g.
+## ```yaml
+## podDisruptionBudget:
+##   minAvailable: 1
+##   # or
+##   maxUnavailable: 1
+## ```
+podDisruptionBudget: {}


### PR DESCRIPTION
## Summary

Brings the wg-easy chart to feature parity with the wireguard chart (Phase 2 of the chart audit, see [#384](https://github.com/SlyBase/helm-charts/pull/384) for the wireguard equivalent):

- **commonLabels / commonAnnotations**: new `commonLabels` and `commonAnnotations` values, applied to all chart resources (StatefulSet, Services, PVC, ServiceAccount, NetworkPolicy, PDB, ServiceMonitor, Ingress).
- **NetworkPolicy** (new, opt-in via `networkPolicy.enabled`): restricts ingress to the WireGuard UDP port (`service.wireguard.port`) and the Web UI/metrics TCP port (`service.ui.port`); always allows DNS egress to `kube-system`; optional `allowExternalEgress` (default `true`) for UDP egress to `0.0.0.0/0` (peer connectivity); `extraRules` escape hatches for ingress/egress.
- **PodDisruptionBudget** (new, opt-in via `podDisruptionBudget.minAvailable`/`maxUnavailable`).
- **topologySpreadConstraints** / **priorityClassName**: passthrough to the StatefulSet pod spec.
- New samples: `samples/commonLabels.values.yaml`, `samples/networkpolicy.values.yaml`.
- `readme.md`: new "Advanced Configuration" section documenting all of the above.
- `values.schema.json`: schema entries for all new values (root schema has `additionalProperties: false`, so these were required for `helm lint`/`helm template` to keep validating).

## Why `feat:`

Adds new optional features (NetworkPolicy, PDB, commonLabels/commonAnnotations, scheduling controls) without changing any existing defaults or behavior → minor version bump.

## Validation

- `helm lint charts/wg-easy --strict` — passes
- `helm template` with default values, and with `samples/networkpolicy.values.yaml` + `samples/commonLabels.values.yaml` + PDB + ServiceMonitor enabled — renders cleanly
- `kubectl apply --dry-run=server` against a live cluster for the rendered NetworkPolicy and PodDisruptionBudget — both validate against the K8s API

## Test plan

- [ ] CI: yamllint / Helm Lint / chart-validate workflow
- [ ] Manual: `helm template` with `networkPolicy.enabled=true` and `podDisruptionBudget.minAvailable=1`