### PR TITLE
ci: add workflow_dispatch to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Release Please workflow so it can be run manually via the GitHub UI or `gh workflow run release-please.yml`

## Why

When a release PR has merge conflicts (e.g. another chart's release was merged in the meantime and updated `.release-please-manifest.json`), re-triggering this workflow resolves the conflict automatically by having release-please rebase its PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)