### PR TITLE
ci: add Trivy config scan as non-blocking report step

### DIFF
--- a/.github/workflows/pr-chart-validate.yml
+++ b/.github/workflows/pr-chart-validate.yml
@@ -113,6 +113,15 @@ jobs:
             echo "::endgroup::"
           done
 
+      - name: Trivy config scan (rendered manifests)
+        if: steps.charts.outputs.has_charts == 'true'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: config
+          scan-ref: rendered-manifests/
+          format: table
+          exit-code: "0"
+
       - name: Upload rendered manifests
         if: always() && steps.charts.outputs.has_charts == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Summary
- Adds a Trivy `config` scan (Aqua Security `trivy-action`) over the rendered manifests for changed charts, run as a non-blocking report step (`exit-code: "0"`) in `pr-chart-validate.yml`.
- Surfaces Kubernetes manifest misconfigurations (missing resource limits, privileged containers, etc.) in the job log without failing PRs.

This is Phase 4c (part 1/2) of the CI/CD hardening plan — stacked on #388 (which is stacked on #387) since it extends the same `pr-chart-validate.yml` "Validate changed charts" step that produces `rendered-manifests/`.

## Test plan
- [x] `actionlint` / `yamllint` pass
- [x] Verified via manual `workflow_dispatch` (base_ref=main): both jobs green, Trivy step ran and reported `Tests: 156 (SUCCESSES: 101, FAILURES: 55)` / `Failures: 55 (UNKNOWN: 0, LOW: 33, MEDIUM: 13, HIGH: 9, CRITICAL: 0)` without failing the job — [run 27312864403](https://github.com/SlyBase/helm-charts/actions/runs/27312864403)