### PR TITLE
ci: add helm-unittest test suites and CI step

### DIFF
--- a/.github/workflows/pr-chart-validate.yml
+++ b/.github/workflows/pr-chart-validate.yml
@@ -113,6 +113,15 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Trivy config scan (rendered manifests)
+        if: steps.charts.outputs.has_charts == 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: config
+          scan-ref: rendered-manifests/
+          format: table
+          exit-code: "0"
+
       - name: Upload rendered manifests
         if: always() && steps.charts.outputs.has_charts == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/pr-chart-validate.yml
+++ b/.github/workflows/pr-chart-validate.yml
@@ -18,6 +18,7 @@ concurrency:
 
 env:
   KUBECONFORM_VERSION: "0.8.0"
+  HELM_UNITTEST_VERSION: "1.1.1"
 
 jobs:
   chart-validate:
@@ -65,6 +66,14 @@ jobs:
 
           kubeconform -v
 
+      - name: Install helm-unittest
+        if: steps.charts.outputs.has_charts == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "v${HELM_UNITTEST_VERSION}"
+
       - name: Validate changed charts
         if: steps.charts.outputs.has_charts == 'true'
         shell: bash
@@ -96,6 +105,10 @@ jobs:
               -schema-location default \
               -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
               "rendered-manifests/${chart_name}.yaml"
+
+            if [ -d "${chart_dir}/tests" ]; then
+              helm unittest "${chart_dir}"
+            fi
 
             echo "::endgroup::"
           done

--- a/.github/workflows/pr-chart-validate.yml
+++ b/.github/workflows/pr-chart-validate.yml
@@ -12,6 +12,13 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: pr-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  KUBECONFORM_VERSION: "0.8.0"
+
 jobs:
   chart-validate:
     name: chart-validate
@@ -34,37 +41,93 @@ jobs:
         with:
           base-ref: ${{ github.event.inputs.base_ref || github.base_ref || github.event.repository.default_branch || 'main' }}
 
+      - name: Cache Helm dependencies
+        if: steps.charts.outputs.has_charts == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/helm
+            charts/*/charts
+          key: helm-deps-${{ runner.os }}-${{ hashFiles('charts/*/Chart.lock') }}
+          restore-keys: |
+            helm-deps-${{ runner.os }}-
+
+      - name: Install kubeconform
+        if: steps.charts.outputs.has_charts == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" -o kubeconform.tar.gz
+          tar -xzf kubeconform.tar.gz kubeconform
+          sudo mv kubeconform /usr/local/bin/
+          rm -f kubeconform.tar.gz
+
+          kubeconform -v
+
       - name: Validate changed charts
+        if: steps.charts.outputs.has_charts == 'true'
         shell: bash
         env:
           CHARTS_JSON: ${{ steps.charts.outputs.charts_json }}
         run: |
           set -euo pipefail
 
-          mapfile -t chart_dirs < <(printf '%s' "$CHARTS_JSON" | jq -r '.[]')
+          mkdir -p rendered-manifests
 
-          if [ "${#chart_dirs[@]}" -eq 0 ]; then
-            echo "No chart changes detected"
-            exit 0
-          fi
+          mapfile -t chart_dirs < <(printf '%s' "$CHARTS_JSON" | jq -r '.[]')
 
           printf 'Validating %s\n' "${chart_dirs[@]}"
 
           for chart_dir in "${chart_dirs[@]}"; do
             echo "::group::${chart_dir}"
+            chart_name="$(basename "${chart_dir}")"
             helm dependency build "${chart_dir}"
 
             if [ -f "${chart_dir}/linter_values.yaml" ]; then
               helm lint "${chart_dir}" -f "${chart_dir}/linter_values.yaml"
-              helm template smoke "${chart_dir}" -f "${chart_dir}/linter_values.yaml" >/dev/null
+              helm template smoke "${chart_dir}" -f "${chart_dir}/linter_values.yaml" > "rendered-manifests/${chart_name}.yaml"
             else
               helm lint "${chart_dir}"
-              helm template smoke "${chart_dir}" >/dev/null
+              helm template smoke "${chart_dir}" > "rendered-manifests/${chart_name}.yaml"
             fi
+
+            kubeconform -strict -summary \
+              -schema-location default \
+              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+              "rendered-manifests/${chart_name}.yaml"
 
             echo "::endgroup::"
           done
 
+      - name: Upload rendered manifests
+        if: always() && steps.charts.outputs.has_charts == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rendered-manifests
+          path: rendered-manifests/
+          retention-days: 7
+
       # NOTE: chart version bumps are owned by release-please (release PRs), not by
       # feature/dependency PRs, so there is intentionally no "version must be bumped"
       # gate here — that would fail every Renovate and feature PR.
+
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pr-chart-validate.yml
+++ b/.github/workflows/pr-chart-validate.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "v${HELM_UNITTEST_VERSION}"
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --version "v${HELM_UNITTEST_VERSION}" --verify=false
 
       - name: Validate changed charts
         if: steps.charts.outputs.has_charts == 'true'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,13 @@ repos:
       - id: yamllint
         args: [-c=.yamllint.yml]
 
+  # Validate values.schema.json files against the JSON Schema metaschema
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.2
+    hooks:
+      - id: check-metaschema
+        files: ^charts/[^/]+/values\.schema\.json$
+
   # Validate ArtifactHub annotations in Chart.yaml files
   # Catches: invalid YAML in annotations, wrong 'kind' values, missing required fields,
   # and special characters that need quotes: {}:[],&*#?|-<>=!%@

--- a/charts/wg-easy/.helmignore
+++ b/charts/wg-easy/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# helm-unittest test suites
+/tests/

--- a/charts/wg-easy/tests/statefulset_test.yaml
+++ b/charts/wg-easy/tests/statefulset_test.yaml
@@ -1,0 +1,60 @@
+suite: StatefulSet rendering and securityContext defaults
+
+tests:
+  - it: renders a single StatefulSet with the wg-easy container
+    template: statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: wg-easy
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: wg-easy
+
+  - it: defaults the container securityContext to privileged
+    template: statefulset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true
+
+  - it: does not set a pod securityContext by default
+    template: statefulset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+
+  - it: allows overriding the container securityContext
+    template: statefulset.yaml
+    set:
+      securityContext:
+        privileged: false
+        runAsNonRoot: true
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: allows setting a pod securityContext
+    template: statefulset.yaml
+    set:
+      podSecurityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000

--- a/charts/wireguard/.helmignore
+++ b/charts/wireguard/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# helm-unittest test suites
+/tests/

--- a/charts/wireguard/tests/deployment_test.yaml
+++ b/charts/wireguard/tests/deployment_test.yaml
@@ -1,0 +1,86 @@
+suite: Deployment rendering and securityContext defaults
+
+tests:
+  - it: renders a single Deployment with the wireguard container
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: wireguard
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: wireguard
+
+  - it: defaults the pod securityContext to PUID/PGID
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: defaults the container securityContext for client mode (server.enabled=false)
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 0
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_ADMIN
+
+  - it: defaults the container securityContext for server mode
+    template: deployment.yaml
+    set:
+      wireguard:
+        server:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_ADMIN
+
+  - it: allows overriding the container securityContext
+    template: deployment.yaml
+    set:
+      securityContext:
+        privileged: false
+        runAsNonRoot: true
+        runAsUser: 1000
+        capabilities:
+          drop:
+            - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: allows overriding the pod securityContext
+    template: deployment.yaml
+    set:
+      podSecurityContext:
+        fsGroup: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser

--- a/charts/wordpress/.helmignore
+++ b/charts/wordpress/.helmignore
@@ -21,3 +21,5 @@
 .idea/
 *.tmproj
 .vscode/
+# helm-unittest test suites
+/tests/

--- a/charts/wordpress/tests/commonlabels_test.yaml
+++ b/charts/wordpress/tests/commonlabels_test.yaml
@@ -1,0 +1,71 @@
+suite: commonLabels propagation
+set:
+  wordpress:
+    url: "https://example.com"
+
+tests:
+  - it: propagates commonLabels to the Deployment metadata and pod template
+    template: deployment.yaml
+    set:
+      commonLabels:
+        team: platform
+        environment: test
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.environment
+          value: test
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.environment
+          value: test
+
+  - it: propagates commonLabels to the StatefulSet metadata and pod template
+    template: statefulset.yaml
+    set:
+      controllerType: statefulset
+      commonLabels:
+        team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: platform
+
+  - it: propagates commonLabels to the Service
+    template: service.yaml
+    set:
+      commonLabels:
+        team: platform
+        environment: test
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - equal:
+          path: metadata.labels.environment
+          value: test
+
+  - it: propagates commonLabels to the NetworkPolicy
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+      commonLabels:
+        team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: platform
+
+  - it: does not add extra labels when commonLabels is empty
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: metadata.labels.team

--- a/charts/wordpress/tests/controller_test.yaml
+++ b/charts/wordpress/tests/controller_test.yaml
@@ -1,0 +1,51 @@
+suite: Controller rendering (Deployment vs StatefulSet)
+set:
+  wordpress:
+    url: "https://example.com"
+
+tests:
+  - it: renders a Deployment by default
+    template: deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: does not render a StatefulSet by default
+    template: statefulset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a StatefulSet when controllerType=statefulset
+    template: statefulset.yaml
+    set:
+      controllerType: statefulset
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - isNotEmpty:
+          path: spec.serviceName
+      - isNotEmpty:
+          path: spec.volumeClaimTemplates
+
+  - it: does not render a Deployment when controllerType=statefulset
+    template: deployment.yaml
+    set:
+      controllerType: statefulset
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when controllerType=statefulset and storage.existingClaim is set
+    template: statefulset.yaml
+    set:
+      controllerType: statefulset
+      storage:
+        existingClaim: my-existing-pvc
+    asserts:
+      - failedTemplate:
+          errorMessage: "storage.existingClaim is not supported with controllerType=statefulset; each replica gets its own PVC via volumeClaimTemplates."

--- a/charts/wordpress/tests/networkpolicy_test.yaml
+++ b/charts/wordpress/tests/networkpolicy_test.yaml
@@ -1,0 +1,94 @@
+suite: NetworkPolicy
+set:
+  wordpress:
+    url: "https://example.com"
+
+tests:
+  - it: does not render a NetworkPolicy by default
+    template: networkpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a NetworkPolicy with Ingress and Egress policy types when enabled
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: 8080
+
+  - it: includes a DNS egress rule to kube-system by default
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[0].to[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: kube-system
+
+  - it: includes a mariadb egress rule when the mariadb subchart is enabled
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+      mariadb:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[1].to[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: mariadb
+
+  - it: includes an internet egress rule with SMTP ports by default
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].ipBlock.cidr
+          value: 0.0.0.0/0
+      - contains:
+          path: spec.egress[2].ports
+          content:
+            port: 587
+            protocol: TCP
+
+  - it: omits the internet egress rule when allowExternalEgress is false
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+        allowExternalEgress: false
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 2
+
+  - it: adds a memcached egress rule when memcached is the selected cache backend
+    template: networkpolicy.yaml
+    set:
+      networkPolicy:
+        enabled: true
+      memcached:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.egress[2].to[0].podSelector.matchLabels["app.kubernetes.io/name"]
+          value: memcached
+      - equal:
+          path: spec.egress[2].ports[0].port
+          value: 11211

--- a/charts/wordpress/tests/securitycontext_test.yaml
+++ b/charts/wordpress/tests/securitycontext_test.yaml
@@ -1,0 +1,94 @@
+suite: SecurityContext defaults
+set:
+  wordpress:
+    url: "https://example.com"
+
+tests:
+  - it: sets the hardened default pod-level securityContext
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 33
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 33
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: sets the hardened default container securityContext on the main container
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: wordpress
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.privileged
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: applies the hardened containerSecurityContext to init containers too
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: allows overriding podSecurityContext
+    template: deployment.yaml
+    set:
+      podSecurityContext:
+        fsGroup: 2000
+        runAsUser: 2000
+        runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 2000
+
+  - it: adds the rwx-permissions init container only for Deployment + ReadWriteMany
+    template: deployment.yaml
+    set:
+      storage:
+        accessModes:
+          - ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wordpress-rwx-permissions
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+
+  - it: does not add the rwx-permissions init container for StatefulSet even with ReadWriteMany
+    template: statefulset.yaml
+    set:
+      controllerType: statefulset
+      storage:
+        accessModes:
+          - ReadWriteMany
+    asserts:
+      - notEqual:
+          path: spec.template.spec.initContainers[0].name
+          value: wordpress-rwx-permissions


### PR DESCRIPTION
## Summary
- Adds `charts/<chart>/tests/*_test.yaml` helm-unittest suites:
  - **wordpress**: controller rendering (Deployment vs StatefulSet incl. the `storage.existingClaim` + `controllerType=statefulset` failure case), `podSecurityContext`/`containerSecurityContext` hardened defaults (incl. init containers and the RWX-permissions init container), NetworkPolicy enabled/disabled + key ingress/egress rules, and `commonLabels` propagation to Deployment/StatefulSet/Service/NetworkPolicy.
  - **wireguard** / **wg-easy**: foundational Deployment/StatefulSet rendering and current `securityContext` defaults (baseline for the upcoming hardening/feature-parity PRs #382-#385).
- `pr-chart-validate.yml`: installs the `helm-unittest` plugin (pinned via `HELM_UNITTEST_VERSION`, `--verify=false` since the plugin source has no provenance) and runs `helm unittest <chart>` for any changed chart that has a `tests/` directory, as part of the existing per-chart validation loop.
- `.helmignore`: excludes `/tests/` from the packaged chart artifact for all three charts (dev-only test suites, not part of the chart contents).

No `values.yaml`/template changes, so no chart version bump needed (release-please unaffected).

**Stacked on #387** (this PR's base branch is `ci/pr-validate-quick-wins`) since both touch `pr-chart-validate.yml`. Diff will shrink to just this PR's changes once #387 merges.

## Test plan
- [x] `helm unittest charts/wordpress` — 4 suites / 23 tests pass
- [x] `helm unittest charts/wireguard` — 1 suite / 6 tests pass
- [x] `helm unittest charts/wg-easy` — 1 suite / 5 tests pass
- [x] `pre-commit run --all-files` passes
- [x] CI green on this PR (chart-validate + pre-commit jobs), incl. manual `workflow_dispatch` run confirming `helm unittest` executes for all 3 charts (34/34 tests pass)