### PR TITLE
fix(wireguard): make SERVERPORT default to service.port

### DIFF
--- a/charts/wireguard/templates/deployment.yaml
+++ b/charts/wireguard/templates/deployment.yaml
@@ -127,7 +127,7 @@ spec:
             - name: SERVERURL
               value: {{ if .Values.wireguard.server.config.address }}"{{ .Values.wireguard.server.config.address }}"{{ else }}"auto"{{ end }}
             - name: SERVERPORT
-              value: "{{ .Values.wireguard.listenPort }}"
+              value: "{{ .Values.wireguard.listenPort | default .Values.service.port }}"
             - name: INTERNAL_SUBNET
               value: {{ if .Values.wireguard.server.config.subnet }}"{{ .Values.wireguard.server.config.subnet }}"{{ else }}"10.13.13.0/24"{{ end }}
             - name: PEER_DNS

--- a/charts/wireguard/values.schema.json
+++ b/charts/wireguard/values.schema.json
@@ -199,6 +199,11 @@
           "title": "Allowed IPs",
           "description": "IPs/networks reachable via VPN connection. Default: 0.0.0.0/0, ::0/0 (routes all traffic through VPN). For split tunneling, set only required networks including server WG IP."
         },
+        "listenPort": {
+          "type": "integer",
+          "title": "Listen Port",
+          "description": "Override the WireGuard listen port inside the container (server mode only). Defaults to service.port."
+        },
         "extraEnvVars": {
           "type": "array",
           "title": "Additional Environment Variables",

--- a/charts/wireguard/values.yaml
+++ b/charts/wireguard/values.yaml
@@ -146,6 +146,8 @@ wireguard:
   ## @param wireguard.existingSecret string Existing secret with full wg0.conf. NOTE: Overrides server/client config
   existingSecret: ""
 
+  ## @extra wireguard.listenPort int Override the WireGuard listen port inside the container (server mode only). Default: service.port
+
   ## @section Wireguard Server Mode
   server:
     ## @param wireguard.server.enabled bool Enable WireGuard server mode (mutually exclusive with client mode)


### PR DESCRIPTION
## Summary
- `templates/deployment.yaml` rendered the `SERVERPORT` env var from `wireguard.listenPort`, a key that has never existed in `values.yaml` / `values.schema.json`, so it always rendered as `value: ""`.
- The linuxserver/wireguard image silently falls back to its hardcoded default of `51820` when `SERVERPORT` is empty, which happens to match the chart's default `service.port: 51820` — so the default install works, but any non-default `service.port` results in the Service forwarding to a port WireGuard isn't actually listening on.
- `SERVERPORT` now defaults to `.Values.service.port` via `| default`, and `wireguard.listenPort` remains available as an optional explicit override (documented via `## @extra` and added to `values.schema.json`, following the existing pattern used for `wireguard.dns`/`wireguard.allowedIPs`).

## Test plan
- [x] `helm template ... --set wireguard.server.enabled=true` → `SERVERPORT` renders `"51820"` (default, unchanged)
- [x] `helm template ... --set wireguard.server.enabled=true --set service.port=12345` → `SERVERPORT` renders `"12345"` (was `""` before this fix)
- [x] `helm template ... --set wireguard.server.enabled=true --set service.port=12345 --set wireguard.listenPort=9999` → `SERVERPORT` renders `"9999"` (explicit override still works)
- [x] `helm lint charts/wireguard --strict`
- [x] `./charts/wireguard/samples/verify/verify.sh` against a live cluster — wg0 up, `wg show` reports listening port 51820 (expected with default `service.port`), 2 peers configured, Service smoke test OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)