### PR TITLE
ci: time-box ignore for CVE-2025-68121 in apache-exporter image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,7 @@
+# CVE-2025-68121: Go stdlib crypto/tls cert validation issue
+# Affects docker.io/lusotycoon/apache-exporter:v1.0.12 (gobinary stdlib).
+# Sidecar is optional (metrics.apache.enabled: false by default) and
+# scraped over plain HTTP locally — TLS session resumption path not used.
+# No upstream apache_exporter image rebuild available yet (checked 2026-06-11).
+# Re-evaluate / remove after expiry.
+CVE-2025-68121 exp:2026-09-09


### PR DESCRIPTION
## Summary
- Adds a root `.trivyignore` with a time-boxed (90-day, expires 2026-09-09) entry for **CVE-2025-68121** (Go stdlib `crypto/tls` cert validation issue during TLS session resumption).
- This CVE is flagged by the new blocking image-vuln gate ([#391](https://github.com/SlyBase/helm-charts/pull/391)) in `docker.io/lusotycoon/apache-exporter:v1.0.12`, the image for the WordPress chart's optional Apache metrics sidecar (`metrics.apache.enabled: false` by default).
- No upstream `apache_exporter` image rebuild with the patched Go runtime exists yet, and this currently blocks **every** wordpress chart release at the `oci-release` Trivy gate (e.g. [run 27339422646](https://github.com/SlyBase/helm-charts/actions/runs/27339422646), `wordpress-v4.6.4`).

## Why this is acceptable
- The sidecar is opt-in and disabled by default.
- It only scrapes Apache `mod_status` over plain local HTTP — the TLS session-resumption code path affected by this CVE is not exercised.
- The ignore expires after 90 days, forcing a re-check for a fixed upstream image build.

## Test plan
- [x] `Helm Lint` pre-commit hook passed
- [ ] After merge, manually re-trigger the `oci-release.yaml` workflow (`workflow_dispatch`, `chart=wordpress`, `version=4.6.4`, `dry_run=false`) to publish the previously-failed `wordpress-v4.6.4` release