### PR TITLE
chore: add rtk filters config and graphify output artifacts

### DIFF
--- a/.rtk/filters.toml
+++ b/.rtk/filters.toml
@@ -1,0 +1,13 @@
+# Project-local RTK filters — commit this file with your repo.
+# Filters here override user-global and built-in filters.
+# Docs: https://github.com/rtk-ai/rtk#custom-filters
+schema_version = 1
+
+# Example: suppress build noise from a custom tool
+# [filters.my-tool]
+# description = "Compact my-tool output"
+# match_command = "^my-tool\\s+build"
+# strip_ansi = true
+# strip_lines_matching = ["^\\s*$", "^Downloading", "^Installing"]
+# max_lines = 30
+# on_empty = "my-tool: ok"

--- a/graphify-out/.graphify_analysis.json
+++ b/graphify-out/.graphify_analysis.json
@@ -1,0 +1,1952 @@
+{
+  "communities": {
+    "0": [
+      "wg_easy_values_schema_config_additionalproperties",
+      "wg_easy_values_schema_config_properties",
+      "wg_easy_values_schema_config_required",
+      "wg_easy_values_schema_config_title",
+      "wg_easy_values_schema_config_type",
+      "wg_easy_values_schema_disable_ipv6_description",
+      "wg_easy_values_schema_disable_ipv6_title",
+      "wg_easy_values_schema_disable_ipv6_type",
+      "wg_easy_values_schema_dns_description",
+      "wg_easy_values_schema_dns_title",
+      "wg_easy_values_schema_dns_type",
+      "wg_easy_values_schema_existingsecret_description",
+      "wg_easy_values_schema_existingsecret_title",
+      "wg_easy_values_schema_existingsecret_type",
+      "wg_easy_values_schema_host_description",
+      "wg_easy_values_schema_host_title",
+      "wg_easy_values_schema_host_type",
+      "wg_easy_values_schema_init_additionalproperties",
+      "wg_easy_values_schema_init_properties",
+      "wg_easy_values_schema_init_required",
+      "wg_easy_values_schema_init_title",
+      "wg_easy_values_schema_init_type",
+      "wg_easy_values_schema_insecure_description",
+      "wg_easy_values_schema_insecure_title",
+      "wg_easy_values_schema_insecure_type",
+      "wg_easy_values_schema_ipv4_cidr_description",
+      "wg_easy_values_schema_ipv4_cidr_title",
+      "wg_easy_values_schema_ipv4_cidr_type",
+      "wg_easy_values_schema_ipv6_cidr_description",
+      "wg_easy_values_schema_ipv6_cidr_title",
+      "wg_easy_values_schema_ipv6_cidr_type",
+      "wg_easy_values_schema_password_description",
+      "wg_easy_values_schema_password_title",
+      "wg_easy_values_schema_password_type",
+      "wg_easy_values_schema_properties_config",
+      "wg_easy_values_schema_properties_disable_ipv6",
+      "wg_easy_values_schema_properties_dns",
+      "wg_easy_values_schema_properties_existingsecret",
+      "wg_easy_values_schema_properties_host",
+      "wg_easy_values_schema_properties_init",
+      "wg_easy_values_schema_properties_insecure",
+      "wg_easy_values_schema_properties_ipv4_cidr",
+      "wg_easy_values_schema_properties_ipv6_cidr",
+      "wg_easy_values_schema_properties_password",
+      "wg_easy_values_schema_properties_username",
+      "wg_easy_values_schema_username_description",
+      "wg_easy_values_schema_username_title",
+      "wg_easy_values_schema_username_type"
+    ],
+    "1": [
+      "wordpress_values_schema_accessmodes_default",
+      "wordpress_values_schema_accessmodes_description",
+      "wordpress_values_schema_accessmodes_type",
+      "wordpress_values_schema_annotations_description",
+      "wordpress_values_schema_annotations_type",
+      "wordpress_values_schema_automount_default",
+      "wordpress_values_schema_automount_description",
+      "wordpress_values_schema_automount_type",
+      "wordpress_values_schema_create_default",
+      "wordpress_values_schema_create_description",
+      "wordpress_values_schema_create_type",
+      "wordpress_values_schema_existingclaim_description",
+      "wordpress_values_schema_existingclaim_type",
+      "wordpress_values_schema_labels_description",
+      "wordpress_values_schema_labels_type",
+      "wordpress_values_schema_properties_accessmodes",
+      "wordpress_values_schema_properties_annotations",
+      "wordpress_values_schema_properties_automount",
+      "wordpress_values_schema_properties_create",
+      "wordpress_values_schema_properties_existingclaim",
+      "wordpress_values_schema_properties_labels",
+      "wordpress_values_schema_properties_resourcepolicy",
+      "wordpress_values_schema_properties_selector",
+      "wordpress_values_schema_properties_serviceaccount",
+      "wordpress_values_schema_properties_size",
+      "wordpress_values_schema_properties_storage",
+      "wordpress_values_schema_properties_storageclass",
+      "wordpress_values_schema_resourcepolicy_default",
+      "wordpress_values_schema_resourcepolicy_description",
+      "wordpress_values_schema_resourcepolicy_enum",
+      "wordpress_values_schema_resourcepolicy_type",
+      "wordpress_values_schema_selector_description",
+      "wordpress_values_schema_selector_type",
+      "wordpress_values_schema_serviceaccount_properties",
+      "wordpress_values_schema_serviceaccount_type",
+      "wordpress_values_schema_size_default",
+      "wordpress_values_schema_size_description",
+      "wordpress_values_schema_size_type",
+      "wordpress_values_schema_storage_properties",
+      "wordpress_values_schema_storage_type",
+      "wordpress_values_schema_storageclass_default",
+      "wordpress_values_schema_storageclass_description",
+      "wordpress_values_schema_storageclass_type"
+    ],
+    "2": [
+      "wireguard_values_schema_add_description",
+      "wireguard_values_schema_add_items",
+      "wireguard_values_schema_add_title",
+      "wireguard_values_schema_add_type",
+      "wireguard_values_schema_allowprivilegeescalation_description",
+      "wireguard_values_schema_allowprivilegeescalation_title",
+      "wireguard_values_schema_allowprivilegeescalation_type",
+      "wireguard_values_schema_capabilities_additionalproperties",
+      "wireguard_values_schema_capabilities_description",
+      "wireguard_values_schema_capabilities_properties",
+      "wireguard_values_schema_capabilities_title",
+      "wireguard_values_schema_capabilities_type",
+      "wireguard_values_schema_drop_description",
+      "wireguard_values_schema_drop_items",
+      "wireguard_values_schema_drop_title",
+      "wireguard_values_schema_drop_type",
+      "wireguard_values_schema_privileged_description",
+      "wireguard_values_schema_privileged_title",
+      "wireguard_values_schema_privileged_type",
+      "wireguard_values_schema_properties_add",
+      "wireguard_values_schema_properties_allowprivilegeescalation",
+      "wireguard_values_schema_properties_capabilities",
+      "wireguard_values_schema_properties_drop",
+      "wireguard_values_schema_properties_privileged",
+      "wireguard_values_schema_properties_readonlyrootfilesystem",
+      "wireguard_values_schema_properties_runasnonroot",
+      "wireguard_values_schema_properties_runasuser",
+      "wireguard_values_schema_properties_securitycontext",
+      "wireguard_values_schema_readonlyrootfilesystem_description",
+      "wireguard_values_schema_readonlyrootfilesystem_title",
+      "wireguard_values_schema_readonlyrootfilesystem_type",
+      "wireguard_values_schema_runasnonroot_description",
+      "wireguard_values_schema_runasnonroot_title",
+      "wireguard_values_schema_runasnonroot_type",
+      "wireguard_values_schema_runasuser_description",
+      "wireguard_values_schema_runasuser_title",
+      "wireguard_values_schema_runasuser_type",
+      "wireguard_values_schema_securitycontext_additionalproperties",
+      "wireguard_values_schema_securitycontext_description",
+      "wireguard_values_schema_securitycontext_properties",
+      "wireguard_values_schema_securitycontext_title",
+      "wireguard_values_schema_securitycontext_type"
+    ],
+    "3": [
+      "wg_easy_values_schema_add_description",
+      "wg_easy_values_schema_add_items",
+      "wg_easy_values_schema_add_title",
+      "wg_easy_values_schema_add_type",
+      "wg_easy_values_schema_allowprivilegeescalation_description",
+      "wg_easy_values_schema_allowprivilegeescalation_title",
+      "wg_easy_values_schema_allowprivilegeescalation_type",
+      "wg_easy_values_schema_capabilities_additionalproperties",
+      "wg_easy_values_schema_capabilities_properties",
+      "wg_easy_values_schema_capabilities_title",
+      "wg_easy_values_schema_capabilities_type",
+      "wg_easy_values_schema_drop_description",
+      "wg_easy_values_schema_drop_items",
+      "wg_easy_values_schema_drop_title",
+      "wg_easy_values_schema_drop_type",
+      "wg_easy_values_schema_privileged_description",
+      "wg_easy_values_schema_privileged_title",
+      "wg_easy_values_schema_privileged_type",
+      "wg_easy_values_schema_properties_add",
+      "wg_easy_values_schema_properties_allowprivilegeescalation",
+      "wg_easy_values_schema_properties_capabilities",
+      "wg_easy_values_schema_properties_drop",
+      "wg_easy_values_schema_properties_privileged",
+      "wg_easy_values_schema_properties_readonlyrootfilesystem",
+      "wg_easy_values_schema_properties_runasnonroot",
+      "wg_easy_values_schema_properties_runasuser",
+      "wg_easy_values_schema_properties_securitycontext",
+      "wg_easy_values_schema_readonlyrootfilesystem_description",
+      "wg_easy_values_schema_readonlyrootfilesystem_title",
+      "wg_easy_values_schema_readonlyrootfilesystem_type",
+      "wg_easy_values_schema_runasnonroot_description",
+      "wg_easy_values_schema_runasnonroot_title",
+      "wg_easy_values_schema_runasnonroot_type",
+      "wg_easy_values_schema_runasuser_description",
+      "wg_easy_values_schema_runasuser_title",
+      "wg_easy_values_schema_runasuser_type",
+      "wg_easy_values_schema_securitycontext_additionalproperties",
+      "wg_easy_values_schema_securitycontext_properties",
+      "wg_easy_values_schema_securitycontext_title",
+      "wg_easy_values_schema_securitycontext_type"
+    ],
+    "4": [
+      "wireguard_values_schema_enabled_default",
+      "wireguard_values_schema_enabled_description",
+      "wireguard_values_schema_enabled_title",
+      "wireguard_values_schema_enabled_type",
+      "wireguard_values_schema_failurethreshold_default",
+      "wireguard_values_schema_failurethreshold_title",
+      "wireguard_values_schema_failurethreshold_type",
+      "wireguard_values_schema_initialdelayseconds_default",
+      "wireguard_values_schema_initialdelayseconds_title",
+      "wireguard_values_schema_initialdelayseconds_type",
+      "wireguard_values_schema_livenessprobe_description",
+      "wireguard_values_schema_livenessprobe_properties",
+      "wireguard_values_schema_livenessprobe_title",
+      "wireguard_values_schema_livenessprobe_type",
+      "wireguard_values_schema_periodseconds_default",
+      "wireguard_values_schema_periodseconds_title",
+      "wireguard_values_schema_periodseconds_type",
+      "wireguard_values_schema_properties_enabled",
+      "wireguard_values_schema_properties_failurethreshold",
+      "wireguard_values_schema_properties_initialdelayseconds",
+      "wireguard_values_schema_properties_livenessprobe",
+      "wireguard_values_schema_properties_periodseconds",
+      "wireguard_values_schema_properties_readinessprobe",
+      "wireguard_values_schema_properties_startupprobe",
+      "wireguard_values_schema_properties_successthreshold",
+      "wireguard_values_schema_properties_timeoutseconds",
+      "wireguard_values_schema_readinessprobe_description",
+      "wireguard_values_schema_readinessprobe_properties",
+      "wireguard_values_schema_readinessprobe_title",
+      "wireguard_values_schema_readinessprobe_type",
+      "wireguard_values_schema_startupprobe_description",
+      "wireguard_values_schema_startupprobe_properties",
+      "wireguard_values_schema_startupprobe_title",
+      "wireguard_values_schema_startupprobe_type",
+      "wireguard_values_schema_successthreshold_default",
+      "wireguard_values_schema_successthreshold_title",
+      "wireguard_values_schema_successthreshold_type",
+      "wireguard_values_schema_timeoutseconds_default",
+      "wireguard_values_schema_timeoutseconds_title",
+      "wireguard_values_schema_timeoutseconds_type"
+    ],
+    "5": [
+      "wireguard_values_schema_externalips_default",
+      "wireguard_values_schema_externalips_description",
+      "wireguard_values_schema_externalips_items",
+      "wireguard_values_schema_externalips_title",
+      "wireguard_values_schema_externalips_type",
+      "wireguard_values_schema_localhostprofile_description",
+      "wireguard_values_schema_localhostprofile_type",
+      "wireguard_values_schema_nodeport_description",
+      "wireguard_values_schema_nodeport_title",
+      "wireguard_values_schema_nodeport_type",
+      "wireguard_values_schema_port_description",
+      "wireguard_values_schema_port_title",
+      "wireguard_values_schema_port_type",
+      "wireguard_values_schema_properties_externalips",
+      "wireguard_values_schema_properties_localhostprofile",
+      "wireguard_values_schema_properties_nodeport",
+      "wireguard_values_schema_properties_port",
+      "wireguard_values_schema_properties_seccompprofile",
+      "wireguard_values_schema_properties_service",
+      "wireguard_values_schema_properties_type",
+      "wireguard_values_schema_properties_updatestrategy",
+      "wireguard_values_schema_seccompprofile_additionalproperties",
+      "wireguard_values_schema_seccompprofile_description",
+      "wireguard_values_schema_seccompprofile_properties",
+      "wireguard_values_schema_seccompprofile_title",
+      "wireguard_values_schema_seccompprofile_type",
+      "wireguard_values_schema_service_description",
+      "wireguard_values_schema_service_properties",
+      "wireguard_values_schema_service_title",
+      "wireguard_values_schema_service_type",
+      "wireguard_values_schema_type_description",
+      "wireguard_values_schema_type_enum",
+      "wireguard_values_schema_type_title",
+      "wireguard_values_schema_type_type",
+      "wireguard_values_schema_updatestrategy_description",
+      "wireguard_values_schema_updatestrategy_properties",
+      "wireguard_values_schema_updatestrategy_title",
+      "wireguard_values_schema_updatestrategy_type"
+    ],
+    "6": [
+      "wordpress_values_schema_maxsurge_oneof",
+      "wordpress_values_schema_maxunavailable_oneof",
+      "wordpress_values_schema_persistentvolumeclaimretentionpolicy_description",
+      "wordpress_values_schema_persistentvolumeclaimretentionpolicy_properties",
+      "wordpress_values_schema_persistentvolumeclaimretentionpolicy_type",
+      "wordpress_values_schema_podmanagementpolicy_default",
+      "wordpress_values_schema_podmanagementpolicy_description",
+      "wordpress_values_schema_podmanagementpolicy_enum",
+      "wordpress_values_schema_podmanagementpolicy_type",
+      "wordpress_values_schema_properties_maxsurge",
+      "wordpress_values_schema_properties_maxunavailable",
+      "wordpress_values_schema_properties_persistentvolumeclaimretentionpolicy",
+      "wordpress_values_schema_properties_podmanagementpolicy",
+      "wordpress_values_schema_properties_rollingupdate",
+      "wordpress_values_schema_properties_statefulset",
+      "wordpress_values_schema_properties_type",
+      "wordpress_values_schema_properties_updatestrategy",
+      "wordpress_values_schema_properties_whendeleted",
+      "wordpress_values_schema_properties_whenscaled",
+      "wordpress_values_schema_rollingupdate_properties",
+      "wordpress_values_schema_rollingupdate_type",
+      "wordpress_values_schema_statefulset_description",
+      "wordpress_values_schema_statefulset_properties",
+      "wordpress_values_schema_statefulset_type",
+      "wordpress_values_schema_type_default",
+      "wordpress_values_schema_type_description",
+      "wordpress_values_schema_type_enum",
+      "wordpress_values_schema_type_type",
+      "wordpress_values_schema_updatestrategy_description",
+      "wordpress_values_schema_updatestrategy_properties",
+      "wordpress_values_schema_updatestrategy_type",
+      "wordpress_values_schema_whendeleted_default",
+      "wordpress_values_schema_whendeleted_enum",
+      "wordpress_values_schema_whendeleted_type",
+      "wordpress_values_schema_whenscaled_default",
+      "wordpress_values_schema_whenscaled_enum",
+      "wordpress_values_schema_whenscaled_type"
+    ],
+    "7": [
+      "wordpress_values_schema_apache_properties",
+      "wordpress_values_schema_apache_type",
+      "wordpress_values_schema_customdefaultsiteconfig_description",
+      "wordpress_values_schema_customdefaultsiteconfig_type",
+      "wordpress_values_schema_customdefaultsiteconfigmap_default",
+      "wordpress_values_schema_customdefaultsiteconfigmap_description",
+      "wordpress_values_schema_customdefaultsiteconfigmap_type",
+      "wordpress_values_schema_customphpconfig_description",
+      "wordpress_values_schema_customphpconfig_type",
+      "wordpress_values_schema_customphpconfigmap_default",
+      "wordpress_values_schema_customphpconfigmap_description",
+      "wordpress_values_schema_customphpconfigmap_type",
+      "wordpress_values_schema_customportsconfig_description",
+      "wordpress_values_schema_customportsconfig_type",
+      "wordpress_values_schema_customportsconfigmap_default",
+      "wordpress_values_schema_customportsconfigmap_description",
+      "wordpress_values_schema_customportsconfigmap_type",
+      "wordpress_values_schema_properties_apache",
+      "wordpress_values_schema_properties_customdefaultsiteconfig",
+      "wordpress_values_schema_properties_customdefaultsiteconfigmap",
+      "wordpress_values_schema_properties_customphpconfig",
+      "wordpress_values_schema_properties_customphpconfigmap",
+      "wordpress_values_schema_properties_customportsconfig",
+      "wordpress_values_schema_properties_customportsconfigmap",
+      "wordpress_values_schema_properties_servername",
+      "wordpress_values_schema_servername_default",
+      "wordpress_values_schema_servername_description",
+      "wordpress_values_schema_servername_type"
+    ],
+    "8": [
+      "wg_easy_values_schema_image_additionalproperties",
+      "wg_easy_values_schema_image_properties",
+      "wg_easy_values_schema_image_required",
+      "wg_easy_values_schema_image_title",
+      "wg_easy_values_schema_image_type",
+      "wg_easy_values_schema_properties_image",
+      "wg_easy_values_schema_properties_pullpolicy",
+      "wg_easy_values_schema_properties_registry",
+      "wg_easy_values_schema_properties_repository",
+      "wg_easy_values_schema_properties_tag",
+      "wg_easy_values_schema_pullpolicy_description",
+      "wg_easy_values_schema_pullpolicy_enum",
+      "wg_easy_values_schema_pullpolicy_title",
+      "wg_easy_values_schema_pullpolicy_type",
+      "wg_easy_values_schema_registry_default",
+      "wg_easy_values_schema_registry_description",
+      "wg_easy_values_schema_registry_title",
+      "wg_easy_values_schema_registry_type",
+      "wg_easy_values_schema_repository_description",
+      "wg_easy_values_schema_repository_title",
+      "wg_easy_values_schema_repository_type",
+      "wg_easy_values_schema_tag_description",
+      "wg_easy_values_schema_tag_title",
+      "wg_easy_values_schema_tag_type"
+    ],
+    "9": [
+      "wireguard_values_schema_image_description",
+      "wireguard_values_schema_image_properties",
+      "wireguard_values_schema_image_required",
+      "wireguard_values_schema_image_title",
+      "wireguard_values_schema_image_type",
+      "wireguard_values_schema_properties_image",
+      "wireguard_values_schema_properties_pullpolicy",
+      "wireguard_values_schema_properties_registry",
+      "wireguard_values_schema_properties_repository",
+      "wireguard_values_schema_properties_tag",
+      "wireguard_values_schema_pullpolicy_description",
+      "wireguard_values_schema_pullpolicy_enum",
+      "wireguard_values_schema_pullpolicy_title",
+      "wireguard_values_schema_pullpolicy_type",
+      "wireguard_values_schema_registry_default",
+      "wireguard_values_schema_registry_description",
+      "wireguard_values_schema_registry_title",
+      "wireguard_values_schema_registry_type",
+      "wireguard_values_schema_repository_description",
+      "wireguard_values_schema_repository_title",
+      "wireguard_values_schema_repository_type",
+      "wireguard_values_schema_tag_description",
+      "wireguard_values_schema_tag_title",
+      "wireguard_values_schema_tag_type"
+    ],
+    "10": [
+      "release_please_config",
+      "release_please_config_bootstrap_sha",
+      "release_please_config_changelog_sections",
+      "release_please_config_charts_wg_easy_changelog_path",
+      "release_please_config_charts_wg_easy_component",
+      "release_please_config_charts_wg_easy_extra_files",
+      "release_please_config_charts_wireguard_changelog_path",
+      "release_please_config_charts_wireguard_component",
+      "release_please_config_charts_wireguard_extra_files",
+      "release_please_config_charts_wordpress_changelog_path",
+      "release_please_config_charts_wordpress_component",
+      "release_please_config_charts_wordpress_extra_files",
+      "release_please_config_draft",
+      "release_please_config_include_component_in_tag",
+      "release_please_config_include_v_in_tag",
+      "release_please_config_packages",
+      "release_please_config_packages_charts_wg_easy",
+      "release_please_config_packages_charts_wireguard",
+      "release_please_config_packages_charts_wordpress",
+      "release_please_config_release_type",
+      "release_please_config_schema",
+      "release_please_config_separate_pull_requests"
+    ],
+    "11": [
+      "wireguard_values_schema_annotations_description",
+      "wireguard_values_schema_annotations_title",
+      "wireguard_values_schema_annotations_type",
+      "wireguard_values_schema_automount_description",
+      "wireguard_values_schema_automount_title",
+      "wireguard_values_schema_automount_type",
+      "wireguard_values_schema_create_description",
+      "wireguard_values_schema_create_title",
+      "wireguard_values_schema_create_type",
+      "wireguard_values_schema_name_description",
+      "wireguard_values_schema_name_title",
+      "wireguard_values_schema_name_type",
+      "wireguard_values_schema_properties_annotations",
+      "wireguard_values_schema_properties_automount",
+      "wireguard_values_schema_properties_create",
+      "wireguard_values_schema_properties_name",
+      "wireguard_values_schema_properties_serviceaccount",
+      "wireguard_values_schema_serviceaccount_description",
+      "wireguard_values_schema_serviceaccount_properties",
+      "wireguard_values_schema_serviceaccount_title",
+      "wireguard_values_schema_serviceaccount_type"
+    ],
+    "12": [
+      "wordpress_values_schema_image_properties",
+      "wordpress_values_schema_image_required",
+      "wordpress_values_schema_image_type",
+      "wordpress_values_schema_properties_image",
+      "wordpress_values_schema_properties_pullpolicy",
+      "wordpress_values_schema_properties_registry",
+      "wordpress_values_schema_properties_repository",
+      "wordpress_values_schema_properties_tag",
+      "wordpress_values_schema_pullpolicy_default",
+      "wordpress_values_schema_pullpolicy_description",
+      "wordpress_values_schema_pullpolicy_enum",
+      "wordpress_values_schema_pullpolicy_type",
+      "wordpress_values_schema_registry_default",
+      "wordpress_values_schema_registry_description",
+      "wordpress_values_schema_registry_type",
+      "wordpress_values_schema_repository_default",
+      "wordpress_values_schema_repository_description",
+      "wordpress_values_schema_repository_type",
+      "wordpress_values_schema_tag_default",
+      "wordpress_values_schema_tag_description",
+      "wordpress_values_schema_tag_type"
+    ],
+    "13": [
+      "namespace",
+      "path",
+      "scripts_sync_artifacthub_changes",
+      "scripts_sync_artifacthub_changes_build_artifacthub_changes_block",
+      "scripts_sync_artifacthub_changes_ensure_annotations_section",
+      "scripts_sync_artifacthub_changes_extract_version_block",
+      "scripts_sync_artifacthub_changes_find_annotation_entry",
+      "scripts_sync_artifacthub_changes_find_annotations_section",
+      "scripts_sync_artifacthub_changes_is_prerelease_version",
+      "scripts_sync_artifacthub_changes_main",
+      "scripts_sync_artifacthub_changes_parse_args",
+      "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "scripts_sync_artifacthub_changes_rationale_103",
+      "scripts_sync_artifacthub_changes_rationale_140",
+      "scripts_sync_artifacthub_changes_rationale_163",
+      "scripts_sync_artifacthub_changes_read_current_version",
+      "scripts_sync_artifacthub_changes_remove_annotation",
+      "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "scripts_sync_artifacthub_changes_split_description_and_link",
+      "scripts_sync_artifacthub_changes_sync_prerelease_annotation"
+    ],
+    "14": [
+      "wordpress_values_schema_email_description",
+      "wordpress_values_schema_email_type",
+      "wordpress_values_schema_firstname_description",
+      "wordpress_values_schema_firstname_type",
+      "wordpress_values_schema_items_properties",
+      "wordpress_values_schema_properties_activate",
+      "wordpress_values_schema_properties_autoupdate",
+      "wordpress_values_schema_properties_displayname",
+      "wordpress_values_schema_properties_email",
+      "wordpress_values_schema_properties_firstname",
+      "wordpress_values_schema_properties_networkactivate",
+      "wordpress_values_schema_properties_networkenable",
+      "wordpress_values_schema_properties_role",
+      "wordpress_values_schema_properties_sendemail",
+      "wordpress_values_schema_properties_sites",
+      "wordpress_values_schema_properties_slug",
+      "wordpress_values_schema_properties_superadmin",
+      "wordpress_values_schema_properties_value",
+      "wordpress_values_schema_properties_version",
+      "wordpress_values_schema_value_type"
+    ],
+    "15": [
+      "wg_easy_values_schema_classname_description",
+      "wg_easy_values_schema_classname_title",
+      "wg_easy_values_schema_classname_type",
+      "wg_easy_values_schema_enabled_description",
+      "wg_easy_values_schema_enabled_title",
+      "wg_easy_values_schema_enabled_type",
+      "wg_easy_values_schema_ingress_additionalproperties",
+      "wg_easy_values_schema_ingress_properties",
+      "wg_easy_values_schema_ingress_required",
+      "wg_easy_values_schema_ingress_title",
+      "wg_easy_values_schema_ingress_type",
+      "wg_easy_values_schema_properties_classname",
+      "wg_easy_values_schema_properties_enabled",
+      "wg_easy_values_schema_properties_ingress",
+      "wg_easy_values_schema_properties_tls",
+      "wg_easy_values_schema_tls_description",
+      "wg_easy_values_schema_tls_items",
+      "wg_easy_values_schema_tls_title",
+      "wg_easy_values_schema_tls_type"
+    ],
+    "16": [
+      "wordpress_values_schema_auth_type",
+      "wordpress_values_schema_encryption_type",
+      "wordpress_values_schema_existingsecretfromemailkey_type",
+      "wordpress_values_schema_existingsecretpasswordkey_type",
+      "wordpress_values_schema_existingsecretusernamekey_type",
+      "wordpress_values_schema_fromemail_type",
+      "wordpress_values_schema_fromname_type",
+      "wordpress_values_schema_host_type",
+      "wordpress_values_schema_port_type",
+      "wordpress_values_schema_properties_auth",
+      "wordpress_values_schema_properties_encryption",
+      "wordpress_values_schema_properties_existingsecretfromemailkey",
+      "wordpress_values_schema_properties_existingsecretpasswordkey",
+      "wordpress_values_schema_properties_existingsecretusernamekey",
+      "wordpress_values_schema_properties_fromemail",
+      "wordpress_values_schema_properties_fromname",
+      "wordpress_values_schema_properties_host",
+      "wordpress_values_schema_properties_port",
+      "wordpress_values_schema_smtp_properties"
+    ],
+    "17": [
+      "wg_easy_values_schema_automount_description",
+      "wg_easy_values_schema_automount_title",
+      "wg_easy_values_schema_automount_type",
+      "wg_easy_values_schema_create_description",
+      "wg_easy_values_schema_create_title",
+      "wg_easy_values_schema_create_type",
+      "wg_easy_values_schema_name_description",
+      "wg_easy_values_schema_name_title",
+      "wg_easy_values_schema_name_type",
+      "wg_easy_values_schema_properties_automount",
+      "wg_easy_values_schema_properties_create",
+      "wg_easy_values_schema_properties_name",
+      "wg_easy_values_schema_properties_serviceaccount",
+      "wg_easy_values_schema_serviceaccount_additionalproperties",
+      "wg_easy_values_schema_serviceaccount_properties",
+      "wg_easy_values_schema_serviceaccount_required",
+      "wg_easy_values_schema_serviceaccount_title",
+      "wg_easy_values_schema_serviceaccount_type"
+    ],
+    "18": [
+      "wireguard_values_schema_autoscaling_description",
+      "wireguard_values_schema_autoscaling_properties",
+      "wireguard_values_schema_autoscaling_title",
+      "wireguard_values_schema_autoscaling_type",
+      "wireguard_values_schema_maxreplicas_title",
+      "wireguard_values_schema_maxreplicas_type",
+      "wireguard_values_schema_minreplicas_title",
+      "wireguard_values_schema_minreplicas_type",
+      "wireguard_values_schema_properties_autoscaling",
+      "wireguard_values_schema_properties_maxreplicas",
+      "wireguard_values_schema_properties_minreplicas",
+      "wireguard_values_schema_properties_targetcpuutilizationpercentage",
+      "wireguard_values_schema_properties_targetmemoryutilizationpercentage",
+      "wireguard_values_schema_targetcpuutilizationpercentage_title",
+      "wireguard_values_schema_targetcpuutilizationpercentage_type",
+      "wireguard_values_schema_targetmemoryutilizationpercentage_title",
+      "wireguard_values_schema_targetmemoryutilizationpercentage_type"
+    ],
+    "19": [
+      "scripts_validate_artifacthub_annotations",
+      "scripts_validate_artifacthub_annotations_check_special_chars_quoted",
+      "scripts_validate_artifacthub_annotations_main",
+      "scripts_validate_artifacthub_annotations_rationale_100",
+      "scripts_validate_artifacthub_annotations_rationale_128",
+      "scripts_validate_artifacthub_annotations_rationale_158",
+      "scripts_validate_artifacthub_annotations_rationale_188",
+      "scripts_validate_artifacthub_annotations_rationale_202",
+      "scripts_validate_artifacthub_annotations_rationale_30",
+      "scripts_validate_artifacthub_annotations_rationale_43",
+      "scripts_validate_artifacthub_annotations_validate_category",
+      "scripts_validate_artifacthub_annotations_validate_changes",
+      "scripts_validate_artifacthub_annotations_validate_chart_yaml",
+      "scripts_validate_artifacthub_annotations_validate_images",
+      "scripts_validate_artifacthub_annotations_validate_links",
+      "scripts_validate_artifacthub_annotations_validate_maintainers"
+    ],
+    "20": [
+      "renovate",
+      "renovate_assignees",
+      "renovate_custommanagers",
+      "renovate_enabledmanagers",
+      "renovate_extends",
+      "renovate_gitignoredauthors",
+      "renovate_packagerules",
+      "renovate_pindigests",
+      "renovate_platformautomerge",
+      "renovate_prconcurrentlimit",
+      "renovate_prhourlylimit",
+      "renovate_rebasewhen",
+      "renovate_semanticcommits",
+      "renovate_semanticcommitscope",
+      "renovate_timezone"
+    ],
+    "21": [
+      "wireguard_values_schema_extraenvvars_items",
+      "wireguard_values_schema_extravolumemounts_items",
+      "wireguard_values_schema_extravolumes_items",
+      "wireguard_values_schema_imagepullsecrets_items",
+      "wireguard_values_schema_initcontainers_items",
+      "wireguard_values_schema_items_additionalproperties",
+      "wireguard_values_schema_items_properties",
+      "wireguard_values_schema_items_required",
+      "wireguard_values_schema_items_type",
+      "wireguard_values_schema_mountpath_title",
+      "wireguard_values_schema_mountpath_type",
+      "wireguard_values_schema_options_items",
+      "wireguard_values_schema_properties_mountpath",
+      "wireguard_values_schema_properties_value",
+      "wireguard_values_schema_sidecars_items"
+    ],
+    "22": [
+      "wg_easy_values_schema_accessmodes_items",
+      "wg_easy_values_schema_extraenvvars_items",
+      "wg_easy_values_schema_hosts_items",
+      "wg_easy_values_schema_hosts_title",
+      "wg_easy_values_schema_hosts_type",
+      "wg_easy_values_schema_imagepullsecrets_items",
+      "wg_easy_values_schema_items_additionalproperties",
+      "wg_easy_values_schema_items_enum",
+      "wg_easy_values_schema_items_properties",
+      "wg_easy_values_schema_items_required",
+      "wg_easy_values_schema_items_type",
+      "wg_easy_values_schema_options_items",
+      "wg_easy_values_schema_properties_hosts",
+      "wg_easy_values_schema_properties_paths"
+    ],
+    "23": [
+      "wordpress_values_schema_custominitscript_description",
+      "wordpress_values_schema_custominitscript_type",
+      "wordpress_values_schema_init_properties",
+      "wordpress_values_schema_jwt_description",
+      "wordpress_values_schema_jwt_properties",
+      "wordpress_values_schema_jwt_type",
+      "wordpress_values_schema_password_description",
+      "wordpress_values_schema_password_type",
+      "wordpress_values_schema_properties_custominitscript",
+      "wordpress_values_schema_properties_jwt",
+      "wordpress_values_schema_properties_password",
+      "wordpress_values_schema_properties_title",
+      "wordpress_values_schema_title_description",
+      "wordpress_values_schema_title_type"
+    ],
+    "24": [
+      "wg_easy_values_schema_additionalproperties_type",
+      "wg_easy_values_schema_annotations_additionalproperties",
+      "wg_easy_values_schema_labels_additionalproperties",
+      "wg_easy_values_schema_podannotations_additionalproperties",
+      "wg_easy_values_schema_podannotations_title",
+      "wg_easy_values_schema_podannotations_type",
+      "wg_easy_values_schema_podlabels_additionalproperties",
+      "wg_easy_values_schema_podlabels_title",
+      "wg_easy_values_schema_podlabels_type",
+      "wg_easy_values_schema_properties_podannotations",
+      "wg_easy_values_schema_properties_podlabels"
+    ],
+    "25": [
+      "wordpress_values_schema_customstructure_description",
+      "wordpress_values_schema_customstructure_type",
+      "wordpress_values_schema_permalinks_properties",
+      "wordpress_values_schema_permalinks_type",
+      "wordpress_values_schema_properties_customstructure",
+      "wordpress_values_schema_properties_permalinks",
+      "wordpress_values_schema_properties_structure",
+      "wordpress_values_schema_structure_default",
+      "wordpress_values_schema_structure_description",
+      "wordpress_values_schema_structure_enum",
+      "wordpress_values_schema_structure_type"
+    ],
+    "26": [
+      "wg_easy_values_schema_dnsconfig_additionalproperties",
+      "wg_easy_values_schema_dnsconfig_description",
+      "wg_easy_values_schema_dnsconfig_properties",
+      "wg_easy_values_schema_dnsconfig_title",
+      "wg_easy_values_schema_dnsconfig_type",
+      "wg_easy_values_schema_options_description",
+      "wg_easy_values_schema_options_title",
+      "wg_easy_values_schema_options_type",
+      "wg_easy_values_schema_properties_dnsconfig",
+      "wg_easy_values_schema_properties_options"
+    ],
+    "27": [
+      "wg_easy_values_schema_properties_type",
+      "wg_easy_values_schema_properties_updatestrategy",
+      "wg_easy_values_schema_type_description",
+      "wg_easy_values_schema_type_enum",
+      "wg_easy_values_schema_type_title",
+      "wg_easy_values_schema_type_type",
+      "wg_easy_values_schema_updatestrategy_description",
+      "wg_easy_values_schema_updatestrategy_properties",
+      "wg_easy_values_schema_updatestrategy_title",
+      "wg_easy_values_schema_updatestrategy_type"
+    ],
+    "28": [
+      "wireguard_values_schema_client_description",
+      "wireguard_values_schema_client_properties",
+      "wireguard_values_schema_client_title",
+      "wireguard_values_schema_client_type",
+      "wireguard_values_schema_config_description",
+      "wireguard_values_schema_config_properties",
+      "wireguard_values_schema_config_title",
+      "wireguard_values_schema_config_type",
+      "wireguard_values_schema_properties_client",
+      "wireguard_values_schema_properties_config"
+    ],
+    "29": [
+      "wireguard_values_schema_dnsconfig_additionalproperties",
+      "wireguard_values_schema_dnsconfig_description",
+      "wireguard_values_schema_dnsconfig_properties",
+      "wireguard_values_schema_dnsconfig_title",
+      "wireguard_values_schema_dnsconfig_type",
+      "wireguard_values_schema_options_description",
+      "wireguard_values_schema_options_title",
+      "wireguard_values_schema_options_type",
+      "wireguard_values_schema_properties_dnsconfig",
+      "wireguard_values_schema_properties_options"
+    ],
+    "30": [
+      "wireguard_values_schema_properties_server",
+      "wireguard_values_schema_properties_storage",
+      "wireguard_values_schema_server_description",
+      "wireguard_values_schema_server_properties",
+      "wireguard_values_schema_server_title",
+      "wireguard_values_schema_server_type",
+      "wireguard_values_schema_storage_description",
+      "wireguard_values_schema_storage_properties",
+      "wireguard_values_schema_storage_title",
+      "wireguard_values_schema_storage_type"
+    ],
+    "31": [
+      "wordpress_values_schema_composer_default",
+      "wordpress_values_schema_composer_properties",
+      "wordpress_values_schema_composer_type",
+      "wordpress_values_schema_default_repositories",
+      "wordpress_values_schema_properties_composer",
+      "wordpress_values_schema_properties_repositories",
+      "wordpress_values_schema_repositories_default",
+      "wordpress_values_schema_repositories_description",
+      "wordpress_values_schema_repositories_items",
+      "wordpress_values_schema_repositories_type"
+    ],
+    "32": [
+      "wordpress_values_schema_htaccess_description",
+      "wordpress_values_schema_htaccess_type",
+      "wordpress_values_schema_init_type",
+      "wordpress_values_schema_properties_htaccess",
+      "wordpress_values_schema_properties_init",
+      "wordpress_values_schema_properties_url",
+      "wordpress_values_schema_url_description",
+      "wordpress_values_schema_url_minlength",
+      "wordpress_values_schema_url_type",
+      "wordpress_values_schema_wordpress_properties"
+    ],
+    "33": [
+      "wg_easy_values_schema_annotations_title",
+      "wg_easy_values_schema_annotations_type",
+      "wg_easy_values_schema_properties_annotations",
+      "wg_easy_values_schema_properties_ui",
+      "wg_easy_values_schema_ui_additionalproperties",
+      "wg_easy_values_schema_ui_properties",
+      "wg_easy_values_schema_ui_required",
+      "wg_easy_values_schema_ui_title",
+      "wg_easy_values_schema_ui_type"
+    ],
+    "34": [
+      "wg_easy_values_schema_existingclaim_description",
+      "wg_easy_values_schema_existingclaim_title",
+      "wg_easy_values_schema_existingclaim_type",
+      "wg_easy_values_schema_properties_existingclaim",
+      "wg_easy_values_schema_properties_storageclass",
+      "wg_easy_values_schema_storage_properties",
+      "wg_easy_values_schema_storageclass_description",
+      "wg_easy_values_schema_storageclass_title",
+      "wg_easy_values_schema_storageclass_type"
+    ],
+    "35": [
+      "wg_easy_values_schema_existingsecretkey_description",
+      "wg_easy_values_schema_existingsecretkey_title",
+      "wg_easy_values_schema_existingsecretkey_type",
+      "wg_easy_values_schema_interval_description",
+      "wg_easy_values_schema_interval_title",
+      "wg_easy_values_schema_interval_type",
+      "wg_easy_values_schema_properties_existingsecretkey",
+      "wg_easy_values_schema_properties_interval",
+      "wg_easy_values_schema_servicemonitor_properties"
+    ],
+    "36": [
+      "wg_easy_values_schema_localhostprofile_description",
+      "wg_easy_values_schema_localhostprofile_type",
+      "wg_easy_values_schema_properties_localhostprofile",
+      "wg_easy_values_schema_properties_seccompprofile",
+      "wg_easy_values_schema_seccompprofile_additionalproperties",
+      "wg_easy_values_schema_seccompprofile_description",
+      "wg_easy_values_schema_seccompprofile_properties",
+      "wg_easy_values_schema_seccompprofile_title",
+      "wg_easy_values_schema_seccompprofile_type"
+    ],
+    "37": [
+      "wordpress_values_schema",
+      "wordpress_values_schema_dnspolicy_description",
+      "wordpress_values_schema_dnspolicy_type",
+      "wordpress_values_schema_podsecuritycontext_type",
+      "wordpress_values_schema_properties",
+      "wordpress_values_schema_properties_dnspolicy",
+      "wordpress_values_schema_properties_podsecuritycontext",
+      "wordpress_values_schema_schema",
+      "wordpress_values_schema_type"
+    ],
+    "38": [
+      "wordpress_values_schema_additionalproperties_type",
+      "wordpress_values_schema_commonannotations_additionalproperties",
+      "wordpress_values_schema_commonannotations_description",
+      "wordpress_values_schema_commonannotations_type",
+      "wordpress_values_schema_commonlabels_additionalproperties",
+      "wordpress_values_schema_commonlabels_description",
+      "wordpress_values_schema_commonlabels_type",
+      "wordpress_values_schema_properties_commonannotations",
+      "wordpress_values_schema_properties_commonlabels"
+    ],
+    "39": [
+      "wordpress_values_schema_configextraconfigmap_description",
+      "wordpress_values_schema_configextraconfigmap_properties",
+      "wordpress_values_schema_configextraconfigmap_type",
+      "wordpress_values_schema_name_default",
+      "wordpress_values_schema_name_description",
+      "wordpress_values_schema_name_title",
+      "wordpress_values_schema_name_type",
+      "wordpress_values_schema_properties_configextraconfigmap",
+      "wordpress_values_schema_properties_name"
+    ],
+    "40": [
+      "wordpress_values_schema_configextrasecret_description",
+      "wordpress_values_schema_configextrasecret_properties",
+      "wordpress_values_schema_configextrasecret_type",
+      "wordpress_values_schema_key_default",
+      "wordpress_values_schema_key_description",
+      "wordpress_values_schema_key_type",
+      "wordpress_values_schema_properties_configextrasecret",
+      "wordpress_values_schema_properties_key"
+    ],
+    "41": [
+      "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "charts_wg_easy_samples_verify_verify_sh_verify_verify_bold",
+      "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "charts_wg_easy_samples_verify_verify_sh_verify_verify_green",
+      "charts_wg_easy_samples_verify_verify_sh_verify_verify_red",
+      "charts_wg_easy_samples_verify_verify_sh_verify_verify_yellow",
+      "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry"
+    ],
+    "42": [
+      "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "charts_wireguard_samples_verify_verify_sh_verify_verify_bold",
+      "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "charts_wireguard_samples_verify_verify_sh_verify_verify_green",
+      "charts_wireguard_samples_verify_verify_sh_verify_verify_red",
+      "charts_wireguard_samples_verify_verify_sh_verify_verify_yellow",
+      "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry"
+    ],
+    "43": [
+      "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "charts_wordpress_samples_verify_verify_sh_verify_verify_bold",
+      "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "charts_wordpress_samples_verify_verify_sh_verify_verify_green",
+      "charts_wordpress_samples_verify_verify_sh_verify_verify_red",
+      "charts_wordpress_samples_verify_verify_sh_verify_verify_yellow",
+      "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry"
+    ],
+    "44": [
+      "wg_easy_values_schema",
+      "wg_easy_values_schema_additionalproperties",
+      "wg_easy_values_schema_description",
+      "wg_easy_values_schema_id",
+      "wg_easy_values_schema_schema",
+      "wg_easy_values_schema_title",
+      "wg_easy_values_schema_type"
+    ],
+    "45": [
+      "wireguard_values_schema_nodeselector_description",
+      "wireguard_values_schema_nodeselector_title",
+      "wireguard_values_schema_nodeselector_type",
+      "wireguard_values_schema_priorityclassname_type",
+      "wireguard_values_schema_properties",
+      "wireguard_values_schema_properties_nodeselector",
+      "wireguard_values_schema_properties_priorityclassname"
+    ],
+    "46": [
+      "wordpress_values_schema_imagepullsecrets_default",
+      "wordpress_values_schema_imagepullsecrets_description",
+      "wordpress_values_schema_imagepullsecrets_items",
+      "wordpress_values_schema_imagepullsecrets_title",
+      "wordpress_values_schema_imagepullsecrets_type",
+      "wordpress_values_schema_items_additionalproperties",
+      "wordpress_values_schema_properties_imagepullsecrets"
+    ],
+    "47": [
+      "scripts_helmlint",
+      "scripts_helmlint_chart_path",
+      "scripts_helmlint_contains_element",
+      "scripts_helmlint_cwd_abspath",
+      "scripts_helmlint_path",
+      "users_timon_homelab_helm_charts_scripts_helmlint_sh__entry"
+    ],
+    "48": [
+      "wg_easy_values_schema_externalips_description",
+      "wg_easy_values_schema_externalips_items",
+      "wg_easy_values_schema_externalips_title",
+      "wg_easy_values_schema_externalips_type",
+      "wg_easy_values_schema_properties_externalips",
+      "wg_easy_values_schema_wireguard_properties"
+    ],
+    "49": [
+      "wg_easy_values_schema_nodeport_description",
+      "wg_easy_values_schema_nodeport_maximum",
+      "wg_easy_values_schema_nodeport_minimum",
+      "wg_easy_values_schema_nodeport_title",
+      "wg_easy_values_schema_nodeport_type",
+      "wg_easy_values_schema_properties_nodeport"
+    ],
+    "50": [
+      "wg_easy_values_schema_port_description",
+      "wg_easy_values_schema_port_maximum",
+      "wg_easy_values_schema_port_minimum",
+      "wg_easy_values_schema_port_title",
+      "wg_easy_values_schema_port_type",
+      "wg_easy_values_schema_properties_port"
+    ],
+    "51": [
+      "wg_easy_values_schema_properties_replicacount",
+      "wg_easy_values_schema_replicacount_default",
+      "wg_easy_values_schema_replicacount_description",
+      "wg_easy_values_schema_replicacount_minimum",
+      "wg_easy_values_schema_replicacount_title",
+      "wg_easy_values_schema_replicacount_type"
+    ],
+    "52": [
+      "wg_easy_values_schema_properties_resourcepolicy",
+      "wg_easy_values_schema_resourcepolicy_default",
+      "wg_easy_values_schema_resourcepolicy_description",
+      "wg_easy_values_schema_resourcepolicy_enum",
+      "wg_easy_values_schema_resourcepolicy_title",
+      "wg_easy_values_schema_resourcepolicy_type"
+    ],
+    "53": [
+      "wg_easy_values_schema_properties_service",
+      "wg_easy_values_schema_service_additionalproperties",
+      "wg_easy_values_schema_service_properties",
+      "wg_easy_values_schema_service_required",
+      "wg_easy_values_schema_service_title",
+      "wg_easy_values_schema_service_type"
+    ],
+    "54": [
+      "wireguard_values_schema",
+      "wireguard_values_schema_additionalproperties",
+      "wireguard_values_schema_description",
+      "wireguard_values_schema_schema",
+      "wireguard_values_schema_title",
+      "wireguard_values_schema_type"
+    ],
+    "55": [
+      "wordpress_values_schema_items_required",
+      "wordpress_values_schema_plugins_default",
+      "wordpress_values_schema_plugins_description",
+      "wordpress_values_schema_plugins_items",
+      "wordpress_values_schema_plugins_type",
+      "wordpress_values_schema_properties_plugins"
+    ],
+    "56": [
+      "wg_easy_values_schema_dnspolicy_description",
+      "wg_easy_values_schema_dnspolicy_enum",
+      "wg_easy_values_schema_dnspolicy_title",
+      "wg_easy_values_schema_dnspolicy_type",
+      "wg_easy_values_schema_properties_dnspolicy"
+    ],
+    "57": [
+      "wg_easy_values_schema_extraenvvars_default",
+      "wg_easy_values_schema_extraenvvars_description",
+      "wg_easy_values_schema_extraenvvars_title",
+      "wg_easy_values_schema_extraenvvars_type",
+      "wg_easy_values_schema_properties_extraenvvars"
+    ],
+    "58": [
+      "wg_easy_values_schema_global_additionalproperties",
+      "wg_easy_values_schema_global_description",
+      "wg_easy_values_schema_global_title",
+      "wg_easy_values_schema_global_type",
+      "wg_easy_values_schema_properties_global"
+    ],
+    "59": [
+      "wg_easy_values_schema_imagepullsecrets_default",
+      "wg_easy_values_schema_imagepullsecrets_description",
+      "wg_easy_values_schema_imagepullsecrets_title",
+      "wg_easy_values_schema_imagepullsecrets_type",
+      "wg_easy_values_schema_properties_imagepullsecrets"
+    ],
+    "60": [
+      "wg_easy_values_schema_initcontainers_description",
+      "wg_easy_values_schema_initcontainers_items",
+      "wg_easy_values_schema_initcontainers_title",
+      "wg_easy_values_schema_initcontainers_type",
+      "wg_easy_values_schema_properties_initcontainers"
+    ],
+    "61": [
+      "wg_easy_values_schema_nameservers_description",
+      "wg_easy_values_schema_nameservers_items",
+      "wg_easy_values_schema_nameservers_title",
+      "wg_easy_values_schema_nameservers_type",
+      "wg_easy_values_schema_properties_nameservers"
+    ],
+    "62": [
+      "wg_easy_values_schema_properties_searches",
+      "wg_easy_values_schema_searches_description",
+      "wg_easy_values_schema_searches_items",
+      "wg_easy_values_schema_searches_title",
+      "wg_easy_values_schema_searches_type"
+    ],
+    "63": [
+      "wg_easy_values_schema_properties_servicemonitor",
+      "wg_easy_values_schema_servicemonitor_additionalproperties",
+      "wg_easy_values_schema_servicemonitor_required",
+      "wg_easy_values_schema_servicemonitor_title",
+      "wg_easy_values_schema_servicemonitor_type"
+    ],
+    "64": [
+      "wg_easy_values_schema_properties_sidecars",
+      "wg_easy_values_schema_sidecars_description",
+      "wg_easy_values_schema_sidecars_items",
+      "wg_easy_values_schema_sidecars_title",
+      "wg_easy_values_schema_sidecars_type"
+    ],
+    "65": [
+      "wg_easy_values_schema_properties_storage",
+      "wg_easy_values_schema_storage_additionalproperties",
+      "wg_easy_values_schema_storage_required",
+      "wg_easy_values_schema_storage_title",
+      "wg_easy_values_schema_storage_type"
+    ],
+    "66": [
+      "wg_easy_values_schema_properties_wireguard",
+      "wg_easy_values_schema_wireguard_additionalproperties",
+      "wg_easy_values_schema_wireguard_required",
+      "wg_easy_values_schema_wireguard_title",
+      "wg_easy_values_schema_wireguard_type"
+    ],
+    "67": [
+      "wireguard_values_schema_dnspolicy_description",
+      "wireguard_values_schema_dnspolicy_enum",
+      "wireguard_values_schema_dnspolicy_title",
+      "wireguard_values_schema_dnspolicy_type",
+      "wireguard_values_schema_properties_dnspolicy"
+    ],
+    "68": [
+      "wireguard_values_schema_existingsecret_description",
+      "wireguard_values_schema_existingsecret_title",
+      "wireguard_values_schema_existingsecret_type",
+      "wireguard_values_schema_properties_existingsecret",
+      "wireguard_values_schema_wireguard_properties"
+    ],
+    "69": [
+      "wireguard_values_schema_imagepullsecrets_default",
+      "wireguard_values_schema_imagepullsecrets_description",
+      "wireguard_values_schema_imagepullsecrets_title",
+      "wireguard_values_schema_imagepullsecrets_type",
+      "wireguard_values_schema_properties_imagepullsecrets"
+    ],
+    "70": [
+      "wireguard_values_schema_nameservers_description",
+      "wireguard_values_schema_nameservers_items",
+      "wireguard_values_schema_nameservers_title",
+      "wireguard_values_schema_nameservers_type",
+      "wireguard_values_schema_properties_nameservers"
+    ],
+    "71": [
+      "wireguard_values_schema_podsecuritycontext_additionalproperties",
+      "wireguard_values_schema_podsecuritycontext_description",
+      "wireguard_values_schema_podsecuritycontext_title",
+      "wireguard_values_schema_podsecuritycontext_type",
+      "wireguard_values_schema_properties_podsecuritycontext"
+    ],
+    "72": [
+      "wireguard_values_schema_properties_searches",
+      "wireguard_values_schema_searches_description",
+      "wireguard_values_schema_searches_items",
+      "wireguard_values_schema_searches_title",
+      "wireguard_values_schema_searches_type"
+    ],
+    "73": [
+      "wireguard_values_schema_properties_tolerations",
+      "wireguard_values_schema_tolerations_description",
+      "wireguard_values_schema_tolerations_items",
+      "wireguard_values_schema_tolerations_title",
+      "wireguard_values_schema_tolerations_type"
+    ],
+    "74": [
+      "wireguard_values_schema_properties_topologyspreadconstraints",
+      "wireguard_values_schema_topologyspreadconstraints_description",
+      "wireguard_values_schema_topologyspreadconstraints_items",
+      "wireguard_values_schema_topologyspreadconstraints_title",
+      "wireguard_values_schema_topologyspreadconstraints_type"
+    ],
+    "75": [
+      "wordpress_values_schema_args_default",
+      "wordpress_values_schema_args_description",
+      "wordpress_values_schema_args_items",
+      "wordpress_values_schema_args_type",
+      "wordpress_values_schema_properties_args"
+    ],
+    "76": [
+      "wordpress_values_schema_command_default",
+      "wordpress_values_schema_command_description",
+      "wordpress_values_schema_command_items",
+      "wordpress_values_schema_command_type",
+      "wordpress_values_schema_properties_command"
+    ],
+    "77": [
+      "wordpress_values_schema_controllertype_default",
+      "wordpress_values_schema_controllertype_description",
+      "wordpress_values_schema_controllertype_enum",
+      "wordpress_values_schema_controllertype_type",
+      "wordpress_values_schema_properties_controllertype"
+    ],
+    "78": [
+      "wordpress_values_schema_extraenvvars_default",
+      "wordpress_values_schema_extraenvvars_description",
+      "wordpress_values_schema_extraenvvars_items",
+      "wordpress_values_schema_extraenvvars_type",
+      "wordpress_values_schema_properties_extraenvvars"
+    ],
+    "79": [
+      "wordpress_values_schema_initcontainers_default",
+      "wordpress_values_schema_initcontainers_description",
+      "wordpress_values_schema_initcontainers_items",
+      "wordpress_values_schema_initcontainers_type",
+      "wordpress_values_schema_properties_initcontainers"
+    ],
+    "80": [
+      "wordpress_values_schema_multisites_default",
+      "wordpress_values_schema_multisites_description",
+      "wordpress_values_schema_multisites_properties",
+      "wordpress_values_schema_multisites_type",
+      "wordpress_values_schema_properties_multisites"
+    ],
+    "81": [
+      "wordpress_values_schema_mupluginsconfigmaps_default",
+      "wordpress_values_schema_mupluginsconfigmaps_description",
+      "wordpress_values_schema_mupluginsconfigmaps_items",
+      "wordpress_values_schema_mupluginsconfigmaps_type",
+      "wordpress_values_schema_properties_mupluginsconfigmaps"
+    ],
+    "82": [
+      "wordpress_values_schema_properties_sidecars",
+      "wordpress_values_schema_sidecars_default",
+      "wordpress_values_schema_sidecars_description",
+      "wordpress_values_schema_sidecars_items",
+      "wordpress_values_schema_sidecars_type"
+    ],
+    "83": [
+      "wordpress_values_schema_properties_themes",
+      "wordpress_values_schema_themes_default",
+      "wordpress_values_schema_themes_description",
+      "wordpress_values_schema_themes_items",
+      "wordpress_values_schema_themes_type"
+    ],
+    "84": [
+      "wordpress_values_schema_properties_users",
+      "wordpress_values_schema_users_default",
+      "wordpress_values_schema_users_description",
+      "wordpress_values_schema_users_items",
+      "wordpress_values_schema_users_type"
+    ],
+    "85": [
+      "wg_easy_values_schema_accessmodes_description",
+      "wg_easy_values_schema_accessmodes_title",
+      "wg_easy_values_schema_accessmodes_type",
+      "wg_easy_values_schema_properties_accessmodes"
+    ],
+    "86": [
+      "wg_easy_values_schema_commonannotations_description",
+      "wg_easy_values_schema_commonannotations_title",
+      "wg_easy_values_schema_commonannotations_type",
+      "wg_easy_values_schema_properties_commonannotations"
+    ],
+    "87": [
+      "wg_easy_values_schema_commonlabels_description",
+      "wg_easy_values_schema_commonlabels_title",
+      "wg_easy_values_schema_commonlabels_type",
+      "wg_easy_values_schema_properties_commonlabels"
+    ],
+    "88": [
+      "wg_easy_values_schema_extraenvvarscm_description",
+      "wg_easy_values_schema_extraenvvarscm_title",
+      "wg_easy_values_schema_extraenvvarscm_type",
+      "wg_easy_values_schema_properties_extraenvvarscm"
+    ],
+    "89": [
+      "wg_easy_values_schema_extraenvvarssecret_description",
+      "wg_easy_values_schema_extraenvvarssecret_title",
+      "wg_easy_values_schema_extraenvvarssecret_type",
+      "wg_easy_values_schema_properties_extraenvvarssecret"
+    ],
+    "90": [
+      "wg_easy_values_schema_fullnameoverride_description",
+      "wg_easy_values_schema_fullnameoverride_title",
+      "wg_easy_values_schema_fullnameoverride_type",
+      "wg_easy_values_schema_properties_fullnameoverride"
+    ],
+    "91": [
+      "wg_easy_values_schema_hostnetwork_description",
+      "wg_easy_values_schema_hostnetwork_title",
+      "wg_easy_values_schema_hostnetwork_type",
+      "wg_easy_values_schema_properties_hostnetwork"
+    ],
+    "92": [
+      "wg_easy_values_schema_metricspath_description",
+      "wg_easy_values_schema_metricspath_title",
+      "wg_easy_values_schema_metricspath_type",
+      "wg_easy_values_schema_properties_metricspath"
+    ],
+    "93": [
+      "wg_easy_values_schema_nameoverride_description",
+      "wg_easy_values_schema_nameoverride_title",
+      "wg_easy_values_schema_nameoverride_type",
+      "wg_easy_values_schema_properties_nameoverride"
+    ],
+    "94": [
+      "wg_easy_values_schema_namespace_description",
+      "wg_easy_values_schema_namespace_title",
+      "wg_easy_values_schema_namespace_type",
+      "wg_easy_values_schema_properties_namespace"
+    ],
+    "95": [
+      "wg_easy_values_schema_podsecuritycontext_description",
+      "wg_easy_values_schema_podsecuritycontext_title",
+      "wg_easy_values_schema_podsecuritycontext_type",
+      "wg_easy_values_schema_properties_podsecuritycontext"
+    ],
+    "96": [
+      "wg_easy_values_schema_properties",
+      "wg_easy_values_schema_properties_resources",
+      "wg_easy_values_schema_resources_title",
+      "wg_easy_values_schema_resources_type"
+    ],
+    "97": [
+      "wg_easy_values_schema_properties_runtimeclassname",
+      "wg_easy_values_schema_runtimeclassname_description",
+      "wg_easy_values_schema_runtimeclassname_title",
+      "wg_easy_values_schema_runtimeclassname_type"
+    ],
+    "98": [
+      "wg_easy_values_schema_properties_selector",
+      "wg_easy_values_schema_selector_description",
+      "wg_easy_values_schema_selector_title",
+      "wg_easy_values_schema_selector_type"
+    ],
+    "99": [
+      "wg_easy_values_schema_properties_size",
+      "wg_easy_values_schema_size_description",
+      "wg_easy_values_schema_size_title",
+      "wg_easy_values_schema_size_type"
+    ],
+    "100": [
+      "wireguard_values_schema_affinity_description",
+      "wireguard_values_schema_affinity_title",
+      "wireguard_values_schema_affinity_type",
+      "wireguard_values_schema_properties_affinity"
+    ],
+    "101": [
+      "wireguard_values_schema_allowedips_description",
+      "wireguard_values_schema_allowedips_title",
+      "wireguard_values_schema_allowedips_type",
+      "wireguard_values_schema_properties_allowedips"
+    ],
+    "102": [
+      "wireguard_values_schema_commonannotations_description",
+      "wireguard_values_schema_commonannotations_title",
+      "wireguard_values_schema_commonannotations_type",
+      "wireguard_values_schema_properties_commonannotations"
+    ],
+    "103": [
+      "wireguard_values_schema_commonlabels_description",
+      "wireguard_values_schema_commonlabels_title",
+      "wireguard_values_schema_commonlabels_type",
+      "wireguard_values_schema_properties_commonlabels"
+    ],
+    "104": [
+      "wireguard_values_schema_customlivenessprobe_description",
+      "wireguard_values_schema_customlivenessprobe_title",
+      "wireguard_values_schema_customlivenessprobe_type",
+      "wireguard_values_schema_properties_customlivenessprobe"
+    ],
+    "105": [
+      "wireguard_values_schema_customreadinessprobe_description",
+      "wireguard_values_schema_customreadinessprobe_title",
+      "wireguard_values_schema_customreadinessprobe_type",
+      "wireguard_values_schema_properties_customreadinessprobe"
+    ],
+    "106": [
+      "wireguard_values_schema_customstartupprobe_description",
+      "wireguard_values_schema_customstartupprobe_title",
+      "wireguard_values_schema_customstartupprobe_type",
+      "wireguard_values_schema_properties_customstartupprobe"
+    ],
+    "107": [
+      "wireguard_values_schema_dns_description",
+      "wireguard_values_schema_dns_title",
+      "wireguard_values_schema_dns_type",
+      "wireguard_values_schema_properties_dns"
+    ],
+    "108": [
+      "wireguard_values_schema_extraenvvars_description",
+      "wireguard_values_schema_extraenvvars_title",
+      "wireguard_values_schema_extraenvvars_type",
+      "wireguard_values_schema_properties_extraenvvars"
+    ],
+    "109": [
+      "wireguard_values_schema_extraenvvarscm_description",
+      "wireguard_values_schema_extraenvvarscm_title",
+      "wireguard_values_schema_extraenvvarscm_type",
+      "wireguard_values_schema_properties_extraenvvarscm"
+    ],
+    "110": [
+      "wireguard_values_schema_extraenvvarssecret_description",
+      "wireguard_values_schema_extraenvvarssecret_title",
+      "wireguard_values_schema_extraenvvarssecret_type",
+      "wireguard_values_schema_properties_extraenvvarssecret"
+    ],
+    "111": [
+      "wireguard_values_schema_extravolumemounts_description",
+      "wireguard_values_schema_extravolumemounts_title",
+      "wireguard_values_schema_extravolumemounts_type",
+      "wireguard_values_schema_properties_extravolumemounts"
+    ],
+    "112": [
+      "wireguard_values_schema_extravolumes_description",
+      "wireguard_values_schema_extravolumes_title",
+      "wireguard_values_schema_extravolumes_type",
+      "wireguard_values_schema_properties_extravolumes"
+    ],
+    "113": [
+      "wireguard_values_schema_fullnameoverride_description",
+      "wireguard_values_schema_fullnameoverride_title",
+      "wireguard_values_schema_fullnameoverride_type",
+      "wireguard_values_schema_properties_fullnameoverride"
+    ],
+    "114": [
+      "wireguard_values_schema_hostnetwork_description",
+      "wireguard_values_schema_hostnetwork_title",
+      "wireguard_values_schema_hostnetwork_type",
+      "wireguard_values_schema_properties_hostnetwork"
+    ],
+    "115": [
+      "wireguard_values_schema_initcontainers_description",
+      "wireguard_values_schema_initcontainers_title",
+      "wireguard_values_schema_initcontainers_type",
+      "wireguard_values_schema_properties_initcontainers"
+    ],
+    "116": [
+      "wireguard_values_schema_listenport_description",
+      "wireguard_values_schema_listenport_title",
+      "wireguard_values_schema_listenport_type",
+      "wireguard_values_schema_properties_listenport"
+    ],
+    "117": [
+      "wireguard_values_schema_nameoverride_description",
+      "wireguard_values_schema_nameoverride_title",
+      "wireguard_values_schema_nameoverride_type",
+      "wireguard_values_schema_properties_nameoverride"
+    ],
+    "118": [
+      "wireguard_values_schema_pgid_description",
+      "wireguard_values_schema_pgid_title",
+      "wireguard_values_schema_pgid_type",
+      "wireguard_values_schema_properties_pgid"
+    ],
+    "119": [
+      "wireguard_values_schema_podannotations_description",
+      "wireguard_values_schema_podannotations_title",
+      "wireguard_values_schema_podannotations_type",
+      "wireguard_values_schema_properties_podannotations"
+    ],
+    "120": [
+      "wireguard_values_schema_podlabels_description",
+      "wireguard_values_schema_podlabels_title",
+      "wireguard_values_schema_podlabels_type",
+      "wireguard_values_schema_properties_podlabels"
+    ],
+    "121": [
+      "wireguard_values_schema_properties_puid",
+      "wireguard_values_schema_puid_description",
+      "wireguard_values_schema_puid_title",
+      "wireguard_values_schema_puid_type"
+    ],
+    "122": [
+      "wireguard_values_schema_properties_replicacount",
+      "wireguard_values_schema_replicacount_description",
+      "wireguard_values_schema_replicacount_title",
+      "wireguard_values_schema_replicacount_type"
+    ],
+    "123": [
+      "wireguard_values_schema_properties_resources",
+      "wireguard_values_schema_resources_description",
+      "wireguard_values_schema_resources_title",
+      "wireguard_values_schema_resources_type"
+    ],
+    "124": [
+      "wireguard_values_schema_properties_secret",
+      "wireguard_values_schema_secret_description",
+      "wireguard_values_schema_secret_title",
+      "wireguard_values_schema_secret_type"
+    ],
+    "125": [
+      "wireguard_values_schema_properties_sidecars",
+      "wireguard_values_schema_sidecars_description",
+      "wireguard_values_schema_sidecars_title",
+      "wireguard_values_schema_sidecars_type"
+    ],
+    "126": [
+      "wireguard_values_schema_properties_timezone",
+      "wireguard_values_schema_timezone_description",
+      "wireguard_values_schema_timezone_title",
+      "wireguard_values_schema_timezone_type"
+    ],
+    "127": [
+      "wireguard_values_schema_properties_wireguard",
+      "wireguard_values_schema_wireguard_description",
+      "wireguard_values_schema_wireguard_title",
+      "wireguard_values_schema_wireguard_type"
+    ],
+    "128": [
+      "wordpress_values_schema_applicationpassword_description",
+      "wordpress_values_schema_applicationpassword_properties",
+      "wordpress_values_schema_applicationpassword_type",
+      "wordpress_values_schema_properties_applicationpassword"
+    ],
+    "129": [
+      "wordpress_values_schema_clusterdomain_default",
+      "wordpress_values_schema_clusterdomain_description",
+      "wordpress_values_schema_clusterdomain_type",
+      "wordpress_values_schema_properties_clusterdomain"
+    ],
+    "130": [
+      "wordpress_values_schema_configextrainject_default",
+      "wordpress_values_schema_configextrainject_description",
+      "wordpress_values_schema_configextrainject_type",
+      "wordpress_values_schema_properties_configextrainject"
+    ],
+    "131": [
+      "wordpress_values_schema_customannotations_default",
+      "wordpress_values_schema_customannotations_description",
+      "wordpress_values_schema_customannotations_type",
+      "wordpress_values_schema_properties_customannotations"
+    ],
+    "132": [
+      "wordpress_values_schema_custominitconfigmap_description",
+      "wordpress_values_schema_custominitconfigmap_properties",
+      "wordpress_values_schema_custominitconfigmap_type",
+      "wordpress_values_schema_properties_custominitconfigmap"
+    ],
+    "133": [
+      "wordpress_values_schema_customlabels_default",
+      "wordpress_values_schema_customlabels_description",
+      "wordpress_values_schema_customlabels_type",
+      "wordpress_values_schema_properties_customlabels"
+    ],
+    "134": [
+      "wordpress_values_schema_debug_default",
+      "wordpress_values_schema_debug_description",
+      "wordpress_values_schema_debug_type",
+      "wordpress_values_schema_properties_debug"
+    ],
+    "135": [
+      "wordpress_values_schema_enabled_default",
+      "wordpress_values_schema_enabled_description",
+      "wordpress_values_schema_enabled_type",
+      "wordpress_values_schema_properties_enabled"
+    ],
+    "136": [
+      "wordpress_values_schema_existingsecret_default",
+      "wordpress_values_schema_existingsecret_description",
+      "wordpress_values_schema_existingsecret_type",
+      "wordpress_values_schema_properties_existingsecret"
+    ],
+    "137": [
+      "wordpress_values_schema_extraenvvarscm_default",
+      "wordpress_values_schema_extraenvvarscm_description",
+      "wordpress_values_schema_extraenvvarscm_type",
+      "wordpress_values_schema_properties_extraenvvarscm"
+    ],
+    "138": [
+      "wordpress_values_schema_extraenvvarssecret_default",
+      "wordpress_values_schema_extraenvvarssecret_description",
+      "wordpress_values_schema_extraenvvarssecret_type",
+      "wordpress_values_schema_properties_extraenvvarssecret"
+    ],
+    "139": [
+      "wordpress_values_schema_fullnameoverride_default",
+      "wordpress_values_schema_fullnameoverride_description",
+      "wordpress_values_schema_fullnameoverride_type",
+      "wordpress_values_schema_properties_fullnameoverride"
+    ],
+    "140": [
+      "wordpress_values_schema_htaccessconfigmap_default",
+      "wordpress_values_schema_htaccessconfigmap_description",
+      "wordpress_values_schema_htaccessconfigmap_type",
+      "wordpress_values_schema_properties_htaccessconfigmap"
+    ],
+    "141": [
+      "wordpress_values_schema_nameoverride_default",
+      "wordpress_values_schema_nameoverride_description",
+      "wordpress_values_schema_nameoverride_type",
+      "wordpress_values_schema_properties_nameoverride"
+    ],
+    "142": [
+      "wordpress_values_schema_pluginsprune_default",
+      "wordpress_values_schema_pluginsprune_description",
+      "wordpress_values_schema_pluginsprune_type",
+      "wordpress_values_schema_properties_pluginsprune"
+    ],
+    "143": [
+      "wordpress_values_schema_podannotations_default",
+      "wordpress_values_schema_podannotations_description",
+      "wordpress_values_schema_podannotations_type",
+      "wordpress_values_schema_properties_podannotations"
+    ],
+    "144": [
+      "wordpress_values_schema_podlabels_default",
+      "wordpress_values_schema_podlabels_description",
+      "wordpress_values_schema_podlabels_type",
+      "wordpress_values_schema_properties_podlabels"
+    ],
+    "145": [
+      "wordpress_values_schema_properties_replicacount",
+      "wordpress_values_schema_replicacount_default",
+      "wordpress_values_schema_replicacount_description",
+      "wordpress_values_schema_replicacount_type"
+    ],
+    "146": [
+      "wordpress_values_schema_properties_secretkeys",
+      "wordpress_values_schema_secretkeys_description",
+      "wordpress_values_schema_secretkeys_properties",
+      "wordpress_values_schema_secretkeys_type"
+    ],
+    "147": [
+      "wordpress_values_schema_properties_smtp",
+      "wordpress_values_schema_smtp_additionalproperties",
+      "wordpress_values_schema_smtp_description",
+      "wordpress_values_schema_smtp_type"
+    ],
+    "148": [
+      "wordpress_values_schema_properties_tableprefix",
+      "wordpress_values_schema_tableprefix_default",
+      "wordpress_values_schema_tableprefix_description",
+      "wordpress_values_schema_tableprefix_type"
+    ],
+    "149": [
+      "wordpress_values_schema_properties_themesprune",
+      "wordpress_values_schema_themesprune_default",
+      "wordpress_values_schema_themesprune_description",
+      "wordpress_values_schema_themesprune_type"
+    ],
+    "150": [
+      "wg_easy_values_schema_labels_title",
+      "wg_easy_values_schema_labels_type",
+      "wg_easy_values_schema_properties_labels"
+    ],
+    "151": [
+      "wg_easy_values_schema_properties_value",
+      "wg_easy_values_schema_value_title",
+      "wg_easy_values_schema_value_type"
+    ],
+    "152": [
+      "wireguard_values_schema_properties_readonly",
+      "wireguard_values_schema_readonly_title",
+      "wireguard_values_schema_readonly_type"
+    ],
+    "153": [
+      "wordpress_values_schema_accessmodes_items",
+      "wordpress_values_schema_items_enum",
+      "wordpress_values_schema_items_type"
+    ],
+    "154": [
+      "wordpress_values_schema_configextra_description",
+      "wordpress_values_schema_configextra_type",
+      "wordpress_values_schema_properties_configextra"
+    ],
+    "155": [
+      "wordpress_values_schema_dnsconfig_description",
+      "wordpress_values_schema_dnsconfig_type",
+      "wordpress_values_schema_properties_dnsconfig"
+    ],
+    "156": [
+      "wordpress_values_schema_hostnetwork_description",
+      "wordpress_values_schema_hostnetwork_type",
+      "wordpress_values_schema_properties_hostnetwork"
+    ],
+    "157": [
+      "wordpress_values_schema_language_description",
+      "wordpress_values_schema_language_type",
+      "wordpress_values_schema_properties_language"
+    ],
+    "158": [
+      "wordpress_values_schema_lastname_description",
+      "wordpress_values_schema_lastname_type",
+      "wordpress_values_schema_properties_lastname"
+    ],
+    "159": [
+      "wordpress_values_schema_properties_username",
+      "wordpress_values_schema_username_description",
+      "wordpress_values_schema_username_type"
+    ],
+    "160": [
+      "wordpress_values_schema_properties_wordpress",
+      "wordpress_values_schema_wordpress_required",
+      "wordpress_values_schema_wordpress_type"
+    ],
+    "161": [
+      "charts_wg_easy_samples_verify_install_sh_verify_install",
+      "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_install_sh__entry"
+    ],
+    "162": [
+      "charts_wg_easy_samples_verify_uninstall_sh_verify_uninstall",
+      "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_uninstall_sh__entry"
+    ],
+    "163": [
+      "charts_wireguard_samples_verify_install_sh_verify_install",
+      "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_install_sh__entry"
+    ],
+    "164": [
+      "charts_wireguard_samples_verify_uninstall_sh_verify_uninstall",
+      "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_uninstall_sh__entry"
+    ],
+    "165": [
+      "charts_wordpress_samples_verify_install_sh_verify_install",
+      "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_install_sh__entry"
+    ],
+    "166": [
+      "charts_wordpress_samples_verify_uninstall_sh_verify_uninstall",
+      "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_uninstall_sh__entry"
+    ],
+    "167": [
+      "advanced-values.yaml"
+    ],
+    "168": [
+      "advanced.configmap.yaml"
+    ],
+    "169": [
+      "advanced2.values.yaml"
+    ],
+    "170": [
+      "commonAnnotations.values.yaml"
+    ],
+    "171": [
+      "commonLabels.values.yaml"
+    ],
+    "172": [
+      "mariaDB.secrets.yaml"
+    ],
+    "173": [
+      "memcached.secrets.yaml"
+    ],
+    "174": [
+      "metrics.apache.rules"
+    ],
+    "175": [
+      "networkpolicy.yaml"
+    ],
+    "176": [
+      "prometheusrule.yaml"
+    ],
+    "177": [
+      "pvc.yaml"
+    ],
+    "178": [
+      "service.yaml"
+    ],
+    "179": [
+      "smtp.secrets.yaml"
+    ],
+    "180": [
+      "statefulset.yaml"
+    ],
+    "181": [
+      "tests/**/*.yaml"
+    ],
+    "182": [
+      "valkey.secrets.yaml"
+    ]
+  },
+  "cohesion": {
+    "0": 0.0425531914893617,
+    "1": 0.046511627906976744,
+    "2": 0.047619047619047616,
+    "3": 0.05,
+    "4": 0.06282051282051282,
+    "5": 0.05263157894736842,
+    "6": 0.05405405405405406,
+    "7": 0.07142857142857142,
+    "8": 0.08333333333333333,
+    "9": 0.08333333333333333,
+    "10": 0.09090909090909091,
+    "11": 0.09523809523809523,
+    "12": 0.09523809523809523,
+    "13": 0.18947368421052632,
+    "14": 0.1,
+    "15": 0.10526315789473684,
+    "16": 0.10526315789473684,
+    "17": 0.1111111111111111,
+    "18": 0.11764705882352941,
+    "19": 0.14166666666666666,
+    "20": 0.13333333333333333,
+    "21": 0.22857142857142856,
+    "22": 0.24175824175824176,
+    "23": 0.14285714285714285,
+    "24": 0.18181818181818182,
+    "25": 0.18181818181818182,
+    "26": 0.2,
+    "27": 0.2,
+    "28": 0.2,
+    "29": 0.2,
+    "30": 0.2,
+    "31": 0.2,
+    "32": 0.2,
+    "33": 0.2222222222222222,
+    "34": 0.2222222222222222,
+    "35": 0.2222222222222222,
+    "36": 0.2222222222222222,
+    "37": 0.2222222222222222,
+    "38": 0.2222222222222222,
+    "39": 0.2222222222222222,
+    "40": 0.25,
+    "41": 0.6666666666666666,
+    "42": 0.6666666666666666,
+    "43": 0.6666666666666666,
+    "44": 0.2857142857142857,
+    "45": 0.2857142857142857,
+    "46": 0.2857142857142857,
+    "47": 0.4,
+    "48": 0.3333333333333333,
+    "49": 0.3333333333333333,
+    "50": 0.3333333333333333,
+    "51": 0.3333333333333333,
+    "52": 0.3333333333333333,
+    "53": 0.3333333333333333,
+    "54": 0.3333333333333333,
+    "55": 0.3333333333333333,
+    "56": 0.4,
+    "57": 0.4,
+    "58": 0.4,
+    "59": 0.4,
+    "60": 0.4,
+    "61": 0.4,
+    "62": 0.4,
+    "63": 0.4,
+    "64": 0.4,
+    "65": 0.4,
+    "66": 0.4,
+    "67": 0.4,
+    "68": 0.4,
+    "69": 0.4,
+    "70": 0.4,
+    "71": 0.4,
+    "72": 0.4,
+    "73": 0.4,
+    "74": 0.4,
+    "75": 0.4,
+    "76": 0.4,
+    "77": 0.4,
+    "78": 0.4,
+    "79": 0.4,
+    "80": 0.4,
+    "81": 0.4,
+    "82": 0.4,
+    "83": 0.4,
+    "84": 0.4,
+    "85": 0.5,
+    "86": 0.5,
+    "87": 0.5,
+    "88": 0.5,
+    "89": 0.5,
+    "90": 0.5,
+    "91": 0.5,
+    "92": 0.5,
+    "93": 0.5,
+    "94": 0.5,
+    "95": 0.5,
+    "96": 0.5,
+    "97": 0.5,
+    "98": 0.5,
+    "99": 0.5,
+    "100": 0.5,
+    "101": 0.5,
+    "102": 0.5,
+    "103": 0.5,
+    "104": 0.5,
+    "105": 0.5,
+    "106": 0.5,
+    "107": 0.5,
+    "108": 0.5,
+    "109": 0.5,
+    "110": 0.5,
+    "111": 0.5,
+    "112": 0.5,
+    "113": 0.5,
+    "114": 0.5,
+    "115": 0.5,
+    "116": 0.5,
+    "117": 0.5,
+    "118": 0.5,
+    "119": 0.5,
+    "120": 0.5,
+    "121": 0.5,
+    "122": 0.5,
+    "123": 0.5,
+    "124": 0.5,
+    "125": 0.5,
+    "126": 0.5,
+    "127": 0.5,
+    "128": 0.5,
+    "129": 0.5,
+    "130": 0.5,
+    "131": 0.5,
+    "132": 0.5,
+    "133": 0.5,
+    "134": 0.5,
+    "135": 0.5,
+    "136": 0.5,
+    "137": 0.5,
+    "138": 0.5,
+    "139": 0.5,
+    "140": 0.5,
+    "141": 0.5,
+    "142": 0.5,
+    "143": 0.5,
+    "144": 0.5,
+    "145": 0.5,
+    "146": 0.5,
+    "147": 0.5,
+    "148": 0.5,
+    "149": 0.5,
+    "150": 0.6666666666666666,
+    "151": 0.6666666666666666,
+    "152": 0.6666666666666666,
+    "153": 0.6666666666666666,
+    "154": 0.6666666666666666,
+    "155": 0.6666666666666666,
+    "156": 0.6666666666666666,
+    "157": 0.6666666666666666,
+    "158": 0.6666666666666666,
+    "159": 0.6666666666666666,
+    "160": 0.6666666666666666,
+    "161": 1.0,
+    "162": 1.0,
+    "163": 1.0,
+    "164": 1.0,
+    "165": 1.0,
+    "166": 1.0,
+    "167": 1.0,
+    "168": 1.0,
+    "169": 1.0,
+    "170": 1.0,
+    "171": 1.0,
+    "172": 1.0,
+    "173": 1.0,
+    "174": 1.0,
+    "175": 1.0,
+    "176": 1.0,
+    "177": 1.0,
+    "178": 1.0,
+    "179": 1.0,
+    "180": 1.0,
+    "181": 1.0,
+    "182": 1.0
+  },
+  "gods": [
+    {
+      "id": "wireguard_values_schema_properties_enabled",
+      "label": "enabled",
+      "degree": 10
+    },
+    {
+      "id": "scripts_sync_artifacthub_changes_main",
+      "label": "main()",
+      "degree": 9
+    },
+    {
+      "id": "wg_easy_values_schema_properties_annotations",
+      "label": "annotations",
+      "degree": 9
+    },
+    {
+      "id": "wg_easy_values_schema_properties_port",
+      "label": "port",
+      "degree": 7
+    },
+    {
+      "id": "wg_easy_values_schema_properties_nodeport",
+      "label": "nodePort",
+      "degree": 7
+    },
+    {
+      "id": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "label": "verify.sh script",
+      "degree": 6
+    },
+    {
+      "id": "wg_easy_values_schema_properties_replicacount",
+      "label": "replicaCount",
+      "degree": 6
+    },
+    {
+      "id": "wg_easy_values_schema_properties_image",
+      "label": "image",
+      "degree": 6
+    },
+    {
+      "id": "wg_easy_values_schema_properties_imagepullsecrets",
+      "label": "imagePullSecrets",
+      "degree": 6
+    },
+    {
+      "id": "wg_easy_values_schema_items_additionalproperties",
+      "label": "additionalProperties",
+      "degree": 6
+    }
+  ],
+  "surprises": [],
+  "tokens": {
+    "input": 44258,
+    "output": 2538
+  }
+}

--- a/graphify-out/.graphify_semantic_marker
+++ b/graphify-out/.graphify_semantic_marker
@@ -1,0 +1,1 @@
+{"output_tokens": 2538}

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,0 +1,28291 @@
+{
+  "directed": false,
+  "multigraph": false,
+  "graph": {},
+  "nodes": [
+    {
+      "label": "sync-artifacthub-changes.py",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes",
+      "community": 13,
+      "norm_label": "sync-artifacthub-changes.py"
+    },
+    {
+      "label": "main()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_main",
+      "community": 13,
+      "norm_label": "main()"
+    },
+    {
+      "label": "parse_args()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L85",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_parse_args",
+      "community": 13,
+      "norm_label": "parse_args()"
+    },
+    {
+      "label": "Namespace",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L85",
+      "_origin": "ast",
+      "id": "namespace",
+      "community": 13,
+      "norm_label": "namespace"
+    },
+    {
+      "label": "read_current_version()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L91",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_read_current_version",
+      "community": 13,
+      "norm_label": "read_current_version()"
+    },
+    {
+      "label": "Path",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L91",
+      "_origin": "ast",
+      "id": "path",
+      "community": 13,
+      "norm_label": "path"
+    },
+    {
+      "label": "parse_top_changelog_entry()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L102",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "community": 13,
+      "norm_label": "parse_top_changelog_entry()"
+    },
+    {
+      "label": "extract_version_block()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L139",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_extract_version_block",
+      "community": 13,
+      "norm_label": "extract_version_block()"
+    },
+    {
+      "label": "split_description_and_link()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L162",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_split_description_and_link",
+      "community": 13,
+      "norm_label": "split_description_and_link()"
+    },
+    {
+      "label": "build_artifacthub_changes_block()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L180",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_build_artifacthub_changes_block",
+      "community": 13,
+      "norm_label": "build_artifacthub_changes_block()"
+    },
+    {
+      "label": "sync_prerelease_annotation()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L193",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_sync_prerelease_annotation",
+      "community": 13,
+      "norm_label": "sync_prerelease_annotation()"
+    },
+    {
+      "label": "replace_annotation_block()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L200",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "community": 13,
+      "norm_label": "replace_annotation_block()"
+    },
+    {
+      "label": "remove_annotation()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L219",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_remove_annotation",
+      "community": 13,
+      "norm_label": "remove_annotation()"
+    },
+    {
+      "label": "ensure_annotations_section()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L234",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_ensure_annotations_section",
+      "community": 13,
+      "norm_label": "ensure_annotations_section()"
+    },
+    {
+      "label": "find_annotations_section()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L249",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_find_annotations_section",
+      "community": 13,
+      "norm_label": "find_annotations_section()"
+    },
+    {
+      "label": "find_annotation_entry()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L263",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_find_annotation_entry",
+      "community": 13,
+      "norm_label": "find_annotation_entry()"
+    },
+    {
+      "label": "is_prerelease_version()",
+      "file_type": "code",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L283",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_is_prerelease_version",
+      "community": 13,
+      "norm_label": "is_prerelease_version()"
+    },
+    {
+      "label": "Return the change entries of the changelog section matching ``version``.      Ha",
+      "file_type": "rationale",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L103",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_rationale_103",
+      "community": 13,
+      "norm_label": "return the change entries of the changelog section matching ``version``.      ha"
+    },
+    {
+      "label": "Slice the changelog text belonging to the ``## <version>`` heading.",
+      "file_type": "rationale",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L140",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_rationale_140",
+      "community": 13,
+      "norm_label": "slice the changelog text belonging to the ``## <version>`` heading."
+    },
+    {
+      "label": "Strip a trailing markdown link ``([name](url))`` and return (description, url).",
+      "file_type": "rationale",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L163",
+      "_origin": "ast",
+      "id": "scripts_sync_artifacthub_changes_rationale_163",
+      "community": 13,
+      "norm_label": "strip a trailing markdown link ``([name](url))`` and return (description, url)."
+    },
+    {
+      "label": "install.sh",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/install.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_install_sh_verify_install",
+      "community": 161,
+      "norm_label": "install.sh"
+    },
+    {
+      "label": "install.sh script",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/install.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_install_sh__entry",
+      "community": 161,
+      "norm_label": "install.sh script"
+    },
+    {
+      "label": "uninstall.sh",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_uninstall_sh_verify_uninstall",
+      "community": 162,
+      "norm_label": "uninstall.sh"
+    },
+    {
+      "label": "uninstall.sh script",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_uninstall_sh__entry",
+      "community": 162,
+      "norm_label": "uninstall.sh script"
+    },
+    {
+      "label": "verify.sh",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "community": 41,
+      "norm_label": "verify.sh"
+    },
+    {
+      "label": "verify.sh script",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "community": 41,
+      "norm_label": "verify.sh script"
+    },
+    {
+      "label": "red()",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L11",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_verify_sh_verify_verify_red",
+      "community": 41,
+      "norm_label": "red()"
+    },
+    {
+      "label": "green()",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L12",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_verify_sh_verify_verify_green",
+      "community": 41,
+      "norm_label": "green()"
+    },
+    {
+      "label": "yellow()",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L13",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_verify_sh_verify_verify_yellow",
+      "community": 41,
+      "norm_label": "yellow()"
+    },
+    {
+      "label": "bold()",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L14",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_verify_sh_verify_verify_bold",
+      "community": 41,
+      "norm_label": "bold()"
+    },
+    {
+      "label": "check_logs()",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L16",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "community": 41,
+      "norm_label": "check_logs()"
+    },
+    {
+      "label": "values.schema.json",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema",
+      "community": 44,
+      "norm_label": "values.schema.json"
+    },
+    {
+      "label": "$schema",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_schema",
+      "community": 44,
+      "norm_label": "$schema"
+    },
+    {
+      "label": "$id",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L3",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_id",
+      "community": 44,
+      "norm_label": "$id"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_title",
+      "community": 44,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_description",
+      "community": 44,
+      "norm_label": "description"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_type",
+      "community": 44,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_additionalproperties",
+      "community": 44,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties",
+      "community": 96,
+      "norm_label": "properties"
+    },
+    {
+      "label": "global",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_global",
+      "community": 58,
+      "norm_label": "global"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_global_title",
+      "community": 58,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_global_description",
+      "community": 58,
+      "norm_label": "description"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_global_type",
+      "community": 58,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_global_additionalproperties",
+      "community": 58,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "replicaCount",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L15",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_replicacount",
+      "community": 51,
+      "norm_label": "replicacount"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L16",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_replicacount_title",
+      "community": 51,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L17",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_replicacount_type",
+      "community": 51,
+      "norm_label": "type"
+    },
+    {
+      "label": "minimum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L18",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_replicacount_minimum",
+      "community": 51,
+      "norm_label": "minimum"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_replicacount_default",
+      "community": 51,
+      "norm_label": "default"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_replicacount_description",
+      "community": 51,
+      "norm_label": "description"
+    },
+    {
+      "label": "image",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_image",
+      "community": 8,
+      "norm_label": "image"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_image_title",
+      "community": 8,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L24",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_image_type",
+      "community": 8,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_image_additionalproperties",
+      "community": 8,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L26",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_image_properties",
+      "community": 8,
+      "norm_label": "properties"
+    },
+    {
+      "label": "registry",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L27",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_registry",
+      "community": 8,
+      "norm_label": "registry"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L28",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_registry_title",
+      "community": 8,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_registry_type",
+      "community": 8,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_registry_description",
+      "community": 8,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L31",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_registry_default",
+      "community": 8,
+      "norm_label": "default"
+    },
+    {
+      "label": "repository",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L33",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_repository",
+      "community": 8,
+      "norm_label": "repository"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L34",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_repository_title",
+      "community": 8,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L35",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_repository_type",
+      "community": 8,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_repository_description",
+      "community": 8,
+      "norm_label": "description"
+    },
+    {
+      "label": "pullPolicy",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L38",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_pullpolicy",
+      "community": 8,
+      "norm_label": "pullpolicy"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_pullpolicy_title",
+      "community": 8,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L40",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_pullpolicy_type",
+      "community": 8,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L41",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_pullpolicy_enum",
+      "community": 8,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_pullpolicy_description",
+      "community": 8,
+      "norm_label": "description"
+    },
+    {
+      "label": "tag",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_tag",
+      "community": 8,
+      "norm_label": "tag"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tag_title",
+      "community": 8,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L50",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tag_type",
+      "community": 8,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L51",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tag_description",
+      "community": 8,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_image_required",
+      "community": 8,
+      "norm_label": "required"
+    },
+    {
+      "label": "imagePullSecrets",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_imagepullsecrets",
+      "community": 59,
+      "norm_label": "imagepullsecrets"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L60",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_imagepullsecrets_title",
+      "community": 59,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_imagepullsecrets_type",
+      "community": 59,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L62",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_imagepullsecrets_description",
+      "community": 59,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L63",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_imagepullsecrets_items",
+      "community": 22,
+      "norm_label": "items"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L64",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_items_type",
+      "community": 22,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L65",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_items_additionalproperties",
+      "community": 22,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_items_properties",
+      "community": 22,
+      "norm_label": "properties"
+    },
+    {
+      "label": "name",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L67",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_name",
+      "community": 17,
+      "norm_label": "name"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L68",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_name_title",
+      "community": 17,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L69",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_name_type",
+      "community": 17,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L70",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_name_description",
+      "community": 17,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L73",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_items_required",
+      "community": 22,
+      "norm_label": "required"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L75",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_imagepullsecrets_default",
+      "community": 59,
+      "norm_label": "default"
+    },
+    {
+      "label": "updateStrategy",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L77",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_updatestrategy",
+      "community": 27,
+      "norm_label": "updatestrategy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L78",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_updatestrategy_type",
+      "community": 27,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L79",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_updatestrategy_title",
+      "community": 27,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L80",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_updatestrategy_description",
+      "community": 27,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L81",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_updatestrategy_properties",
+      "community": 27,
+      "norm_label": "properties"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L82",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_type",
+      "community": 27,
+      "norm_label": "type"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L83",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_type_type",
+      "community": 27,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L84",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_type_title",
+      "community": 27,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L85",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_type_description",
+      "community": 27,
+      "norm_label": "description"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L86",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_type_enum",
+      "community": 27,
+      "norm_label": "enum"
+    },
+    {
+      "label": "nameOverride",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L93",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_nameoverride",
+      "community": 93,
+      "norm_label": "nameoverride"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L94",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameoverride_title",
+      "community": 93,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L95",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameoverride_type",
+      "community": 93,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L96",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameoverride_description",
+      "community": 93,
+      "norm_label": "description"
+    },
+    {
+      "label": "fullnameOverride",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L98",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_fullnameoverride",
+      "community": 90,
+      "norm_label": "fullnameoverride"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L99",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_fullnameoverride_title",
+      "community": 90,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L100",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_fullnameoverride_type",
+      "community": 90,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L101",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_fullnameoverride_description",
+      "community": 90,
+      "norm_label": "description"
+    },
+    {
+      "label": "commonLabels",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L103",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_commonlabels",
+      "community": 87,
+      "norm_label": "commonlabels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L104",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_commonlabels_type",
+      "community": 87,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L105",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_commonlabels_title",
+      "community": 87,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L106",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_commonlabels_description",
+      "community": 87,
+      "norm_label": "description"
+    },
+    {
+      "label": "commonAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L108",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_commonannotations",
+      "community": 86,
+      "norm_label": "commonannotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L109",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_commonannotations_type",
+      "community": 86,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L110",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_commonannotations_title",
+      "community": 86,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L111",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_commonannotations_description",
+      "community": 86,
+      "norm_label": "description"
+    },
+    {
+      "label": "initContainers",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L113",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_initcontainers",
+      "community": 60,
+      "norm_label": "initcontainers"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L114",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_initcontainers_type",
+      "community": 60,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L115",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_initcontainers_title",
+      "community": 60,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L116",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_initcontainers_description",
+      "community": 60,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L117",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_initcontainers_items",
+      "community": 60,
+      "norm_label": "items"
+    },
+    {
+      "label": "dnsPolicy",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L122",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_dnspolicy",
+      "community": 56,
+      "norm_label": "dnspolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L123",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnspolicy_type",
+      "community": 56,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L124",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnspolicy_title",
+      "community": 56,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L125",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnspolicy_description",
+      "community": 56,
+      "norm_label": "description"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L126",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnspolicy_enum",
+      "community": 56,
+      "norm_label": "enum"
+    },
+    {
+      "label": "dnsConfig",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L133",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_dnsconfig",
+      "community": 26,
+      "norm_label": "dnsconfig"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L134",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnsconfig_type",
+      "community": 26,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L135",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnsconfig_title",
+      "community": 26,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L136",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnsconfig_description",
+      "community": 26,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L137",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnsconfig_properties",
+      "community": 26,
+      "norm_label": "properties"
+    },
+    {
+      "label": "nameservers",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L138",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_nameservers",
+      "community": 61,
+      "norm_label": "nameservers"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L139",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameservers_type",
+      "community": 61,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L140",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameservers_title",
+      "community": 61,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L141",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameservers_description",
+      "community": 61,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L142",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nameservers_items",
+      "community": 61,
+      "norm_label": "items"
+    },
+    {
+      "label": "searches",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L146",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_searches",
+      "community": 62,
+      "norm_label": "searches"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L147",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_searches_type",
+      "community": 62,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L148",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_searches_title",
+      "community": 62,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L149",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_searches_description",
+      "community": 62,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L150",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_searches_items",
+      "community": 62,
+      "norm_label": "items"
+    },
+    {
+      "label": "options",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L154",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_options",
+      "community": 26,
+      "norm_label": "options"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L155",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_options_type",
+      "community": 26,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L156",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_options_title",
+      "community": 26,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L157",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_options_description",
+      "community": 26,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L158",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_options_items",
+      "community": 22,
+      "norm_label": "items"
+    },
+    {
+      "label": "value",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L165",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_value",
+      "community": 151,
+      "norm_label": "value"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L175",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dnsconfig_additionalproperties",
+      "community": 26,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "hostNetwork",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L177",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_hostnetwork",
+      "community": 91,
+      "norm_label": "hostnetwork"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L178",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_hostnetwork_title",
+      "community": 91,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L179",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_hostnetwork_type",
+      "community": 91,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L180",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_hostnetwork_description",
+      "community": 91,
+      "norm_label": "description"
+    },
+    {
+      "label": "sidecars",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L182",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_sidecars",
+      "community": 64,
+      "norm_label": "sidecars"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L183",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_sidecars_type",
+      "community": 64,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L184",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_sidecars_title",
+      "community": 64,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L185",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_sidecars_description",
+      "community": 64,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L186",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_sidecars_items",
+      "community": 64,
+      "norm_label": "items"
+    },
+    {
+      "label": "runtimeClassName",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L191",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_runtimeclassname",
+      "community": 97,
+      "norm_label": "runtimeclassname"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L192",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runtimeclassname_type",
+      "community": 97,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L193",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runtimeclassname_title",
+      "community": 97,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L194",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runtimeclassname_description",
+      "community": 97,
+      "norm_label": "description"
+    },
+    {
+      "label": "storage",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L196",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_storage",
+      "community": 65,
+      "norm_label": "storage"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L197",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storage_title",
+      "community": 65,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L198",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storage_type",
+      "community": 65,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L199",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storage_additionalproperties",
+      "community": 65,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L200",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storage_properties",
+      "community": 34,
+      "norm_label": "properties"
+    },
+    {
+      "label": "existingClaim",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L201",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_existingclaim",
+      "community": 34,
+      "norm_label": "existingclaim"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L202",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingclaim_title",
+      "community": 34,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L203",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingclaim_type",
+      "community": 34,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L204",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingclaim_description",
+      "community": 34,
+      "norm_label": "description"
+    },
+    {
+      "label": "storageClass",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L206",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_storageclass",
+      "community": 34,
+      "norm_label": "storageclass"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L207",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storageclass_title",
+      "community": 34,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L208",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storageclass_type",
+      "community": 34,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L209",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storageclass_description",
+      "community": 34,
+      "norm_label": "description"
+    },
+    {
+      "label": "size",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L211",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_size",
+      "community": 99,
+      "norm_label": "size"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L212",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_size_title",
+      "community": 99,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L213",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_size_type",
+      "community": 99,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L214",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_size_description",
+      "community": 99,
+      "norm_label": "description"
+    },
+    {
+      "label": "accessModes",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L216",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_accessmodes",
+      "community": 85,
+      "norm_label": "accessmodes"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L217",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_accessmodes_title",
+      "community": 85,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L218",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_accessmodes_type",
+      "community": 85,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L219",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_accessmodes_items",
+      "community": 22,
+      "norm_label": "items"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L221",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_items_enum",
+      "community": 22,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L228",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_accessmodes_description",
+      "community": 85,
+      "norm_label": "description"
+    },
+    {
+      "label": "annotations",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L230",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_annotations",
+      "community": 33,
+      "norm_label": "annotations"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L231",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_annotations_title",
+      "community": 33,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L232",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_annotations_type",
+      "community": 33,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L233",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_annotations_additionalproperties",
+      "community": 24,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L234",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_additionalproperties_type",
+      "community": 24,
+      "norm_label": "type"
+    },
+    {
+      "label": "labels",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L241",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_labels",
+      "community": 150,
+      "norm_label": "labels"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L242",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_labels_title",
+      "community": 150,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L243",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_labels_type",
+      "community": 150,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L244",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_labels_additionalproperties",
+      "community": 24,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "selector",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L252",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_selector",
+      "community": 98,
+      "norm_label": "selector"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L253",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_selector_title",
+      "community": 98,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L254",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_selector_type",
+      "community": 98,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L255",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_selector_description",
+      "community": 98,
+      "norm_label": "description"
+    },
+    {
+      "label": "resourcePolicy",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L257",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_resourcepolicy",
+      "community": 52,
+      "norm_label": "resourcepolicy"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L258",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resourcepolicy_title",
+      "community": 52,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L259",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resourcepolicy_type",
+      "community": 52,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L260",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resourcepolicy_enum",
+      "community": 52,
+      "norm_label": "enum"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L264",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resourcepolicy_default",
+      "community": 52,
+      "norm_label": "default"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L265",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resourcepolicy_description",
+      "community": 52,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L268",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_storage_required",
+      "community": 65,
+      "norm_label": "required"
+    },
+    {
+      "label": "config",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L274",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_config",
+      "community": 0,
+      "norm_label": "config"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L275",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_config_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L276",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_config_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L277",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_config_additionalproperties",
+      "community": 0,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L278",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_config_properties",
+      "community": 0,
+      "norm_label": "properties"
+    },
+    {
+      "label": "host",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L279",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_host",
+      "community": 0,
+      "norm_label": "host"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L280",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_host_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L281",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_host_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L282",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_host_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "insecure",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L284",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_insecure",
+      "community": 0,
+      "norm_label": "insecure"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L285",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_insecure_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L286",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_insecure_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L287",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_insecure_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "disable_ipv6",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L289",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_disable_ipv6",
+      "community": 0,
+      "norm_label": "disable_ipv6"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L290",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_disable_ipv6_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L291",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_disable_ipv6_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L292",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_disable_ipv6_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "init",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L294",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_init",
+      "community": 0,
+      "norm_label": "init"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L295",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_init_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L296",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_init_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L297",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_init_additionalproperties",
+      "community": 0,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L298",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_init_properties",
+      "community": 0,
+      "norm_label": "properties"
+    },
+    {
+      "label": "enabled",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L299",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_enabled",
+      "community": 15,
+      "norm_label": "enabled"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L300",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_enabled_title",
+      "community": 15,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L301",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_enabled_type",
+      "community": 15,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L302",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_enabled_description",
+      "community": 15,
+      "norm_label": "description"
+    },
+    {
+      "label": "existingSecret",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L304",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_existingsecret",
+      "community": 0,
+      "norm_label": "existingsecret"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L305",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingsecret_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L306",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingsecret_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L307",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingsecret_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "username",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L309",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_username",
+      "community": 0,
+      "norm_label": "username"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L310",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_username_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L311",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_username_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L312",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_username_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "password",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L314",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_password",
+      "community": 0,
+      "norm_label": "password"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L315",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_password_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L316",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_password_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L317",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_password_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "dns",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L324",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_dns",
+      "community": 0,
+      "norm_label": "dns"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L325",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dns_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L326",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dns_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L327",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_dns_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "ipv4_cidr",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L329",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_ipv4_cidr",
+      "community": 0,
+      "norm_label": "ipv4_cidr"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L330",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ipv4_cidr_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L331",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ipv4_cidr_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L332",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ipv4_cidr_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "ipv6_cidr",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L334",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_ipv6_cidr",
+      "community": 0,
+      "norm_label": "ipv6_cidr"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L335",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ipv6_cidr_title",
+      "community": 0,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L336",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ipv6_cidr_type",
+      "community": 0,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L337",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ipv6_cidr_description",
+      "community": 0,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L340",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_init_required",
+      "community": 0,
+      "norm_label": "required"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L343",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_config_required",
+      "community": 0,
+      "norm_label": "required"
+    },
+    {
+      "label": "extraEnvVars",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L345",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_extraenvvars",
+      "community": 57,
+      "norm_label": "extraenvvars"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L346",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvars_title",
+      "community": 57,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L347",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvars_type",
+      "community": 57,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L348",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvars_description",
+      "community": 57,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L349",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvars_items",
+      "community": 22,
+      "norm_label": "items"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L358",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_value_title",
+      "community": 151,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L359",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_value_type",
+      "community": 151,
+      "norm_label": "type"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L364",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvars_default",
+      "community": 57,
+      "norm_label": "default"
+    },
+    {
+      "label": "extraEnvVarsSecret",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L366",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_extraenvvarssecret",
+      "community": 89,
+      "norm_label": "extraenvvarssecret"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L367",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvarssecret_title",
+      "community": 89,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L368",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvarssecret_type",
+      "community": 89,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L369",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvarssecret_description",
+      "community": 89,
+      "norm_label": "description"
+    },
+    {
+      "label": "extraEnvVarsCM",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L371",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_extraenvvarscm",
+      "community": 88,
+      "norm_label": "extraenvvarscm"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L372",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvarscm_title",
+      "community": 88,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L373",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvarscm_type",
+      "community": 88,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L374",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_extraenvvarscm_description",
+      "community": 88,
+      "norm_label": "description"
+    },
+    {
+      "label": "serviceAccount",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L376",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_serviceaccount",
+      "community": 17,
+      "norm_label": "serviceaccount"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L377",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_serviceaccount_title",
+      "community": 17,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L378",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_serviceaccount_type",
+      "community": 17,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L379",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_serviceaccount_additionalproperties",
+      "community": 17,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L380",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_serviceaccount_properties",
+      "community": 17,
+      "norm_label": "properties"
+    },
+    {
+      "label": "create",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L381",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_create",
+      "community": 17,
+      "norm_label": "create"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L382",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_create_title",
+      "community": 17,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L383",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_create_type",
+      "community": 17,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L384",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_create_description",
+      "community": 17,
+      "norm_label": "description"
+    },
+    {
+      "label": "automount",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L386",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_automount",
+      "community": 17,
+      "norm_label": "automount"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L387",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_automount_title",
+      "community": 17,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L388",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_automount_type",
+      "community": 17,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L389",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_automount_description",
+      "community": 17,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L408",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_serviceaccount_required",
+      "community": 17,
+      "norm_label": "required"
+    },
+    {
+      "label": "serviceMonitor",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L410",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_servicemonitor",
+      "community": 63,
+      "norm_label": "servicemonitor"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L411",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_servicemonitor_title",
+      "community": 63,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L412",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_servicemonitor_type",
+      "community": 63,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L413",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_servicemonitor_additionalproperties",
+      "community": 63,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L414",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_servicemonitor_properties",
+      "community": 35,
+      "norm_label": "properties"
+    },
+    {
+      "label": "interval",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L447",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_interval",
+      "community": 35,
+      "norm_label": "interval"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L448",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_interval_title",
+      "community": 35,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L449",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_interval_type",
+      "community": 35,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L450",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_interval_description",
+      "community": 35,
+      "norm_label": "description"
+    },
+    {
+      "label": "namespace",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L452",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_namespace",
+      "community": 94,
+      "norm_label": "namespace"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L453",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_namespace_title",
+      "community": 94,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L454",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_namespace_type",
+      "community": 94,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L455",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_namespace_description",
+      "community": 94,
+      "norm_label": "description"
+    },
+    {
+      "label": "metricsPath",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L457",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_metricspath",
+      "community": 92,
+      "norm_label": "metricspath"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L458",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_metricspath_title",
+      "community": 92,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L459",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_metricspath_type",
+      "community": 92,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L460",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_metricspath_description",
+      "community": 92,
+      "norm_label": "description"
+    },
+    {
+      "label": "existingSecretKey",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L467",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_existingsecretkey",
+      "community": 35,
+      "norm_label": "existingsecretkey"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L468",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingsecretkey_title",
+      "community": 35,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L469",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingsecretkey_type",
+      "community": 35,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L470",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_existingsecretkey_description",
+      "community": 35,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L473",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_servicemonitor_required",
+      "community": 63,
+      "norm_label": "required"
+    },
+    {
+      "label": "podAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L475",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_podannotations",
+      "community": 24,
+      "norm_label": "podannotations"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L476",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podannotations_title",
+      "community": 24,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L477",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podannotations_type",
+      "community": 24,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L478",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podannotations_additionalproperties",
+      "community": 24,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "podLabels",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L486",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_podlabels",
+      "community": 24,
+      "norm_label": "podlabels"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L487",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podlabels_title",
+      "community": 24,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L488",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podlabels_type",
+      "community": 24,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L489",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podlabels_additionalproperties",
+      "community": 24,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "podSecurityContext",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L497",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_podsecuritycontext",
+      "community": 95,
+      "norm_label": "podsecuritycontext"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L498",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podsecuritycontext_title",
+      "community": 95,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L499",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podsecuritycontext_type",
+      "community": 95,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L500",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_podsecuritycontext_description",
+      "community": 95,
+      "norm_label": "description"
+    },
+    {
+      "label": "securityContext",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L502",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_securitycontext",
+      "community": 3,
+      "norm_label": "securitycontext"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L503",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_securitycontext_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L504",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_securitycontext_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L505",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_securitycontext_additionalproperties",
+      "community": 3,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L506",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_securitycontext_properties",
+      "community": 3,
+      "norm_label": "properties"
+    },
+    {
+      "label": "privileged",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L507",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_privileged",
+      "community": 3,
+      "norm_label": "privileged"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L508",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_privileged_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L509",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_privileged_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L510",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_privileged_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "allowPrivilegeEscalation",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L512",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_allowprivilegeescalation",
+      "community": 3,
+      "norm_label": "allowprivilegeescalation"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L513",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_allowprivilegeescalation_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L514",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_allowprivilegeescalation_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L515",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_allowprivilegeescalation_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "readOnlyRootFilesystem",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L517",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_readonlyrootfilesystem",
+      "community": 3,
+      "norm_label": "readonlyrootfilesystem"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L518",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_readonlyrootfilesystem_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L519",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_readonlyrootfilesystem_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L520",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_readonlyrootfilesystem_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "runAsNonRoot",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L522",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_runasnonroot",
+      "community": 3,
+      "norm_label": "runasnonroot"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L523",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runasnonroot_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L524",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runasnonroot_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L525",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runasnonroot_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "runAsUser",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L527",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_runasuser",
+      "community": 3,
+      "norm_label": "runasuser"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L528",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runasuser_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L529",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runasuser_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L530",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_runasuser_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "seccompProfile",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L532",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_seccompprofile",
+      "community": 36,
+      "norm_label": "seccompprofile"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L533",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_seccompprofile_title",
+      "community": 36,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L534",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_seccompprofile_type",
+      "community": 36,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L535",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_seccompprofile_description",
+      "community": 36,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L536",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_seccompprofile_properties",
+      "community": 36,
+      "norm_label": "properties"
+    },
+    {
+      "label": "localhostProfile",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L546",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_localhostprofile",
+      "community": 36,
+      "norm_label": "localhostprofile"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L547",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_localhostprofile_type",
+      "community": 36,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L548",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_localhostprofile_description",
+      "community": 36,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L551",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_seccompprofile_additionalproperties",
+      "community": 36,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "capabilities",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L553",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_capabilities",
+      "community": 3,
+      "norm_label": "capabilities"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L554",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_capabilities_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L555",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_capabilities_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L556",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_capabilities_additionalproperties",
+      "community": 3,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L557",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_capabilities_properties",
+      "community": 3,
+      "norm_label": "properties"
+    },
+    {
+      "label": "add",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L558",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_add",
+      "community": 3,
+      "norm_label": "add"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L559",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_add_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L560",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_add_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L561",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_add_items",
+      "community": 3,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L564",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_add_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "drop",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L566",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_drop",
+      "community": 3,
+      "norm_label": "drop"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L567",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_drop_title",
+      "community": 3,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L568",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_drop_type",
+      "community": 3,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L569",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_drop_items",
+      "community": 3,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L572",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_drop_description",
+      "community": 3,
+      "norm_label": "description"
+    },
+    {
+      "label": "service",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L578",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_service",
+      "community": 53,
+      "norm_label": "service"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L579",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_service_title",
+      "community": 53,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L580",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_service_type",
+      "community": 53,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L581",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_service_additionalproperties",
+      "community": 53,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L582",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_service_properties",
+      "community": 53,
+      "norm_label": "properties"
+    },
+    {
+      "label": "ui",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L583",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_ui",
+      "community": 33,
+      "norm_label": "ui"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L584",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ui_title",
+      "community": 33,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L585",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ui_type",
+      "community": 33,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L586",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ui_additionalproperties",
+      "community": 33,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L587",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ui_properties",
+      "community": 33,
+      "norm_label": "properties"
+    },
+    {
+      "label": "port",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L598",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_port",
+      "community": 50,
+      "norm_label": "port"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L599",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_port_title",
+      "community": 50,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L600",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_port_type",
+      "community": 50,
+      "norm_label": "type"
+    },
+    {
+      "label": "minimum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L601",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_port_minimum",
+      "community": 50,
+      "norm_label": "minimum"
+    },
+    {
+      "label": "maximum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L602",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_port_maximum",
+      "community": 50,
+      "norm_label": "maximum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L603",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_port_description",
+      "community": 50,
+      "norm_label": "description"
+    },
+    {
+      "label": "nodePort",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L605",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_nodeport",
+      "community": 49,
+      "norm_label": "nodeport"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L606",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nodeport_title",
+      "community": 49,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L607",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nodeport_type",
+      "community": 49,
+      "norm_label": "type"
+    },
+    {
+      "label": "minimum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L608",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nodeport_minimum",
+      "community": 49,
+      "norm_label": "minimum"
+    },
+    {
+      "label": "maximum",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L609",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nodeport_maximum",
+      "community": 49,
+      "norm_label": "maximum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L610",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_nodeport_description",
+      "community": 49,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L624",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ui_required",
+      "community": 33,
+      "norm_label": "required"
+    },
+    {
+      "label": "wireguard",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L626",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_wireguard",
+      "community": 66,
+      "norm_label": "wireguard"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L627",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_wireguard_title",
+      "community": 66,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L628",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_wireguard_type",
+      "community": 66,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L629",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_wireguard_additionalproperties",
+      "community": 66,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L630",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_wireguard_properties",
+      "community": 48,
+      "norm_label": "properties"
+    },
+    {
+      "label": "externalIPs",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L655",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_externalips",
+      "community": 48,
+      "norm_label": "externalips"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L656",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_externalips_title",
+      "community": 48,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L657",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_externalips_type",
+      "community": 48,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L658",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_externalips_description",
+      "community": 48,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L659",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_externalips_items",
+      "community": 48,
+      "norm_label": "items"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L675",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_wireguard_required",
+      "community": 66,
+      "norm_label": "required"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L678",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_service_required",
+      "community": 53,
+      "norm_label": "required"
+    },
+    {
+      "label": "ingress",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L680",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_ingress",
+      "community": 15,
+      "norm_label": "ingress"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L681",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ingress_title",
+      "community": 15,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L682",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ingress_type",
+      "community": 15,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L683",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ingress_additionalproperties",
+      "community": 15,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L684",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ingress_properties",
+      "community": 15,
+      "norm_label": "properties"
+    },
+    {
+      "label": "className",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L690",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_classname",
+      "community": 15,
+      "norm_label": "classname"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L691",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_classname_title",
+      "community": 15,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L692",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_classname_type",
+      "community": 15,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L693",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_classname_description",
+      "community": 15,
+      "norm_label": "description"
+    },
+    {
+      "label": "hosts",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L706",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_hosts",
+      "community": 22,
+      "norm_label": "hosts"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L707",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_hosts_title",
+      "community": 22,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L708",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_hosts_type",
+      "community": 22,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L709",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_hosts_items",
+      "community": 22,
+      "norm_label": "items"
+    },
+    {
+      "label": "paths",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L717",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_paths",
+      "community": 22,
+      "norm_label": "paths"
+    },
+    {
+      "label": "tls",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L740",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_tls",
+      "community": 15,
+      "norm_label": "tls"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L741",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tls_title",
+      "community": 15,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L742",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tls_type",
+      "community": 15,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L743",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tls_items",
+      "community": 15,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L746",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_tls_description",
+      "community": 15,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L749",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_ingress_required",
+      "community": 15,
+      "norm_label": "required"
+    },
+    {
+      "label": "resources",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L751",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_properties_resources",
+      "community": 96,
+      "norm_label": "resources"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L752",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resources_title",
+      "community": 96,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L753",
+      "_origin": "ast",
+      "id": "wg_easy_values_schema_resources_type",
+      "community": 96,
+      "norm_label": "type"
+    },
+    {
+      "label": "install.sh",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/install.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_install_sh_verify_install",
+      "community": 163,
+      "norm_label": "install.sh"
+    },
+    {
+      "label": "install.sh script",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/install.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_install_sh__entry",
+      "community": 163,
+      "norm_label": "install.sh script"
+    },
+    {
+      "label": "uninstall.sh",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_uninstall_sh_verify_uninstall",
+      "community": 164,
+      "norm_label": "uninstall.sh"
+    },
+    {
+      "label": "uninstall.sh script",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_uninstall_sh__entry",
+      "community": 164,
+      "norm_label": "uninstall.sh script"
+    },
+    {
+      "label": "verify.sh",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "community": 42,
+      "norm_label": "verify.sh"
+    },
+    {
+      "label": "verify.sh script",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "community": 42,
+      "norm_label": "verify.sh script"
+    },
+    {
+      "label": "red()",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L11",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_verify_sh_verify_verify_red",
+      "community": 42,
+      "norm_label": "red()"
+    },
+    {
+      "label": "green()",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L12",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_verify_sh_verify_verify_green",
+      "community": 42,
+      "norm_label": "green()"
+    },
+    {
+      "label": "yellow()",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L13",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_verify_sh_verify_verify_yellow",
+      "community": 42,
+      "norm_label": "yellow()"
+    },
+    {
+      "label": "bold()",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L14",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_verify_sh_verify_verify_bold",
+      "community": 42,
+      "norm_label": "bold()"
+    },
+    {
+      "label": "check_logs()",
+      "file_type": "code",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L16",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "community": 42,
+      "norm_label": "check_logs()"
+    },
+    {
+      "label": "values.schema.json",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "wireguard_values_schema",
+      "community": 54,
+      "norm_label": "values.schema.json"
+    },
+    {
+      "label": "$schema",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_schema",
+      "community": 54,
+      "norm_label": "$schema"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L3",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_title",
+      "community": 54,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_description",
+      "community": 54,
+      "norm_label": "description"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_type",
+      "community": 54,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_additionalproperties",
+      "community": 54,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties",
+      "community": 45,
+      "norm_label": "properties"
+    },
+    {
+      "label": "image",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_image",
+      "community": 9,
+      "norm_label": "image"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_image_type",
+      "community": 9,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_image_title",
+      "community": 9,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_image_description",
+      "community": 9,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_image_properties",
+      "community": 9,
+      "norm_label": "properties"
+    },
+    {
+      "label": "registry",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_registry",
+      "community": 9,
+      "norm_label": "registry"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L14",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_registry_type",
+      "community": 9,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L15",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_registry_title",
+      "community": 9,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L16",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_registry_description",
+      "community": 9,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L17",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_registry_default",
+      "community": 9,
+      "norm_label": "default"
+    },
+    {
+      "label": "repository",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_repository",
+      "community": 9,
+      "norm_label": "repository"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_repository_type",
+      "community": 9,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_repository_title",
+      "community": 9,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_repository_description",
+      "community": 9,
+      "norm_label": "description"
+    },
+    {
+      "label": "pullPolicy",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L24",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_pullpolicy",
+      "community": 9,
+      "norm_label": "pullpolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pullpolicy_type",
+      "community": 9,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L26",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pullpolicy_title",
+      "community": 9,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L27",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pullpolicy_description",
+      "community": 9,
+      "norm_label": "description"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L28",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pullpolicy_enum",
+      "community": 9,
+      "norm_label": "enum"
+    },
+    {
+      "label": "tag",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L34",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_tag",
+      "community": 9,
+      "norm_label": "tag"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L35",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tag_type",
+      "community": 9,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tag_title",
+      "community": 9,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tag_description",
+      "community": 9,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L40",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_image_required",
+      "community": 9,
+      "norm_label": "required"
+    },
+    {
+      "label": "imagePullSecrets",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L45",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_imagepullsecrets",
+      "community": 69,
+      "norm_label": "imagepullsecrets"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_imagepullsecrets_title",
+      "community": 69,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_imagepullsecrets_type",
+      "community": 69,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_imagepullsecrets_description",
+      "community": 69,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_imagepullsecrets_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L50",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_items_type",
+      "community": 21,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L51",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_items_additionalproperties",
+      "community": 21,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L52",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_items_properties",
+      "community": 21,
+      "norm_label": "properties"
+    },
+    {
+      "label": "name",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L53",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_name",
+      "community": 11,
+      "norm_label": "name"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L54",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_name_title",
+      "community": 11,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L55",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_name_type",
+      "community": 11,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L56",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_name_description",
+      "community": 11,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_items_required",
+      "community": 21,
+      "norm_label": "required"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L61",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_imagepullsecrets_default",
+      "community": 69,
+      "norm_label": "default"
+    },
+    {
+      "label": "nameOverride",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L63",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_nameoverride",
+      "community": 117,
+      "norm_label": "nameoverride"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L64",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameoverride_type",
+      "community": 117,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L65",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameoverride_title",
+      "community": 117,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L66",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameoverride_description",
+      "community": 117,
+      "norm_label": "description"
+    },
+    {
+      "label": "fullnameOverride",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L68",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_fullnameoverride",
+      "community": 113,
+      "norm_label": "fullnameoverride"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L69",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_fullnameoverride_type",
+      "community": 113,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L70",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_fullnameoverride_title",
+      "community": 113,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L71",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_fullnameoverride_description",
+      "community": 113,
+      "norm_label": "description"
+    },
+    {
+      "label": "commonLabels",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L73",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_commonlabels",
+      "community": 103,
+      "norm_label": "commonlabels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L74",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_commonlabels_type",
+      "community": 103,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L75",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_commonlabels_title",
+      "community": 103,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L76",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_commonlabels_description",
+      "community": 103,
+      "norm_label": "description"
+    },
+    {
+      "label": "commonAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L78",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_commonannotations",
+      "community": 102,
+      "norm_label": "commonannotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L79",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_commonannotations_type",
+      "community": 102,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L80",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_commonannotations_title",
+      "community": 102,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L81",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_commonannotations_description",
+      "community": 102,
+      "norm_label": "description"
+    },
+    {
+      "label": "replicaCount",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L83",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_replicacount",
+      "community": 122,
+      "norm_label": "replicacount"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L84",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_replicacount_type",
+      "community": 122,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L85",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_replicacount_title",
+      "community": 122,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L86",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_replicacount_description",
+      "community": 122,
+      "norm_label": "description"
+    },
+    {
+      "label": "dnsPolicy",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L88",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_dnspolicy",
+      "community": 67,
+      "norm_label": "dnspolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L89",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnspolicy_type",
+      "community": 67,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L90",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnspolicy_title",
+      "community": 67,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L91",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnspolicy_description",
+      "community": 67,
+      "norm_label": "description"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L92",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnspolicy_enum",
+      "community": 67,
+      "norm_label": "enum"
+    },
+    {
+      "label": "dnsConfig",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L99",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_dnsconfig",
+      "community": 29,
+      "norm_label": "dnsconfig"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L100",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnsconfig_type",
+      "community": 29,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L101",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnsconfig_title",
+      "community": 29,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L102",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnsconfig_description",
+      "community": 29,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L103",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnsconfig_properties",
+      "community": 29,
+      "norm_label": "properties"
+    },
+    {
+      "label": "nameservers",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L104",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_nameservers",
+      "community": 70,
+      "norm_label": "nameservers"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L105",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameservers_type",
+      "community": 70,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L106",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameservers_title",
+      "community": 70,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L107",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameservers_description",
+      "community": 70,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L108",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nameservers_items",
+      "community": 70,
+      "norm_label": "items"
+    },
+    {
+      "label": "searches",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L112",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_searches",
+      "community": 72,
+      "norm_label": "searches"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L113",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_searches_type",
+      "community": 72,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L114",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_searches_title",
+      "community": 72,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L115",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_searches_description",
+      "community": 72,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L116",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_searches_items",
+      "community": 72,
+      "norm_label": "items"
+    },
+    {
+      "label": "options",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L120",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_options",
+      "community": 29,
+      "norm_label": "options"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L121",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_options_type",
+      "community": 29,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L122",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_options_title",
+      "community": 29,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L123",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_options_description",
+      "community": 29,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L124",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_options_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "value",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L131",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_value",
+      "community": 21,
+      "norm_label": "value"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L141",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dnsconfig_additionalproperties",
+      "community": 29,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "hostNetwork",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L143",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_hostnetwork",
+      "community": 114,
+      "norm_label": "hostnetwork"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L144",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_hostnetwork_title",
+      "community": 114,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L145",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_hostnetwork_type",
+      "community": 114,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L146",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_hostnetwork_description",
+      "community": 114,
+      "norm_label": "description"
+    },
+    {
+      "label": "updateStrategy",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L148",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_updatestrategy",
+      "community": 5,
+      "norm_label": "updatestrategy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L149",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_updatestrategy_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L150",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_updatestrategy_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L151",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_updatestrategy_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L152",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_updatestrategy_properties",
+      "community": 5,
+      "norm_label": "properties"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L153",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L154",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_type_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L155",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_type_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L156",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_type_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L157",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_type_enum",
+      "community": 5,
+      "norm_label": "enum"
+    },
+    {
+      "label": "initContainers",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L164",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_initcontainers",
+      "community": 115,
+      "norm_label": "initcontainers"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L165",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initcontainers_type",
+      "community": 115,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L166",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initcontainers_title",
+      "community": 115,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L167",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initcontainers_description",
+      "community": 115,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L168",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initcontainers_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "sidecars",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L173",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_sidecars",
+      "community": 125,
+      "norm_label": "sidecars"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L174",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_sidecars_type",
+      "community": 125,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L175",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_sidecars_title",
+      "community": 125,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L176",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_sidecars_description",
+      "community": 125,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L177",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_sidecars_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "wireguard",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L182",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_wireguard",
+      "community": 127,
+      "norm_label": "wireguard"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L183",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_wireguard_type",
+      "community": 127,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L184",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_wireguard_title",
+      "community": 127,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L185",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_wireguard_description",
+      "community": 127,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L186",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_wireguard_properties",
+      "community": 68,
+      "norm_label": "properties"
+    },
+    {
+      "label": "timezone",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L187",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_timezone",
+      "community": 126,
+      "norm_label": "timezone"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L188",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_timezone_type",
+      "community": 126,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L189",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_timezone_title",
+      "community": 126,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L190",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_timezone_description",
+      "community": 126,
+      "norm_label": "description"
+    },
+    {
+      "label": "dns",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L192",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_dns",
+      "community": 107,
+      "norm_label": "dns"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L193",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dns_type",
+      "community": 107,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L194",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dns_title",
+      "community": 107,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L195",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_dns_description",
+      "community": 107,
+      "norm_label": "description"
+    },
+    {
+      "label": "allowedIPs",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L197",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_allowedips",
+      "community": 101,
+      "norm_label": "allowedips"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L198",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_allowedips_type",
+      "community": 101,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L199",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_allowedips_title",
+      "community": 101,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L200",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_allowedips_description",
+      "community": 101,
+      "norm_label": "description"
+    },
+    {
+      "label": "listenPort",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L202",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_listenport",
+      "community": 116,
+      "norm_label": "listenport"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L203",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_listenport_type",
+      "community": 116,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L204",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_listenport_title",
+      "community": 116,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L205",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_listenport_description",
+      "community": 116,
+      "norm_label": "description"
+    },
+    {
+      "label": "extraEnvVars",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L207",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_extraenvvars",
+      "community": 108,
+      "norm_label": "extraenvvars"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L208",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvars_type",
+      "community": 108,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L209",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvars_title",
+      "community": 108,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L210",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvars_description",
+      "community": 108,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L211",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvars_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "extraEnvVarsSecret",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L227",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_extraenvvarssecret",
+      "community": 110,
+      "norm_label": "extraenvvarssecret"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L228",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvarssecret_type",
+      "community": 110,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L229",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvarssecret_title",
+      "community": 110,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L230",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvarssecret_description",
+      "community": 110,
+      "norm_label": "description"
+    },
+    {
+      "label": "extraEnvVarsCM",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L232",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_extraenvvarscm",
+      "community": 109,
+      "norm_label": "extraenvvarscm"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L233",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvarscm_type",
+      "community": 109,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L234",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvarscm_title",
+      "community": 109,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L235",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extraenvvarscm_description",
+      "community": 109,
+      "norm_label": "description"
+    },
+    {
+      "label": "existingSecret",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L237",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_existingsecret",
+      "community": 68,
+      "norm_label": "existingsecret"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L238",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_existingsecret_type",
+      "community": 68,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L239",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_existingsecret_title",
+      "community": 68,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L240",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_existingsecret_description",
+      "community": 68,
+      "norm_label": "description"
+    },
+    {
+      "label": "PUID",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L242",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_puid",
+      "community": 121,
+      "norm_label": "puid"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L243",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_puid_type",
+      "community": 121,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L244",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_puid_title",
+      "community": 121,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L245",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_puid_description",
+      "community": 121,
+      "norm_label": "description"
+    },
+    {
+      "label": "PGID",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L247",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_pgid",
+      "community": 118,
+      "norm_label": "pgid"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L248",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pgid_type",
+      "community": 118,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L249",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pgid_title",
+      "community": 118,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L250",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_pgid_description",
+      "community": 118,
+      "norm_label": "description"
+    },
+    {
+      "label": "server",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L252",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_server",
+      "community": 30,
+      "norm_label": "server"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L253",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_server_type",
+      "community": 30,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L254",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_server_title",
+      "community": 30,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L255",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_server_description",
+      "community": 30,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L256",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_server_properties",
+      "community": 30,
+      "norm_label": "properties"
+    },
+    {
+      "label": "enabled",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L257",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_enabled",
+      "community": 4,
+      "norm_label": "enabled"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L258",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_enabled_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L259",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_enabled_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L260",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_enabled_description",
+      "community": 4,
+      "norm_label": "description"
+    },
+    {
+      "label": "storage",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L262",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_storage",
+      "community": 30,
+      "norm_label": "storage"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L263",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_storage_type",
+      "community": 30,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L264",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_storage_title",
+      "community": 30,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L265",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_storage_description",
+      "community": 30,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L266",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_storage_properties",
+      "community": 30,
+      "norm_label": "properties"
+    },
+    {
+      "label": "config",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L318",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_config",
+      "community": 28,
+      "norm_label": "config"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L319",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_config_type",
+      "community": 28,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L320",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_config_title",
+      "community": 28,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L321",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_config_description",
+      "community": 28,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L322",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_config_properties",
+      "community": 28,
+      "norm_label": "properties"
+    },
+    {
+      "label": "client",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L352",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_client",
+      "community": 28,
+      "norm_label": "client"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L353",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_client_type",
+      "community": 28,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L354",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_client_title",
+      "community": 28,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L355",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_client_description",
+      "community": 28,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L356",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_client_properties",
+      "community": 28,
+      "norm_label": "properties"
+    },
+    {
+      "label": "serviceAccount",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L418",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_serviceaccount",
+      "community": 11,
+      "norm_label": "serviceaccount"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L419",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_serviceaccount_type",
+      "community": 11,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L420",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_serviceaccount_title",
+      "community": 11,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L421",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_serviceaccount_description",
+      "community": 11,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L422",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_serviceaccount_properties",
+      "community": 11,
+      "norm_label": "properties"
+    },
+    {
+      "label": "create",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L423",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_create",
+      "community": 11,
+      "norm_label": "create"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L424",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_create_type",
+      "community": 11,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L425",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_create_title",
+      "community": 11,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L426",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_create_description",
+      "community": 11,
+      "norm_label": "description"
+    },
+    {
+      "label": "automount",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L428",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_automount",
+      "community": 11,
+      "norm_label": "automount"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L429",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_automount_type",
+      "community": 11,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L430",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_automount_title",
+      "community": 11,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L431",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_automount_description",
+      "community": 11,
+      "norm_label": "description"
+    },
+    {
+      "label": "annotations",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L433",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_annotations",
+      "community": 11,
+      "norm_label": "annotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L434",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_annotations_type",
+      "community": 11,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L435",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_annotations_title",
+      "community": 11,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L436",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_annotations_description",
+      "community": 11,
+      "norm_label": "description"
+    },
+    {
+      "label": "podAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L445",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_podannotations",
+      "community": 119,
+      "norm_label": "podannotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L446",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podannotations_type",
+      "community": 119,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L447",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podannotations_title",
+      "community": 119,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L448",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podannotations_description",
+      "community": 119,
+      "norm_label": "description"
+    },
+    {
+      "label": "podLabels",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L450",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_podlabels",
+      "community": 120,
+      "norm_label": "podlabels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L451",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podlabels_type",
+      "community": 120,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L452",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podlabels_title",
+      "community": 120,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L453",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podlabels_description",
+      "community": 120,
+      "norm_label": "description"
+    },
+    {
+      "label": "podSecurityContext",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L455",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_podsecuritycontext",
+      "community": 71,
+      "norm_label": "podsecuritycontext"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L456",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podsecuritycontext_type",
+      "community": 71,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L457",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podsecuritycontext_title",
+      "community": 71,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L458",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podsecuritycontext_description",
+      "community": 71,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L459",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_podsecuritycontext_additionalproperties",
+      "community": 71,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "securityContext",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L461",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_securitycontext",
+      "community": 2,
+      "norm_label": "securitycontext"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L462",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_securitycontext_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L463",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_securitycontext_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L464",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_securitycontext_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L465",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_securitycontext_additionalproperties",
+      "community": 2,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L466",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_securitycontext_properties",
+      "community": 2,
+      "norm_label": "properties"
+    },
+    {
+      "label": "privileged",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L467",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_privileged",
+      "community": 2,
+      "norm_label": "privileged"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L468",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_privileged_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L469",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_privileged_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L470",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_privileged_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "allowPrivilegeEscalation",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L472",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_allowprivilegeescalation",
+      "community": 2,
+      "norm_label": "allowprivilegeescalation"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L473",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_allowprivilegeescalation_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L474",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_allowprivilegeescalation_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L475",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_allowprivilegeescalation_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "readOnlyRootFilesystem",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L477",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_readonlyrootfilesystem",
+      "community": 2,
+      "norm_label": "readonlyrootfilesystem"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L478",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readonlyrootfilesystem_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L479",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readonlyrootfilesystem_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L480",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readonlyrootfilesystem_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "runAsNonRoot",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L482",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_runasnonroot",
+      "community": 2,
+      "norm_label": "runasnonroot"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L483",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_runasnonroot_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L484",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_runasnonroot_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L485",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_runasnonroot_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "runAsUser",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L487",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_runasuser",
+      "community": 2,
+      "norm_label": "runasuser"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L488",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_runasuser_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L489",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_runasuser_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L490",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_runasuser_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "seccompProfile",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L492",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_seccompprofile",
+      "community": 5,
+      "norm_label": "seccompprofile"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L493",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_seccompprofile_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L494",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_seccompprofile_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L495",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_seccompprofile_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L496",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_seccompprofile_properties",
+      "community": 5,
+      "norm_label": "properties"
+    },
+    {
+      "label": "localhostProfile",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L506",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_localhostprofile",
+      "community": 5,
+      "norm_label": "localhostprofile"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L507",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_localhostprofile_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L508",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_localhostprofile_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L511",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_seccompprofile_additionalproperties",
+      "community": 5,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "capabilities",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L513",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_capabilities",
+      "community": 2,
+      "norm_label": "capabilities"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L514",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_capabilities_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L515",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_capabilities_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L516",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_capabilities_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L517",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_capabilities_additionalproperties",
+      "community": 2,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L518",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_capabilities_properties",
+      "community": 2,
+      "norm_label": "properties"
+    },
+    {
+      "label": "add",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L519",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_add",
+      "community": 2,
+      "norm_label": "add"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L520",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_add_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L521",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_add_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L522",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_add_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L523",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_add_items",
+      "community": 2,
+      "norm_label": "items"
+    },
+    {
+      "label": "drop",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L527",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_drop",
+      "community": 2,
+      "norm_label": "drop"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L528",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_drop_type",
+      "community": 2,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L529",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_drop_title",
+      "community": 2,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L530",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_drop_description",
+      "community": 2,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L531",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_drop_items",
+      "community": 2,
+      "norm_label": "items"
+    },
+    {
+      "label": "service",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L539",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_service",
+      "community": 5,
+      "norm_label": "service"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L540",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_service_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L541",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_service_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L542",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_service_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L543",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_service_properties",
+      "community": 5,
+      "norm_label": "properties"
+    },
+    {
+      "label": "port",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L554",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_port",
+      "community": 5,
+      "norm_label": "port"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L555",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_port_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L556",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_port_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L557",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_port_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "nodePort",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L559",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_nodeport",
+      "community": 5,
+      "norm_label": "nodeport"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L560",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nodeport_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L561",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nodeport_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L562",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nodeport_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "externalIPs",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L564",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_externalips",
+      "community": 5,
+      "norm_label": "externalips"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L565",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_externalips_type",
+      "community": 5,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L566",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_externalips_title",
+      "community": 5,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L567",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_externalips_description",
+      "community": 5,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L568",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_externalips_items",
+      "community": 5,
+      "norm_label": "items"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L571",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_externalips_default",
+      "community": 5,
+      "norm_label": "default"
+    },
+    {
+      "label": "resources",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L575",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_resources",
+      "community": 123,
+      "norm_label": "resources"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L576",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_resources_type",
+      "community": 123,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L577",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_resources_title",
+      "community": 123,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L578",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_resources_description",
+      "community": 123,
+      "norm_label": "description"
+    },
+    {
+      "label": "livenessProbe",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L580",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_livenessprobe",
+      "community": 4,
+      "norm_label": "livenessprobe"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L581",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_livenessprobe_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L582",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_livenessprobe_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L583",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_livenessprobe_description",
+      "community": 4,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L584",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_livenessprobe_properties",
+      "community": 4,
+      "norm_label": "properties"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L588",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_enabled_default",
+      "community": 4,
+      "norm_label": "default"
+    },
+    {
+      "label": "initialDelaySeconds",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L590",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_initialdelayseconds",
+      "community": 4,
+      "norm_label": "initialdelayseconds"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L591",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initialdelayseconds_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L592",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initialdelayseconds_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L593",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_initialdelayseconds_default",
+      "community": 4,
+      "norm_label": "default"
+    },
+    {
+      "label": "periodSeconds",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L595",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_periodseconds",
+      "community": 4,
+      "norm_label": "periodseconds"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L596",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_periodseconds_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L597",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_periodseconds_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L598",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_periodseconds_default",
+      "community": 4,
+      "norm_label": "default"
+    },
+    {
+      "label": "timeoutSeconds",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L600",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_timeoutseconds",
+      "community": 4,
+      "norm_label": "timeoutseconds"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L601",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_timeoutseconds_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L602",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_timeoutseconds_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L603",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_timeoutseconds_default",
+      "community": 4,
+      "norm_label": "default"
+    },
+    {
+      "label": "failureThreshold",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L605",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_failurethreshold",
+      "community": 4,
+      "norm_label": "failurethreshold"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L606",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_failurethreshold_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L607",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_failurethreshold_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L608",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_failurethreshold_default",
+      "community": 4,
+      "norm_label": "default"
+    },
+    {
+      "label": "successThreshold",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L610",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_successthreshold",
+      "community": 4,
+      "norm_label": "successthreshold"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L611",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_successthreshold_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L612",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_successthreshold_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L613",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_successthreshold_default",
+      "community": 4,
+      "norm_label": "default"
+    },
+    {
+      "label": "readinessProbe",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L617",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_readinessprobe",
+      "community": 4,
+      "norm_label": "readinessprobe"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L618",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readinessprobe_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L619",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readinessprobe_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L620",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readinessprobe_description",
+      "community": 4,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L621",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readinessprobe_properties",
+      "community": 4,
+      "norm_label": "properties"
+    },
+    {
+      "label": "startupProbe",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L654",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_startupprobe",
+      "community": 4,
+      "norm_label": "startupprobe"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L655",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_startupprobe_type",
+      "community": 4,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L656",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_startupprobe_title",
+      "community": 4,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L657",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_startupprobe_description",
+      "community": 4,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L658",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_startupprobe_properties",
+      "community": 4,
+      "norm_label": "properties"
+    },
+    {
+      "label": "customLivenessProbe",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L691",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_customlivenessprobe",
+      "community": 104,
+      "norm_label": "customlivenessprobe"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L692",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customlivenessprobe_type",
+      "community": 104,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L693",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customlivenessprobe_title",
+      "community": 104,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L694",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customlivenessprobe_description",
+      "community": 104,
+      "norm_label": "description"
+    },
+    {
+      "label": "customReadinessProbe",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L696",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_customreadinessprobe",
+      "community": 105,
+      "norm_label": "customreadinessprobe"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L697",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customreadinessprobe_type",
+      "community": 105,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L698",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customreadinessprobe_title",
+      "community": 105,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L699",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customreadinessprobe_description",
+      "community": 105,
+      "norm_label": "description"
+    },
+    {
+      "label": "customStartupProbe",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L701",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_customstartupprobe",
+      "community": 106,
+      "norm_label": "customstartupprobe"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L702",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customstartupprobe_type",
+      "community": 106,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L703",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customstartupprobe_title",
+      "community": 106,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L704",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_customstartupprobe_description",
+      "community": 106,
+      "norm_label": "description"
+    },
+    {
+      "label": "autoscaling",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L706",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_autoscaling",
+      "community": 18,
+      "norm_label": "autoscaling"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L707",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_autoscaling_type",
+      "community": 18,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L708",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_autoscaling_title",
+      "community": 18,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L709",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_autoscaling_description",
+      "community": 18,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L710",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_autoscaling_properties",
+      "community": 18,
+      "norm_label": "properties"
+    },
+    {
+      "label": "minReplicas",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L715",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_minreplicas",
+      "community": 18,
+      "norm_label": "minreplicas"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L716",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_minreplicas_type",
+      "community": 18,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L717",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_minreplicas_title",
+      "community": 18,
+      "norm_label": "title"
+    },
+    {
+      "label": "maxReplicas",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L719",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_maxreplicas",
+      "community": 18,
+      "norm_label": "maxreplicas"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L720",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_maxreplicas_type",
+      "community": 18,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L721",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_maxreplicas_title",
+      "community": 18,
+      "norm_label": "title"
+    },
+    {
+      "label": "targetCPUUtilizationPercentage",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L723",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_targetcpuutilizationpercentage",
+      "community": 18,
+      "norm_label": "targetcpuutilizationpercentage"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L724",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_targetcpuutilizationpercentage_type",
+      "community": 18,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L725",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_targetcpuutilizationpercentage_title",
+      "community": 18,
+      "norm_label": "title"
+    },
+    {
+      "label": "targetMemoryUtilizationPercentage",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L727",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_targetmemoryutilizationpercentage",
+      "community": 18,
+      "norm_label": "targetmemoryutilizationpercentage"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L728",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_targetmemoryutilizationpercentage_type",
+      "community": 18,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L729",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_targetmemoryutilizationpercentage_title",
+      "community": 18,
+      "norm_label": "title"
+    },
+    {
+      "label": "extraVolumes",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L733",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_extravolumes",
+      "community": 112,
+      "norm_label": "extravolumes"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L734",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumes_type",
+      "community": 112,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L735",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumes_title",
+      "community": 112,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L736",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumes_description",
+      "community": 112,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L737",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumes_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "secret",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L744",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_secret",
+      "community": 124,
+      "norm_label": "secret"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L745",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_secret_type",
+      "community": 124,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L746",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_secret_title",
+      "community": 124,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L747",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_secret_description",
+      "community": 124,
+      "norm_label": "description"
+    },
+    {
+      "label": "extraVolumeMounts",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L753",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_extravolumemounts",
+      "community": 111,
+      "norm_label": "extravolumemounts"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L754",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumemounts_type",
+      "community": 111,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L755",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumemounts_title",
+      "community": 111,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L756",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumemounts_description",
+      "community": 111,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L757",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_extravolumemounts_items",
+      "community": 21,
+      "norm_label": "items"
+    },
+    {
+      "label": "mountPath",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L764",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_mountpath",
+      "community": 21,
+      "norm_label": "mountpath"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L765",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_mountpath_type",
+      "community": 21,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L766",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_mountpath_title",
+      "community": 21,
+      "norm_label": "title"
+    },
+    {
+      "label": "readOnly",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L768",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_readonly",
+      "community": 152,
+      "norm_label": "readonly"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L769",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readonly_type",
+      "community": 152,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L770",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_readonly_title",
+      "community": 152,
+      "norm_label": "title"
+    },
+    {
+      "label": "nodeSelector",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L776",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_nodeselector",
+      "community": 45,
+      "norm_label": "nodeselector"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L777",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nodeselector_type",
+      "community": 45,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L778",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nodeselector_title",
+      "community": 45,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L779",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_nodeselector_description",
+      "community": 45,
+      "norm_label": "description"
+    },
+    {
+      "label": "tolerations",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L781",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_tolerations",
+      "community": 73,
+      "norm_label": "tolerations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L782",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tolerations_type",
+      "community": 73,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L783",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tolerations_title",
+      "community": 73,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L784",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tolerations_description",
+      "community": 73,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L785",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_tolerations_items",
+      "community": 73,
+      "norm_label": "items"
+    },
+    {
+      "label": "affinity",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L789",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_affinity",
+      "community": 100,
+      "norm_label": "affinity"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L790",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_affinity_type",
+      "community": 100,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L791",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_affinity_title",
+      "community": 100,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L792",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_affinity_description",
+      "community": 100,
+      "norm_label": "description"
+    },
+    {
+      "label": "topologySpreadConstraints",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L794",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_topologyspreadconstraints",
+      "community": 74,
+      "norm_label": "topologyspreadconstraints"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L795",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_topologyspreadconstraints_type",
+      "community": 74,
+      "norm_label": "type"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L796",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_topologyspreadconstraints_title",
+      "community": 74,
+      "norm_label": "title"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L797",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_topologyspreadconstraints_description",
+      "community": 74,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L798",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_topologyspreadconstraints_items",
+      "community": 74,
+      "norm_label": "items"
+    },
+    {
+      "label": "priorityClassName",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L802",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_properties_priorityclassname",
+      "community": 45,
+      "norm_label": "priorityclassname"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L803",
+      "_origin": "ast",
+      "id": "wireguard_values_schema_priorityclassname_type",
+      "community": 45,
+      "norm_label": "type"
+    },
+    {
+      "label": "install.sh",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/install.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_install_sh_verify_install",
+      "community": 165,
+      "norm_label": "install.sh"
+    },
+    {
+      "label": "install.sh script",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/install.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_install_sh__entry",
+      "community": 165,
+      "norm_label": "install.sh script"
+    },
+    {
+      "label": "uninstall.sh",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_uninstall_sh_verify_uninstall",
+      "community": 166,
+      "norm_label": "uninstall.sh"
+    },
+    {
+      "label": "uninstall.sh script",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_uninstall_sh__entry",
+      "community": 166,
+      "norm_label": "uninstall.sh script"
+    },
+    {
+      "label": "verify.sh",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "community": 43,
+      "norm_label": "verify.sh"
+    },
+    {
+      "label": "verify.sh script",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "community": 43,
+      "norm_label": "verify.sh script"
+    },
+    {
+      "label": "red()",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L10",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_verify_sh_verify_verify_red",
+      "community": 43,
+      "norm_label": "red()"
+    },
+    {
+      "label": "green()",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L11",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_verify_sh_verify_verify_green",
+      "community": 43,
+      "norm_label": "green()"
+    },
+    {
+      "label": "yellow()",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L12",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_verify_sh_verify_verify_yellow",
+      "community": 43,
+      "norm_label": "yellow()"
+    },
+    {
+      "label": "bold()",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L13",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_verify_sh_verify_verify_bold",
+      "community": 43,
+      "norm_label": "bold()"
+    },
+    {
+      "label": "check_logs()",
+      "file_type": "code",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L15",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "community": 43,
+      "norm_label": "check_logs()"
+    },
+    {
+      "label": "values.schema.json",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "wordpress_values_schema",
+      "community": 37,
+      "norm_label": "values.schema.json"
+    },
+    {
+      "label": "$schema",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_schema",
+      "community": 37,
+      "norm_label": "$schema"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L3",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_type",
+      "community": 37,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties",
+      "community": 37,
+      "norm_label": "properties"
+    },
+    {
+      "label": "controllerType",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_controllertype",
+      "community": 77,
+      "norm_label": "controllertype"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_controllertype_type",
+      "community": 77,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_controllertype_enum",
+      "community": 77,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_controllertype_description",
+      "community": 77,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_controllertype_default",
+      "community": 77,
+      "norm_label": "default"
+    },
+    {
+      "label": "replicaCount",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L14",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_replicacount",
+      "community": 145,
+      "norm_label": "replicacount"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L15",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_replicacount_type",
+      "community": 145,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L16",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_replicacount_description",
+      "community": 145,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L17",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_replicacount_default",
+      "community": 145,
+      "norm_label": "default"
+    },
+    {
+      "label": "statefulset",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_statefulset",
+      "community": 6,
+      "norm_label": "statefulset"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_statefulset_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_statefulset_description",
+      "community": 6,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_statefulset_properties",
+      "community": 6,
+      "norm_label": "properties"
+    },
+    {
+      "label": "podManagementPolicy",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_podmanagementpolicy",
+      "community": 6,
+      "norm_label": "podmanagementpolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L24",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podmanagementpolicy_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podmanagementpolicy_enum",
+      "community": 6,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podmanagementpolicy_description",
+      "community": 6,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podmanagementpolicy_default",
+      "community": 6,
+      "norm_label": "default"
+    },
+    {
+      "label": "updateStrategy",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L32",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_updatestrategy",
+      "community": 6,
+      "norm_label": "updatestrategy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L33",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_updatestrategy_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L34",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_updatestrategy_description",
+      "community": 6,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L35",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_updatestrategy_properties",
+      "community": 6,
+      "norm_label": "properties"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_type_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L38",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_type_enum",
+      "community": 6,
+      "norm_label": "enum"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_type_default",
+      "community": 6,
+      "norm_label": "default"
+    },
+    {
+      "label": "persistentVolumeClaimRetentionPolicy",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L46",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_persistentvolumeclaimretentionpolicy",
+      "community": 6,
+      "norm_label": "persistentvolumeclaimretentionpolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L47",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L48",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_description",
+      "community": 6,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L49",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_properties",
+      "community": 6,
+      "norm_label": "properties"
+    },
+    {
+      "label": "whenDeleted",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L50",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_whendeleted",
+      "community": 6,
+      "norm_label": "whendeleted"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L51",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_whendeleted_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L52",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_whendeleted_enum",
+      "community": 6,
+      "norm_label": "enum"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L56",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_whendeleted_default",
+      "community": 6,
+      "norm_label": "default"
+    },
+    {
+      "label": "whenScaled",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L58",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_whenscaled",
+      "community": 6,
+      "norm_label": "whenscaled"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L59",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_whenscaled_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L60",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_whenscaled_enum",
+      "community": 6,
+      "norm_label": "enum"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L64",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_whenscaled_default",
+      "community": 6,
+      "norm_label": "default"
+    },
+    {
+      "label": "image",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L70",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_image",
+      "community": 12,
+      "norm_label": "image"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L71",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_image_type",
+      "community": 12,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L72",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_image_properties",
+      "community": 12,
+      "norm_label": "properties"
+    },
+    {
+      "label": "registry",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L73",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_registry",
+      "community": 12,
+      "norm_label": "registry"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L74",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_registry_type",
+      "community": 12,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L75",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_registry_description",
+      "community": 12,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L76",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_registry_default",
+      "community": 12,
+      "norm_label": "default"
+    },
+    {
+      "label": "repository",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L78",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_repository",
+      "community": 12,
+      "norm_label": "repository"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L79",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repository_type",
+      "community": 12,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L80",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repository_description",
+      "community": 12,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L81",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repository_default",
+      "community": 12,
+      "norm_label": "default"
+    },
+    {
+      "label": "pullPolicy",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L83",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_pullpolicy",
+      "community": 12,
+      "norm_label": "pullpolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L84",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pullpolicy_type",
+      "community": 12,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L85",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pullpolicy_enum",
+      "community": 12,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L90",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pullpolicy_description",
+      "community": 12,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L91",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pullpolicy_default",
+      "community": 12,
+      "norm_label": "default"
+    },
+    {
+      "label": "tag",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L93",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_tag",
+      "community": 12,
+      "norm_label": "tag"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L94",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_tag_type",
+      "community": 12,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L95",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_tag_description",
+      "community": 12,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L96",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_tag_default",
+      "community": 12,
+      "norm_label": "default"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L99",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_image_required",
+      "community": 12,
+      "norm_label": "required"
+    },
+    {
+      "label": "imagePullSecrets",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L105",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_imagepullsecrets",
+      "community": 46,
+      "norm_label": "imagepullsecrets"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L106",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_imagepullsecrets_title",
+      "community": 46,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L107",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_imagepullsecrets_type",
+      "community": 46,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L108",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_imagepullsecrets_description",
+      "community": 46,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L109",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_imagepullsecrets_items",
+      "community": 46,
+      "norm_label": "items"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L110",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_items_type",
+      "community": 153,
+      "norm_label": "type"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L111",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_items_additionalproperties",
+      "community": 46,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L112",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_items_properties",
+      "community": 14,
+      "norm_label": "properties"
+    },
+    {
+      "label": "name",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L113",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_name",
+      "community": 39,
+      "norm_label": "name"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L114",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_name_title",
+      "community": 39,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L115",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_name_type",
+      "community": 39,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L116",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_name_description",
+      "community": 39,
+      "norm_label": "description"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L119",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_items_required",
+      "community": 55,
+      "norm_label": "required"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L121",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_imagepullsecrets_default",
+      "community": 46,
+      "norm_label": "default"
+    },
+    {
+      "label": "nameOverride",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L123",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_nameoverride",
+      "community": 141,
+      "norm_label": "nameoverride"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L124",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_nameoverride_type",
+      "community": 141,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L125",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_nameoverride_description",
+      "community": 141,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L126",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_nameoverride_default",
+      "community": 141,
+      "norm_label": "default"
+    },
+    {
+      "label": "fullnameOverride",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L128",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_fullnameoverride",
+      "community": 139,
+      "norm_label": "fullnameoverride"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L129",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_fullnameoverride_type",
+      "community": 139,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L130",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_fullnameoverride_description",
+      "community": 139,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L131",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_fullnameoverride_default",
+      "community": 139,
+      "norm_label": "default"
+    },
+    {
+      "label": "clusterDomain",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L133",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_clusterdomain",
+      "community": 129,
+      "norm_label": "clusterdomain"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L134",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_clusterdomain_type",
+      "community": 129,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L135",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_clusterdomain_description",
+      "community": 129,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L136",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_clusterdomain_default",
+      "community": 129,
+      "norm_label": "default"
+    },
+    {
+      "label": "dnsPolicy",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L138",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_dnspolicy",
+      "community": 37,
+      "norm_label": "dnspolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L139",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_dnspolicy_type",
+      "community": 37,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L140",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_dnspolicy_description",
+      "community": 37,
+      "norm_label": "description"
+    },
+    {
+      "label": "dnsConfig",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L142",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_dnsconfig",
+      "community": 155,
+      "norm_label": "dnsconfig"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L143",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_dnsconfig_type",
+      "community": 155,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L144",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_dnsconfig_description",
+      "community": 155,
+      "norm_label": "description"
+    },
+    {
+      "label": "hostNetwork",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L146",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_hostnetwork",
+      "community": 156,
+      "norm_label": "hostnetwork"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L147",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_hostnetwork_type",
+      "community": 156,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L148",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_hostnetwork_description",
+      "community": 156,
+      "norm_label": "description"
+    },
+    {
+      "label": "customLabels",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L150",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customlabels",
+      "community": 133,
+      "norm_label": "customlabels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L151",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customlabels_type",
+      "community": 133,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L152",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customlabels_description",
+      "community": 133,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L153",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customlabels_default",
+      "community": 133,
+      "norm_label": "default"
+    },
+    {
+      "label": "customAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L155",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customannotations",
+      "community": 131,
+      "norm_label": "customannotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L156",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customannotations_type",
+      "community": 131,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L157",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customannotations_description",
+      "community": 131,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L158",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customannotations_default",
+      "community": 131,
+      "norm_label": "default"
+    },
+    {
+      "label": "commonLabels",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L160",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_commonlabels",
+      "community": 38,
+      "norm_label": "commonlabels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L161",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_commonlabels_type",
+      "community": 38,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L162",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_commonlabels_description",
+      "community": 38,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L163",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_commonlabels_additionalproperties",
+      "community": 38,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L164",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_additionalproperties_type",
+      "community": 38,
+      "norm_label": "type"
+    },
+    {
+      "label": "commonAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L167",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_commonannotations",
+      "community": 38,
+      "norm_label": "commonannotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L168",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_commonannotations_type",
+      "community": 38,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L169",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_commonannotations_description",
+      "community": 38,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L170",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_commonannotations_additionalproperties",
+      "community": 38,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L183",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_type_description",
+      "community": 6,
+      "norm_label": "description"
+    },
+    {
+      "label": "rollingUpdate",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L186",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_rollingupdate",
+      "community": 6,
+      "norm_label": "rollingupdate"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L187",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_rollingupdate_type",
+      "community": 6,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L188",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_rollingupdate_properties",
+      "community": 6,
+      "norm_label": "properties"
+    },
+    {
+      "label": "maxSurge",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L189",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_maxsurge",
+      "community": 6,
+      "norm_label": "maxsurge"
+    },
+    {
+      "label": "oneOf",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L190",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_maxsurge_oneof",
+      "community": 6,
+      "norm_label": "oneof"
+    },
+    {
+      "label": "maxUnavailable",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L199",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_maxunavailable",
+      "community": 6,
+      "norm_label": "maxunavailable"
+    },
+    {
+      "label": "oneOf",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L200",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_maxunavailable_oneof",
+      "community": 6,
+      "norm_label": "oneof"
+    },
+    {
+      "label": "initContainers",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L213",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_initcontainers",
+      "community": 79,
+      "norm_label": "initcontainers"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L214",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_initcontainers_type",
+      "community": 79,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L215",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_initcontainers_items",
+      "community": 79,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L218",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_initcontainers_description",
+      "community": 79,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L219",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_initcontainers_default",
+      "community": 79,
+      "norm_label": "default"
+    },
+    {
+      "label": "sidecars",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L221",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_sidecars",
+      "community": 82,
+      "norm_label": "sidecars"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L222",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_sidecars_type",
+      "community": 82,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L223",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_sidecars_items",
+      "community": 82,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L226",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_sidecars_description",
+      "community": 82,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L227",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_sidecars_default",
+      "community": 82,
+      "norm_label": "default"
+    },
+    {
+      "label": "command",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L229",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_command",
+      "community": 76,
+      "norm_label": "command"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L230",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_command_type",
+      "community": 76,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L231",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_command_items",
+      "community": 76,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L234",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_command_description",
+      "community": 76,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L235",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_command_default",
+      "community": 76,
+      "norm_label": "default"
+    },
+    {
+      "label": "args",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L237",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_args",
+      "community": 75,
+      "norm_label": "args"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L238",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_args_type",
+      "community": 75,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L239",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_args_items",
+      "community": 75,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L242",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_args_description",
+      "community": 75,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L243",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_args_default",
+      "community": 75,
+      "norm_label": "default"
+    },
+    {
+      "label": "extraEnvVars",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L245",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_extraenvvars",
+      "community": 78,
+      "norm_label": "extraenvvars"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L246",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvars_type",
+      "community": 78,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L247",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvars_items",
+      "community": 78,
+      "norm_label": "items"
+    },
+    {
+      "label": "value",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L253",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_value",
+      "community": 14,
+      "norm_label": "value"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L254",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_value_type",
+      "community": 14,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L261",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvars_description",
+      "community": 78,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L262",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvars_default",
+      "community": 78,
+      "norm_label": "default"
+    },
+    {
+      "label": "extraEnvVarsSecret",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L264",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_extraenvvarssecret",
+      "community": 138,
+      "norm_label": "extraenvvarssecret"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L265",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvarssecret_type",
+      "community": 138,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L266",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvarssecret_description",
+      "community": 138,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L267",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvarssecret_default",
+      "community": 138,
+      "norm_label": "default"
+    },
+    {
+      "label": "extraEnvVarsCM",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L269",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_extraenvvarscm",
+      "community": 137,
+      "norm_label": "extraenvvarscm"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L270",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvarscm_type",
+      "community": 137,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L271",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvarscm_description",
+      "community": 137,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L272",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_extraenvvarscm_default",
+      "community": 137,
+      "norm_label": "default"
+    },
+    {
+      "label": "wordpress",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L274",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_wordpress",
+      "community": 160,
+      "norm_label": "wordpress"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L275",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_wordpress_type",
+      "community": 160,
+      "norm_label": "type"
+    },
+    {
+      "label": "required",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L276",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_wordpress_required",
+      "community": 160,
+      "norm_label": "required"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L279",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_wordpress_properties",
+      "community": 32,
+      "norm_label": "properties"
+    },
+    {
+      "label": "init",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L280",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_init",
+      "community": 32,
+      "norm_label": "init"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L281",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_init_type",
+      "community": 32,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L282",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_init_properties",
+      "community": 23,
+      "norm_label": "properties"
+    },
+    {
+      "label": "enabled",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L313",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_enabled",
+      "community": 135,
+      "norm_label": "enabled"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L314",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_enabled_type",
+      "community": 135,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L315",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_enabled_description",
+      "community": 135,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L316",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_enabled_default",
+      "community": 135,
+      "norm_label": "default"
+    },
+    {
+      "label": "existingSecret",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L318",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_existingsecret",
+      "community": 136,
+      "norm_label": "existingsecret"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L319",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingsecret_type",
+      "community": 136,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L320",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingsecret_description",
+      "community": 136,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L321",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingsecret_default",
+      "community": 136,
+      "norm_label": "default"
+    },
+    {
+      "label": "secretKeys",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L323",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_secretkeys",
+      "community": 146,
+      "norm_label": "secretkeys"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L324",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_secretkeys_type",
+      "community": 146,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L325",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_secretkeys_description",
+      "community": 146,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L326",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_secretkeys_properties",
+      "community": 146,
+      "norm_label": "properties"
+    },
+    {
+      "label": "username",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L344",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_username",
+      "community": 159,
+      "norm_label": "username"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L345",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_username_type",
+      "community": 159,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L346",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_username_description",
+      "community": 159,
+      "norm_label": "description"
+    },
+    {
+      "label": "password",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L348",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_password",
+      "community": 23,
+      "norm_label": "password"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L349",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_password_type",
+      "community": 23,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L350",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_password_description",
+      "community": 23,
+      "norm_label": "description"
+    },
+    {
+      "label": "email",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L352",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_email",
+      "community": 14,
+      "norm_label": "email"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L353",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_email_type",
+      "community": 14,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L354",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_email_description",
+      "community": 14,
+      "norm_label": "description"
+    },
+    {
+      "label": "firstname",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L356",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_firstname",
+      "community": 14,
+      "norm_label": "firstname"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L357",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_firstname_type",
+      "community": 14,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L358",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_firstname_description",
+      "community": 14,
+      "norm_label": "description"
+    },
+    {
+      "label": "lastname",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L360",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_lastname",
+      "community": 158,
+      "norm_label": "lastname"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L361",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_lastname_type",
+      "community": 158,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L362",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_lastname_description",
+      "community": 158,
+      "norm_label": "description"
+    },
+    {
+      "label": "title",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L364",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_title",
+      "community": 23,
+      "norm_label": "title"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L365",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_title_type",
+      "community": 23,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L366",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_title_description",
+      "community": 23,
+      "norm_label": "description"
+    },
+    {
+      "label": "debug",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L368",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_debug",
+      "community": 134,
+      "norm_label": "debug"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L369",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_debug_type",
+      "community": 134,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L370",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_debug_description",
+      "community": 134,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L371",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_debug_default",
+      "community": 134,
+      "norm_label": "default"
+    },
+    {
+      "label": "customInitScript",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L373",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_custominitscript",
+      "community": 23,
+      "norm_label": "custominitscript"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L374",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_custominitscript_type",
+      "community": 23,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L375",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_custominitscript_description",
+      "community": 23,
+      "norm_label": "description"
+    },
+    {
+      "label": "customInitConfigMap",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L377",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_custominitconfigmap",
+      "community": 132,
+      "norm_label": "custominitconfigmap"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L378",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_custominitconfigmap_type",
+      "community": 132,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L379",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_custominitconfigmap_description",
+      "community": 132,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L380",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_custominitconfigmap_properties",
+      "community": 132,
+      "norm_label": "properties"
+    },
+    {
+      "label": "multiSites",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L393",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_multisites",
+      "community": 80,
+      "norm_label": "multisites"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L394",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_multisites_type",
+      "community": 80,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L395",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_multisites_description",
+      "community": 80,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L396",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_multisites_properties",
+      "community": 80,
+      "norm_label": "properties"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L457",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_multisites_default",
+      "community": 80,
+      "norm_label": "default"
+    },
+    {
+      "label": "applicationPassword",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L464",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_applicationpassword",
+      "community": 128,
+      "norm_label": "applicationpassword"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L465",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_applicationpassword_type",
+      "community": 128,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L466",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_applicationpassword_description",
+      "community": 128,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L467",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_applicationpassword_properties",
+      "community": 128,
+      "norm_label": "properties"
+    },
+    {
+      "label": "jwt",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L500",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_jwt",
+      "community": 23,
+      "norm_label": "jwt"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L501",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_jwt_type",
+      "community": 23,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L502",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_jwt_description",
+      "community": 23,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L503",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_jwt_properties",
+      "community": 23,
+      "norm_label": "properties"
+    },
+    {
+      "label": "permalinks",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L528",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_permalinks",
+      "community": 25,
+      "norm_label": "permalinks"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L529",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_permalinks_type",
+      "community": 25,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L530",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_permalinks_properties",
+      "community": 25,
+      "norm_label": "properties"
+    },
+    {
+      "label": "structure",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L531",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_structure",
+      "community": 25,
+      "norm_label": "structure"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L532",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_structure_type",
+      "community": 25,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L533",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_structure_enum",
+      "community": 25,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L540",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_structure_description",
+      "community": 25,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L541",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_structure_default",
+      "community": 25,
+      "norm_label": "default"
+    },
+    {
+      "label": "customStructure",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L543",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customstructure",
+      "community": 25,
+      "norm_label": "customstructure"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L544",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customstructure_type",
+      "community": 25,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L545",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customstructure_description",
+      "community": 25,
+      "norm_label": "description"
+    },
+    {
+      "label": "plugins",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L549",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_plugins",
+      "community": 55,
+      "norm_label": "plugins"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L550",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_plugins_type",
+      "community": 55,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L551",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_plugins_items",
+      "community": 55,
+      "norm_label": "items"
+    },
+    {
+      "label": "version",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L558",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_version",
+      "community": 14,
+      "norm_label": "version"
+    },
+    {
+      "label": "activate",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L562",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_activate",
+      "community": 14,
+      "norm_label": "activate"
+    },
+    {
+      "label": "autoupdate",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L566",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_autoupdate",
+      "community": 14,
+      "norm_label": "autoupdate"
+    },
+    {
+      "label": "networkActivate",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L570",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_networkactivate",
+      "community": 14,
+      "norm_label": "networkactivate"
+    },
+    {
+      "label": "sites",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L574",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_sites",
+      "community": 14,
+      "norm_label": "sites"
+    },
+    {
+      "label": "slug",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L581",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_slug",
+      "community": 14,
+      "norm_label": "slug"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L590",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_plugins_description",
+      "community": 55,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L591",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_plugins_default",
+      "community": 55,
+      "norm_label": "default"
+    },
+    {
+      "label": "pluginsPrune",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L593",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_pluginsprune",
+      "community": 142,
+      "norm_label": "pluginsprune"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L594",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pluginsprune_type",
+      "community": 142,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L595",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pluginsprune_description",
+      "community": 142,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L596",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_pluginsprune_default",
+      "community": 142,
+      "norm_label": "default"
+    },
+    {
+      "label": "themes",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L598",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_themes",
+      "community": 83,
+      "norm_label": "themes"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L599",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themes_type",
+      "community": 83,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L600",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themes_items",
+      "community": 83,
+      "norm_label": "items"
+    },
+    {
+      "label": "networkEnable",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L619",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_networkenable",
+      "community": 14,
+      "norm_label": "networkenable"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L639",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themes_description",
+      "community": 83,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L640",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themes_default",
+      "community": 83,
+      "norm_label": "default"
+    },
+    {
+      "label": "themesPrune",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L642",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_themesprune",
+      "community": 149,
+      "norm_label": "themesprune"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L643",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themesprune_type",
+      "community": 149,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L644",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themesprune_description",
+      "community": 149,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L645",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_themesprune_default",
+      "community": 149,
+      "norm_label": "default"
+    },
+    {
+      "label": "composer",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L647",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_composer",
+      "community": 31,
+      "norm_label": "composer"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L648",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_composer_type",
+      "community": 31,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L649",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_composer_properties",
+      "community": 31,
+      "norm_label": "properties"
+    },
+    {
+      "label": "repositories",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L650",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_repositories",
+      "community": 31,
+      "norm_label": "repositories"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L651",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repositories_type",
+      "community": 31,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L652",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repositories_items",
+      "community": 31,
+      "norm_label": "items"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L669",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repositories_description",
+      "community": 31,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L670",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_repositories_default",
+      "community": 31,
+      "norm_label": "default"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L673",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_composer_default",
+      "community": 31,
+      "norm_label": "default"
+    },
+    {
+      "label": "repositories",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L674",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_default_repositories",
+      "community": 31,
+      "norm_label": "repositories"
+    },
+    {
+      "label": "users",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L677",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_users",
+      "community": 84,
+      "norm_label": "users"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L678",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_users_type",
+      "community": 84,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L679",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_users_items",
+      "community": 84,
+      "norm_label": "items"
+    },
+    {
+      "label": "displayname",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L690",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_displayname",
+      "community": 14,
+      "norm_label": "displayname"
+    },
+    {
+      "label": "role",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L702",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_role",
+      "community": 14,
+      "norm_label": "role"
+    },
+    {
+      "label": "sendEmail",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L713",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_sendemail",
+      "community": 14,
+      "norm_label": "sendemail"
+    },
+    {
+      "label": "superAdmin",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L717",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_superadmin",
+      "community": 14,
+      "norm_label": "superadmin"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L791",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_users_description",
+      "community": 84,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L792",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_users_default",
+      "community": 84,
+      "norm_label": "default"
+    },
+    {
+      "label": "tablePrefix",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L794",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_tableprefix",
+      "community": 148,
+      "norm_label": "tableprefix"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L795",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_tableprefix_type",
+      "community": 148,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L796",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_tableprefix_description",
+      "community": 148,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L797",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_tableprefix_default",
+      "community": 148,
+      "norm_label": "default"
+    },
+    {
+      "label": "language",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L799",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_language",
+      "community": 157,
+      "norm_label": "language"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L800",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_language_type",
+      "community": 157,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L801",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_language_description",
+      "community": 157,
+      "norm_label": "description"
+    },
+    {
+      "label": "url",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L803",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_url",
+      "community": 32,
+      "norm_label": "url"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L804",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_url_type",
+      "community": 32,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L805",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_url_description",
+      "community": 32,
+      "norm_label": "description"
+    },
+    {
+      "label": "minLength",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L806",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_url_minlength",
+      "community": 32,
+      "norm_label": "minlength"
+    },
+    {
+      "label": "configExtraInject",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L808",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_configextrainject",
+      "community": 130,
+      "norm_label": "configextrainject"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L809",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextrainject_type",
+      "community": 130,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L810",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextrainject_description",
+      "community": 130,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L811",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextrainject_default",
+      "community": 130,
+      "norm_label": "default"
+    },
+    {
+      "label": "configExtra",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L813",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_configextra",
+      "community": 154,
+      "norm_label": "configextra"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L814",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextra_type",
+      "community": 154,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L815",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextra_description",
+      "community": 154,
+      "norm_label": "description"
+    },
+    {
+      "label": "configExtraConfigMap",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L817",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_configextraconfigmap",
+      "community": 39,
+      "norm_label": "configextraconfigmap"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L818",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextraconfigmap_type",
+      "community": 39,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L819",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextraconfigmap_description",
+      "community": 39,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L820",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextraconfigmap_properties",
+      "community": 39,
+      "norm_label": "properties"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L824",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_name_default",
+      "community": 39,
+      "norm_label": "default"
+    },
+    {
+      "label": "key",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L826",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_key",
+      "community": 40,
+      "norm_label": "key"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L827",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_key_type",
+      "community": 40,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L828",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_key_description",
+      "community": 40,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L829",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_key_default",
+      "community": 40,
+      "norm_label": "default"
+    },
+    {
+      "label": "configExtraSecret",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L833",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_configextrasecret",
+      "community": 40,
+      "norm_label": "configextrasecret"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L834",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextrasecret_type",
+      "community": 40,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L835",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextrasecret_description",
+      "community": 40,
+      "norm_label": "description"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L836",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_configextrasecret_properties",
+      "community": 40,
+      "norm_label": "properties"
+    },
+    {
+      "label": "htaccess",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L849",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_htaccess",
+      "community": 32,
+      "norm_label": "htaccess"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L850",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_htaccess_type",
+      "community": 32,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L851",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_htaccess_description",
+      "community": 32,
+      "norm_label": "description"
+    },
+    {
+      "label": "htaccessConfigMap",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L853",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_htaccessconfigmap",
+      "community": 140,
+      "norm_label": "htaccessconfigmap"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L854",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_htaccessconfigmap_type",
+      "community": 140,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L855",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_htaccessconfigmap_description",
+      "community": 140,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L856",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_htaccessconfigmap_default",
+      "community": 140,
+      "norm_label": "default"
+    },
+    {
+      "label": "muPluginsConfigMaps",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L863",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_mupluginsconfigmaps",
+      "community": 81,
+      "norm_label": "mupluginsconfigmaps"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L864",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_mupluginsconfigmaps_type",
+      "community": 81,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L865",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_mupluginsconfigmaps_description",
+      "community": 81,
+      "norm_label": "description"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L866",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_mupluginsconfigmaps_items",
+      "community": 81,
+      "norm_label": "items"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L882",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_mupluginsconfigmaps_default",
+      "community": 81,
+      "norm_label": "default"
+    },
+    {
+      "label": "smtp",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L884",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_smtp",
+      "community": 147,
+      "norm_label": "smtp"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L885",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_smtp_type",
+      "community": 147,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L886",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_smtp_description",
+      "community": 147,
+      "norm_label": "description"
+    },
+    {
+      "label": "additionalProperties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L887",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_smtp_additionalproperties",
+      "community": 147,
+      "norm_label": "additionalproperties"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L888",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_smtp_properties",
+      "community": 16,
+      "norm_label": "properties"
+    },
+    {
+      "label": "host",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L892",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_host",
+      "community": 16,
+      "norm_label": "host"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L893",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_host_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "port",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L895",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_port",
+      "community": 16,
+      "norm_label": "port"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L896",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_port_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "encryption",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L898",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_encryption",
+      "community": 16,
+      "norm_label": "encryption"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L899",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_encryption_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "fromEmail",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L901",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_fromemail",
+      "community": 16,
+      "norm_label": "fromemail"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L902",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_fromemail_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "fromName",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L904",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_fromname",
+      "community": 16,
+      "norm_label": "fromname"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L905",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_fromname_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "auth",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L907",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_auth",
+      "community": 16,
+      "norm_label": "auth"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L908",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_auth_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "existingSecretPasswordKey",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L919",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_existingsecretpasswordkey",
+      "community": 16,
+      "norm_label": "existingsecretpasswordkey"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L920",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingsecretpasswordkey_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "existingSecretUsernameKey",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L922",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_existingsecretusernamekey",
+      "community": 16,
+      "norm_label": "existingsecretusernamekey"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L923",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingsecretusernamekey_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "existingSecretFromEmailKey",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L925",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_existingsecretfromemailkey",
+      "community": 16,
+      "norm_label": "existingsecretfromemailkey"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L926",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingsecretfromemailkey_type",
+      "community": 16,
+      "norm_label": "type"
+    },
+    {
+      "label": "apache",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L932",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_apache",
+      "community": 7,
+      "norm_label": "apache"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L933",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_apache_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L934",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_apache_properties",
+      "community": 7,
+      "norm_label": "properties"
+    },
+    {
+      "label": "serverName",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L935",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_servername",
+      "community": 7,
+      "norm_label": "servername"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L936",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_servername_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L937",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_servername_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L938",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_servername_default",
+      "community": 7,
+      "norm_label": "default"
+    },
+    {
+      "label": "customDefaultSiteConfig",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L940",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customdefaultsiteconfig",
+      "community": 7,
+      "norm_label": "customdefaultsiteconfig"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L941",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customdefaultsiteconfig_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L942",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customdefaultsiteconfig_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "customDefaultSiteConfigMap",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L944",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customdefaultsiteconfigmap",
+      "community": 7,
+      "norm_label": "customdefaultsiteconfigmap"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L945",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customdefaultsiteconfigmap_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L946",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customdefaultsiteconfigmap_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L947",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customdefaultsiteconfigmap_default",
+      "community": 7,
+      "norm_label": "default"
+    },
+    {
+      "label": "customPortsConfig",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L949",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customportsconfig",
+      "community": 7,
+      "norm_label": "customportsconfig"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L950",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customportsconfig_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L951",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customportsconfig_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "customPortsConfigMap",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L953",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customportsconfigmap",
+      "community": 7,
+      "norm_label": "customportsconfigmap"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L954",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customportsconfigmap_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L955",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customportsconfigmap_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L956",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customportsconfigmap_default",
+      "community": 7,
+      "norm_label": "default"
+    },
+    {
+      "label": "customPhpConfig",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L958",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customphpconfig",
+      "community": 7,
+      "norm_label": "customphpconfig"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L959",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customphpconfig_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L960",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customphpconfig_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "customPhpConfigMap",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L962",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_customphpconfigmap",
+      "community": 7,
+      "norm_label": "customphpconfigmap"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L963",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customphpconfigmap_type",
+      "community": 7,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L964",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customphpconfigmap_description",
+      "community": 7,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L965",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_customphpconfigmap_default",
+      "community": 7,
+      "norm_label": "default"
+    },
+    {
+      "label": "storage",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L969",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_storage",
+      "community": 1,
+      "norm_label": "storage"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L970",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_storage_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L971",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_storage_properties",
+      "community": 1,
+      "norm_label": "properties"
+    },
+    {
+      "label": "existingClaim",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L972",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_existingclaim",
+      "community": 1,
+      "norm_label": "existingclaim"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L973",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingclaim_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L974",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_existingclaim_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "storageClass",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L976",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_storageclass",
+      "community": 1,
+      "norm_label": "storageclass"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L977",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_storageclass_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L978",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_storageclass_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L979",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_storageclass_default",
+      "community": 1,
+      "norm_label": "default"
+    },
+    {
+      "label": "size",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L981",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_size",
+      "community": 1,
+      "norm_label": "size"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L982",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_size_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L983",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_size_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L984",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_size_default",
+      "community": 1,
+      "norm_label": "default"
+    },
+    {
+      "label": "accessModes",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L986",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_accessmodes",
+      "community": 1,
+      "norm_label": "accessmodes"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L987",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_accessmodes_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "items",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L988",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_accessmodes_items",
+      "community": 153,
+      "norm_label": "items"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L990",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_items_enum",
+      "community": 153,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L996",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_accessmodes_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L997",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_accessmodes_default",
+      "community": 1,
+      "norm_label": "default"
+    },
+    {
+      "label": "annotations",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1001",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_annotations",
+      "community": 1,
+      "norm_label": "annotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1002",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_annotations_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1003",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_annotations_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "labels",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1005",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_labels",
+      "community": 1,
+      "norm_label": "labels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1006",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_labels_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1007",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_labels_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "selector",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1009",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_selector",
+      "community": 1,
+      "norm_label": "selector"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1010",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_selector_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1011",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_selector_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "resourcePolicy",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1013",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_resourcepolicy",
+      "community": 1,
+      "norm_label": "resourcepolicy"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1014",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_resourcepolicy_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "enum",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1015",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_resourcepolicy_enum",
+      "community": 1,
+      "norm_label": "enum"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1019",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_resourcepolicy_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1020",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_resourcepolicy_default",
+      "community": 1,
+      "norm_label": "default"
+    },
+    {
+      "label": "serviceAccount",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1024",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_serviceaccount",
+      "community": 1,
+      "norm_label": "serviceaccount"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1025",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_serviceaccount_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "properties",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1026",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_serviceaccount_properties",
+      "community": 1,
+      "norm_label": "properties"
+    },
+    {
+      "label": "create",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1027",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_create",
+      "community": 1,
+      "norm_label": "create"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1028",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_create_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1029",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_create_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1030",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_create_default",
+      "community": 1,
+      "norm_label": "default"
+    },
+    {
+      "label": "automount",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1032",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_automount",
+      "community": 1,
+      "norm_label": "automount"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1033",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_automount_type",
+      "community": 1,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1034",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_automount_description",
+      "community": 1,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1035",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_automount_default",
+      "community": 1,
+      "norm_label": "default"
+    },
+    {
+      "label": "podAnnotations",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1048",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_podannotations",
+      "community": 143,
+      "norm_label": "podannotations"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1049",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podannotations_type",
+      "community": 143,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1050",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podannotations_description",
+      "community": 143,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1051",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podannotations_default",
+      "community": 143,
+      "norm_label": "default"
+    },
+    {
+      "label": "podLabels",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1053",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_podlabels",
+      "community": 144,
+      "norm_label": "podlabels"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1054",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podlabels_type",
+      "community": 144,
+      "norm_label": "type"
+    },
+    {
+      "label": "description",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1055",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podlabels_description",
+      "community": 144,
+      "norm_label": "description"
+    },
+    {
+      "label": "default",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1056",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podlabels_default",
+      "community": 144,
+      "norm_label": "default"
+    },
+    {
+      "label": "podSecurityContext",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1058",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_properties_podsecuritycontext",
+      "community": 37,
+      "norm_label": "podsecuritycontext"
+    },
+    {
+      "label": "type",
+      "file_type": "code",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1059",
+      "_origin": "ast",
+      "id": "wordpress_values_schema_podsecuritycontext_type",
+      "community": 37,
+      "norm_label": "type"
+    },
+    {
+      "label": "release-please-config.json",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "release_please_config",
+      "community": 10,
+      "norm_label": "release-please-config.json"
+    },
+    {
+      "label": "$schema",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "release_please_config_schema",
+      "community": 10,
+      "norm_label": "$schema"
+    },
+    {
+      "label": "bootstrap-sha",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L3",
+      "_origin": "ast",
+      "id": "release_please_config_bootstrap_sha",
+      "community": 10,
+      "norm_label": "bootstrap-sha"
+    },
+    {
+      "label": "release-type",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L4",
+      "_origin": "ast",
+      "id": "release_please_config_release_type",
+      "community": 10,
+      "norm_label": "release-type"
+    },
+    {
+      "label": "include-component-in-tag",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "release_please_config_include_component_in_tag",
+      "community": 10,
+      "norm_label": "include-component-in-tag"
+    },
+    {
+      "label": "separate-pull-requests",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L6",
+      "_origin": "ast",
+      "id": "release_please_config_separate_pull_requests",
+      "community": 10,
+      "norm_label": "separate-pull-requests"
+    },
+    {
+      "label": "include-v-in-tag",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L7",
+      "_origin": "ast",
+      "id": "release_please_config_include_v_in_tag",
+      "community": 10,
+      "norm_label": "include-v-in-tag"
+    },
+    {
+      "label": "draft",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L8",
+      "_origin": "ast",
+      "id": "release_please_config_draft",
+      "community": 10,
+      "norm_label": "draft"
+    },
+    {
+      "label": "changelog-sections",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "release_please_config_changelog_sections",
+      "community": 10,
+      "norm_label": "changelog-sections"
+    },
+    {
+      "label": "packages",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "release_please_config_packages",
+      "community": 10,
+      "norm_label": "packages"
+    },
+    {
+      "label": "charts/wordpress",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "release_please_config_packages_charts_wordpress",
+      "community": 10,
+      "norm_label": "charts/wordpress"
+    },
+    {
+      "label": "component",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wordpress_component",
+      "community": 10,
+      "norm_label": "component"
+    },
+    {
+      "label": "changelog-path",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L24",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wordpress_changelog_path",
+      "community": 10,
+      "norm_label": "changelog-path"
+    },
+    {
+      "label": "extra-files",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L25",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wordpress_extra_files",
+      "community": 10,
+      "norm_label": "extra-files"
+    },
+    {
+      "label": "charts/wireguard",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "release_please_config_packages_charts_wireguard",
+      "community": 10,
+      "norm_label": "charts/wireguard"
+    },
+    {
+      "label": "component",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wireguard_component",
+      "community": 10,
+      "norm_label": "component"
+    },
+    {
+      "label": "changelog-path",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L31",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wireguard_changelog_path",
+      "community": 10,
+      "norm_label": "changelog-path"
+    },
+    {
+      "label": "extra-files",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L32",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wireguard_extra_files",
+      "community": 10,
+      "norm_label": "extra-files"
+    },
+    {
+      "label": "charts/wg-easy",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L36",
+      "_origin": "ast",
+      "id": "release_please_config_packages_charts_wg_easy",
+      "community": 10,
+      "norm_label": "charts/wg-easy"
+    },
+    {
+      "label": "component",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L37",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wg_easy_component",
+      "community": 10,
+      "norm_label": "component"
+    },
+    {
+      "label": "changelog-path",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L38",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wg_easy_changelog_path",
+      "community": 10,
+      "norm_label": "changelog-path"
+    },
+    {
+      "label": "extra-files",
+      "file_type": "code",
+      "source_file": "release-please-config.json",
+      "source_location": "L39",
+      "_origin": "ast",
+      "id": "release_please_config_charts_wg_easy_extra_files",
+      "community": 10,
+      "norm_label": "extra-files"
+    },
+    {
+      "label": "renovate.json",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "renovate",
+      "community": 20,
+      "norm_label": "renovate.json"
+    },
+    {
+      "label": "extends",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L2",
+      "_origin": "ast",
+      "id": "renovate_extends",
+      "community": 20,
+      "norm_label": "extends"
+    },
+    {
+      "label": "gitIgnoredAuthors",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L5",
+      "_origin": "ast",
+      "id": "renovate_gitignoredauthors",
+      "community": 20,
+      "norm_label": "gitignoredauthors"
+    },
+    {
+      "label": "platformAutomerge",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L9",
+      "_origin": "ast",
+      "id": "renovate_platformautomerge",
+      "community": 20,
+      "norm_label": "platformautomerge"
+    },
+    {
+      "label": "rebaseWhen",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L10",
+      "_origin": "ast",
+      "id": "renovate_rebasewhen",
+      "community": 20,
+      "norm_label": "rebasewhen"
+    },
+    {
+      "label": "semanticCommits",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L11",
+      "_origin": "ast",
+      "id": "renovate_semanticcommits",
+      "community": 20,
+      "norm_label": "semanticcommits"
+    },
+    {
+      "label": "semanticCommitScope",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L12",
+      "_origin": "ast",
+      "id": "renovate_semanticcommitscope",
+      "community": 20,
+      "norm_label": "semanticcommitscope"
+    },
+    {
+      "label": "enabledManagers",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L13",
+      "_origin": "ast",
+      "id": "renovate_enabledmanagers",
+      "community": 20,
+      "norm_label": "enabledmanagers"
+    },
+    {
+      "label": "pinDigests",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L19",
+      "_origin": "ast",
+      "id": "renovate_pindigests",
+      "community": 20,
+      "norm_label": "pindigests"
+    },
+    {
+      "label": "prHourlyLimit",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L20",
+      "_origin": "ast",
+      "id": "renovate_prhourlylimit",
+      "community": 20,
+      "norm_label": "prhourlylimit"
+    },
+    {
+      "label": "prConcurrentLimit",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L21",
+      "_origin": "ast",
+      "id": "renovate_prconcurrentlimit",
+      "community": 20,
+      "norm_label": "prconcurrentlimit"
+    },
+    {
+      "label": "timezone",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L22",
+      "_origin": "ast",
+      "id": "renovate_timezone",
+      "community": 20,
+      "norm_label": "timezone"
+    },
+    {
+      "label": "assignees",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L23",
+      "_origin": "ast",
+      "id": "renovate_assignees",
+      "community": 20,
+      "norm_label": "assignees"
+    },
+    {
+      "label": "customManagers",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L26",
+      "_origin": "ast",
+      "id": "renovate_custommanagers",
+      "community": 20,
+      "norm_label": "custommanagers"
+    },
+    {
+      "label": "packageRules",
+      "file_type": "code",
+      "source_file": "renovate.json",
+      "source_location": "L64",
+      "_origin": "ast",
+      "id": "renovate_packagerules",
+      "community": 20,
+      "norm_label": "packagerules"
+    },
+    {
+      "label": "helmlint.sh",
+      "file_type": "code",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "file"
+      },
+      "_origin": "ast",
+      "id": "scripts_helmlint",
+      "community": 47,
+      "norm_label": "helmlint.sh"
+    },
+    {
+      "label": "helmlint.sh script",
+      "file_type": "code",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L1",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_entrypoint"
+      },
+      "_origin": "ast",
+      "id": "users_timon_homelab_helm_charts_scripts_helmlint_sh__entry",
+      "community": 47,
+      "norm_label": "helmlint.sh script"
+    },
+    {
+      "label": "PATH",
+      "file_type": "code",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L7",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "scripts_helmlint_path",
+      "community": 47,
+      "norm_label": "path"
+    },
+    {
+      "label": "cwd_abspath",
+      "file_type": "code",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L9",
+      "metadata": {
+        "language": "bash",
+        "kind": "code"
+      },
+      "_origin": "ast",
+      "id": "scripts_helmlint_cwd_abspath",
+      "community": 47,
+      "norm_label": "cwd_abspath"
+    },
+    {
+      "label": "contains_element()",
+      "file_type": "code",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L11",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "scripts_helmlint_contains_element",
+      "community": 47,
+      "norm_label": "contains_element()"
+    },
+    {
+      "label": "chart_path()",
+      "file_type": "code",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L17",
+      "metadata": {
+        "language": "bash",
+        "kind": "bash_function"
+      },
+      "_origin": "ast",
+      "id": "scripts_helmlint_chart_path",
+      "community": 47,
+      "norm_label": "chart_path()"
+    },
+    {
+      "label": "validate-artifacthub-annotations.py",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L1",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations",
+      "community": 19,
+      "norm_label": "validate-artifacthub-annotations.py"
+    },
+    {
+      "label": "check_special_chars_quoted()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L29",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_check_special_chars_quoted",
+      "community": 19,
+      "norm_label": "check_special_chars_quoted()"
+    },
+    {
+      "label": "validate_changes()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L42",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_validate_changes",
+      "community": 19,
+      "norm_label": "validate_changes()"
+    },
+    {
+      "label": "validate_images()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L99",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_validate_images",
+      "community": 19,
+      "norm_label": "validate_images()"
+    },
+    {
+      "label": "validate_links()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L127",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_validate_links",
+      "community": 19,
+      "norm_label": "validate_links()"
+    },
+    {
+      "label": "validate_maintainers()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L157",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_validate_maintainers",
+      "community": 19,
+      "norm_label": "validate_maintainers()"
+    },
+    {
+      "label": "validate_category()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L187",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_validate_category",
+      "community": 19,
+      "norm_label": "validate_category()"
+    },
+    {
+      "label": "validate_chart_yaml()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L201",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_validate_chart_yaml",
+      "community": 19,
+      "norm_label": "validate_chart_yaml()"
+    },
+    {
+      "label": "main()",
+      "file_type": "code",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L269",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_main",
+      "community": 19,
+      "norm_label": "main()"
+    },
+    {
+      "label": "Check if strings with special characters are properly quoted.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L30",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_30",
+      "community": 19,
+      "norm_label": "check if strings with special characters are properly quoted."
+    },
+    {
+      "label": "Validate artifacthub.io/changes annotation.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L43",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_43",
+      "community": 19,
+      "norm_label": "validate artifacthub.io/changes annotation."
+    },
+    {
+      "label": "Validate artifacthub.io/images annotation.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L100",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_100",
+      "community": 19,
+      "norm_label": "validate artifacthub.io/images annotation."
+    },
+    {
+      "label": "Validate artifacthub.io/links annotation.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L128",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_128",
+      "community": 19,
+      "norm_label": "validate artifacthub.io/links annotation."
+    },
+    {
+      "label": "Validate artifacthub.io/maintainers annotation.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L158",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_158",
+      "community": 19,
+      "norm_label": "validate artifacthub.io/maintainers annotation."
+    },
+    {
+      "label": "Validate artifacthub.io/category annotation.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L188",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_188",
+      "community": 19,
+      "norm_label": "validate artifacthub.io/category annotation."
+    },
+    {
+      "label": "Validate a Chart.yaml file for artifacthub.io annotations.",
+      "file_type": "rationale",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L202",
+      "_origin": "ast",
+      "id": "scripts_validate_artifacthub_annotations_rationale_202",
+      "community": 19,
+      "norm_label": "validate a chart.yaml file for artifacthub.io annotations."
+    },
+    {
+      "label": "WordPress Configuration Fragment",
+      "source_file": "charts/wordpress/values.yaml",
+      "file_type": "concept",
+      "id": "advanced.configmap.yaml",
+      "community": 168,
+      "norm_label": "wordpress configuration fragment"
+    },
+    {
+      "label": "Advanced WordPress Installation Sample",
+      "source_file": "charts/wordpress/samples/advanced.configmap.yaml",
+      "file_type": "concept",
+      "id": "advanced-values.yaml",
+      "community": 167,
+      "norm_label": "advanced wordpress installation sample"
+    },
+    {
+      "label": "Alternative Advanced Configuration Sample",
+      "source_file": "charts/wordpress/samples/advanced2.values.yaml",
+      "file_type": "concept",
+      "id": "advanced2.values.yaml",
+      "community": 169,
+      "norm_label": "alternative advanced configuration sample"
+    },
+    {
+      "label": "MariaDB Secrets Template",
+      "source_file": "charts/wordpress/samples/mariaDB.secrets.yaml",
+      "file_type": "concept",
+      "id": "mariaDB.secrets.yaml",
+      "community": 172,
+      "norm_label": "mariadb secrets template"
+    },
+    {
+      "label": "Memcached Secrets Template",
+      "source_file": "charts/wordpress/samples/memcached.secrets.yaml",
+      "file_type": "concept",
+      "id": "memcached.secrets.yaml",
+      "community": 173,
+      "norm_label": "memcached secrets template"
+    },
+    {
+      "label": "SMTP Configuration Sample",
+      "source_file": "charts/wordpress/samples/smtp.secrets.yaml",
+      "file_type": "concept",
+      "id": "smtp.secrets.yaml",
+      "community": 179,
+      "norm_label": "smtp configuration sample"
+    },
+    {
+      "label": "Valkey Object Cache Configuration",
+      "source_file": "charts/wordpress/samples/valkey.secrets.yaml",
+      "file_type": "concept",
+      "id": "valkey.secrets.yaml",
+      "community": 182,
+      "norm_label": "valkey object cache configuration"
+    },
+    {
+      "label": "Common Labels Propagation Rules",
+      "source_file": "charts/wordpress/templates/commonLabels.values.yaml",
+      "file_type": "concept",
+      "id": "commonLabels.values.yaml",
+      "community": 171,
+      "norm_label": "common labels propagation rules"
+    },
+    {
+      "label": "Common Annotations Configuration",
+      "source_file": "charts/wordpress/templates/commonLabels.answers.yaml",
+      "file_type": "concept",
+      "id": "commonAnnotations.values.yaml",
+      "community": 170,
+      "norm_label": "common annotations configuration"
+    },
+    {
+      "label": "Prometheus Rules for Apache Monitoring",
+      "source_file": "charts/wordpress/samples/prometheusrule.yaml",
+      "file_type": "concept",
+      "id": "metrics.apache.rules",
+      "community": 174,
+      "norm_label": "prometheus rules for apache monitoring"
+    },
+    {
+      "label": "Persistent Volume Claim Template",
+      "source_file": "charts/wordpress/samples/pvc.yaml",
+      "file_type": "concept",
+      "id": "pvc.yaml",
+      "community": 177,
+      "norm_label": "persistent volume claim template"
+    },
+    {
+      "label": "Service Templates (NodePort & ClusterIP)",
+      "source_file": "charts/wordpress/samples/service.yaml",
+      "file_type": "concept",
+      "id": "service.yaml",
+      "community": 178,
+      "norm_label": "service templates (nodeport & clusterip)"
+    },
+    {
+      "label": "Network Policy with Ingress/Egress",
+      "source_file": "charts/wordpress/samples/networkpolicy.yaml",
+      "file_type": "concept",
+      "id": "networkpolicy.yaml",
+      "community": 175,
+      "norm_label": "network policy with ingress/egress"
+    },
+    {
+      "label": "Monitoring Metrics Rules",
+      "source_file": "charts/wordpress/samples/metrics.prometheusrule.yaml",
+      "file_type": "concept",
+      "id": "prometheusrule.yaml",
+      "community": 176,
+      "norm_label": "monitoring metrics rules"
+    },
+    {
+      "label": "StatefulSet Deployment Definition",
+      "source_file": "charts/wordpress/samples/statefulset.yaml",
+      "file_type": "concept",
+      "id": "statefulset.yaml",
+      "community": 180,
+      "norm_label": "statefulset deployment definition"
+    },
+    {
+      "label": "WordPress Test Suites",
+      "source_file": "charts/wordpress/templates/tests",
+      "file_type": "concept",
+      "id": "tests/**/*.yaml",
+      "community": 181,
+      "norm_label": "wordpress test suites"
+    }
+  ],
+  "links": [
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L180",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_build_artifacthub_changes_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L234",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_ensure_annotations_section",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_extract_version_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L263",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_find_annotation_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L249",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_find_annotations_section",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L283",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_is_prerelease_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_parse_args",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L102",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_read_current_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_remove_annotation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_split_description_and_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L193",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes",
+      "target": "scripts_sync_artifacthub_changes_sync_prerelease_annotation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_build_artifacthub_changes_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_is_prerelease_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_parse_args",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L57",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_read_current_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L72",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L67",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_main",
+      "target": "scripts_sync_artifacthub_changes_sync_prerelease_annotation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "context": "return_type",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_parse_args",
+      "target": "namespace",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "references",
+      "context": "parameter_type",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_read_current_version",
+      "target": "path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L115",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "target": "scripts_sync_artifacthub_changes_extract_version_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L132",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "target": "scripts_sync_artifacthub_changes_split_description_and_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_rationale_103",
+      "target": "scripts_sync_artifacthub_changes_parse_top_changelog_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L140",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_rationale_140",
+      "target": "scripts_sync_artifacthub_changes_extract_version_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L163",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_rationale_163",
+      "target": "scripts_sync_artifacthub_changes_split_description_and_link",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L197",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_sync_prerelease_annotation",
+      "target": "scripts_sync_artifacthub_changes_remove_annotation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L196",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_sync_prerelease_annotation",
+      "target": "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "target": "scripts_sync_artifacthub_changes_ensure_annotations_section",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L203",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_replace_annotation_block",
+      "target": "scripts_sync_artifacthub_changes_find_annotation_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_remove_annotation",
+      "target": "scripts_sync_artifacthub_changes_find_annotation_entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L221",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_remove_annotation",
+      "target": "scripts_sync_artifacthub_changes_find_annotations_section",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": ".github/scripts/sync-artifacthub-changes.py",
+      "source_location": "L235",
+      "weight": 1.0,
+      "source": "scripts_sync_artifacthub_changes_ensure_annotations_section",
+      "target": "scripts_sync_artifacthub_changes_find_annotations_section",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/install.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_install_sh_verify_install",
+      "target": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_install_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_uninstall_sh_verify_uninstall",
+      "target": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_uninstall_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_yellow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify",
+      "target": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L31",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L59",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L70",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L41",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L122",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wg_easy_samples_verify_verify_sh__entry",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_yellow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L23",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L26",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/samples/verify/verify.sh",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wg_easy_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wg_easy_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_id",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_schema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema",
+      "target": "wg_easy_values_schema_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_commonannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_commonlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L274",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_dnsconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L122",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_dnspolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L345",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_extraenvvars",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L371",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_extraenvvarscm",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L366",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_extraenvvarssecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L98",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_fullnameoverride",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_global",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L177",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_hostnetwork",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_image",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_imagepullsecrets",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L680",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_ingress",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_initcontainers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_nameoverride",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L475",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_podannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L486",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_podlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L497",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_podsecuritycontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_replicacount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L751",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_resources",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L191",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_runtimeclassname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L502",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_securitycontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L578",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_service",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L376",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_serviceaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L410",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_servicemonitor",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L182",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_sidecars",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L196",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_storage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L77",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties",
+      "target": "wg_easy_values_schema_properties_updatestrategy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_global",
+      "target": "wg_easy_values_schema_global_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_global",
+      "target": "wg_easy_values_schema_global_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_global",
+      "target": "wg_easy_values_schema_global_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_global",
+      "target": "wg_easy_values_schema_global_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_replicacount",
+      "target": "wg_easy_values_schema_replicacount_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_replicacount",
+      "target": "wg_easy_values_schema_replicacount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L18",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_replicacount",
+      "target": "wg_easy_values_schema_replicacount_minimum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_replicacount",
+      "target": "wg_easy_values_schema_replicacount_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_replicacount",
+      "target": "wg_easy_values_schema_replicacount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_image",
+      "target": "wg_easy_values_schema_image_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_image",
+      "target": "wg_easy_values_schema_image_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L54",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_image",
+      "target": "wg_easy_values_schema_image_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_image",
+      "target": "wg_easy_values_schema_image_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_image",
+      "target": "wg_easy_values_schema_image_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_image_properties",
+      "target": "wg_easy_values_schema_properties_pullpolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_image_properties",
+      "target": "wg_easy_values_schema_properties_registry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L33",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_image_properties",
+      "target": "wg_easy_values_schema_properties_repository",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_image_properties",
+      "target": "wg_easy_values_schema_properties_tag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_registry",
+      "target": "wg_easy_values_schema_registry_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_registry",
+      "target": "wg_easy_values_schema_registry_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_registry",
+      "target": "wg_easy_values_schema_registry_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_registry",
+      "target": "wg_easy_values_schema_registry_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_repository",
+      "target": "wg_easy_values_schema_repository_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_repository",
+      "target": "wg_easy_values_schema_repository_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_repository",
+      "target": "wg_easy_values_schema_repository_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_pullpolicy",
+      "target": "wg_easy_values_schema_pullpolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L41",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_pullpolicy",
+      "target": "wg_easy_values_schema_pullpolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_pullpolicy",
+      "target": "wg_easy_values_schema_pullpolicy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_pullpolicy",
+      "target": "wg_easy_values_schema_pullpolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tag",
+      "target": "wg_easy_values_schema_tag_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tag",
+      "target": "wg_easy_values_schema_tag_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tag",
+      "target": "wg_easy_values_schema_tag_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_imagepullsecrets",
+      "target": "wg_easy_values_schema_imagepullsecrets_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L62",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_imagepullsecrets",
+      "target": "wg_easy_values_schema_imagepullsecrets_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_imagepullsecrets",
+      "target": "wg_easy_values_schema_imagepullsecrets_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_imagepullsecrets",
+      "target": "wg_easy_values_schema_imagepullsecrets_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_imagepullsecrets",
+      "target": "wg_easy_values_schema_imagepullsecrets_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_imagepullsecrets_items",
+      "target": "wg_easy_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_imagepullsecrets_items",
+      "target": "wg_easy_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_imagepullsecrets_items",
+      "target": "wg_easy_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_imagepullsecrets_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L220",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_accessmodes_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L350",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_extraenvvars_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L710",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_hosts_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L118",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_initcontainers_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L143",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_nameservers_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L159",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_options_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L151",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_searches_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_sidecars_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L744",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_tls_items",
+      "target": "wg_easy_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L351",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_extraenvvars_items",
+      "target": "wg_easy_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L711",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_hosts_items",
+      "target": "wg_easy_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_initcontainers_items",
+      "target": "wg_easy_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L171",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_options_items",
+      "target": "wg_easy_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L188",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_sidecars_items",
+      "target": "wg_easy_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L352",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_extraenvvars_items",
+      "target": "wg_easy_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L712",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_hosts_items",
+      "target": "wg_easy_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L713",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_items_properties",
+      "target": "wg_easy_values_schema_properties_host",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L353",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_items_properties",
+      "target": "wg_easy_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L717",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_items_properties",
+      "target": "wg_easy_values_schema_properties_paths",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L357",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_items_properties",
+      "target": "wg_easy_values_schema_properties_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L160",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_options_items",
+      "target": "wg_easy_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L405",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_name",
+      "target": "wg_easy_values_schema_name_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L403",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_name",
+      "target": "wg_easy_values_schema_name_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L404",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_name",
+      "target": "wg_easy_values_schema_name_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L402",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_serviceaccount_properties",
+      "target": "wg_easy_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L362",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_extraenvvars_items",
+      "target": "wg_easy_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L737",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_hosts_items",
+      "target": "wg_easy_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L170",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_options_items",
+      "target": "wg_easy_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_updatestrategy",
+      "target": "wg_easy_values_schema_updatestrategy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_updatestrategy",
+      "target": "wg_easy_values_schema_updatestrategy_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_updatestrategy",
+      "target": "wg_easy_values_schema_updatestrategy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_updatestrategy",
+      "target": "wg_easy_values_schema_updatestrategy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L82",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_updatestrategy_properties",
+      "target": "wg_easy_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L639",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_type",
+      "target": "wg_easy_values_schema_type_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L634",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_type",
+      "target": "wg_easy_values_schema_type_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L632",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_type",
+      "target": "wg_easy_values_schema_type_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L633",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_type",
+      "target": "wg_easy_values_schema_type_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L537",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_seccompprofile_properties",
+      "target": "wg_easy_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L588",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ui_properties",
+      "target": "wg_easy_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L631",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_wireguard_properties",
+      "target": "wg_easy_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L96",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameoverride",
+      "target": "wg_easy_values_schema_nameoverride_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameoverride",
+      "target": "wg_easy_values_schema_nameoverride_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L95",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameoverride",
+      "target": "wg_easy_values_schema_nameoverride_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L101",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_fullnameoverride",
+      "target": "wg_easy_values_schema_fullnameoverride_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_fullnameoverride",
+      "target": "wg_easy_values_schema_fullnameoverride_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_fullnameoverride",
+      "target": "wg_easy_values_schema_fullnameoverride_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_commonlabels",
+      "target": "wg_easy_values_schema_commonlabels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L105",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_commonlabels",
+      "target": "wg_easy_values_schema_commonlabels_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L104",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_commonlabels",
+      "target": "wg_easy_values_schema_commonlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L111",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_commonannotations",
+      "target": "wg_easy_values_schema_commonannotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_commonannotations",
+      "target": "wg_easy_values_schema_commonannotations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L109",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_commonannotations",
+      "target": "wg_easy_values_schema_commonannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_initcontainers",
+      "target": "wg_easy_values_schema_initcontainers_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L117",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_initcontainers",
+      "target": "wg_easy_values_schema_initcontainers_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L115",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_initcontainers",
+      "target": "wg_easy_values_schema_initcontainers_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_initcontainers",
+      "target": "wg_easy_values_schema_initcontainers_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnspolicy",
+      "target": "wg_easy_values_schema_dnspolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnspolicy",
+      "target": "wg_easy_values_schema_dnspolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnspolicy",
+      "target": "wg_easy_values_schema_dnspolicy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L123",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnspolicy",
+      "target": "wg_easy_values_schema_dnspolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L175",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnsconfig",
+      "target": "wg_easy_values_schema_dnsconfig_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L136",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnsconfig",
+      "target": "wg_easy_values_schema_dnsconfig_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L137",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnsconfig",
+      "target": "wg_easy_values_schema_dnsconfig_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L135",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnsconfig",
+      "target": "wg_easy_values_schema_dnsconfig_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L134",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dnsconfig",
+      "target": "wg_easy_values_schema_dnsconfig_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_dnsconfig_properties",
+      "target": "wg_easy_values_schema_properties_nameservers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L154",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_dnsconfig_properties",
+      "target": "wg_easy_values_schema_properties_options",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_dnsconfig_properties",
+      "target": "wg_easy_values_schema_properties_searches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameservers",
+      "target": "wg_easy_values_schema_nameservers_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L142",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameservers",
+      "target": "wg_easy_values_schema_nameservers_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L140",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameservers",
+      "target": "wg_easy_values_schema_nameservers_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nameservers",
+      "target": "wg_easy_values_schema_nameservers_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L149",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_searches",
+      "target": "wg_easy_values_schema_searches_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_searches",
+      "target": "wg_easy_values_schema_searches_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L148",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_searches",
+      "target": "wg_easy_values_schema_searches_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L147",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_searches",
+      "target": "wg_easy_values_schema_searches_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L157",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_options",
+      "target": "wg_easy_values_schema_options_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L158",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_options",
+      "target": "wg_easy_values_schema_options_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L156",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_options",
+      "target": "wg_easy_values_schema_options_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L155",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_options",
+      "target": "wg_easy_values_schema_options_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L358",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_value",
+      "target": "wg_easy_values_schema_value_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L359",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_value",
+      "target": "wg_easy_values_schema_value_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L180",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_hostnetwork",
+      "target": "wg_easy_values_schema_hostnetwork_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L178",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_hostnetwork",
+      "target": "wg_easy_values_schema_hostnetwork_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L179",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_hostnetwork",
+      "target": "wg_easy_values_schema_hostnetwork_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L185",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_sidecars",
+      "target": "wg_easy_values_schema_sidecars_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L186",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_sidecars",
+      "target": "wg_easy_values_schema_sidecars_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_sidecars",
+      "target": "wg_easy_values_schema_sidecars_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_sidecars",
+      "target": "wg_easy_values_schema_sidecars_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L194",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runtimeclassname",
+      "target": "wg_easy_values_schema_runtimeclassname_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L193",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runtimeclassname",
+      "target": "wg_easy_values_schema_runtimeclassname_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L192",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runtimeclassname",
+      "target": "wg_easy_values_schema_runtimeclassname_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storage",
+      "target": "wg_easy_values_schema_storage_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storage",
+      "target": "wg_easy_values_schema_storage_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L268",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storage",
+      "target": "wg_easy_values_schema_storage_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L197",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storage",
+      "target": "wg_easy_values_schema_storage_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storage",
+      "target": "wg_easy_values_schema_storage_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L216",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_accessmodes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L230",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_existingclaim",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L241",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_labels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L257",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_resourcepolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L252",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_selector",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L211",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_size",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L206",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_storage_properties",
+      "target": "wg_easy_values_schema_properties_storageclass",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L204",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingclaim",
+      "target": "wg_easy_values_schema_existingclaim_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingclaim",
+      "target": "wg_easy_values_schema_existingclaim_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L203",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingclaim",
+      "target": "wg_easy_values_schema_existingclaim_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L209",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storageclass",
+      "target": "wg_easy_values_schema_storageclass_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L207",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storageclass",
+      "target": "wg_easy_values_schema_storageclass_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L208",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_storageclass",
+      "target": "wg_easy_values_schema_storageclass_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L214",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_size",
+      "target": "wg_easy_values_schema_size_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L212",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_size",
+      "target": "wg_easy_values_schema_size_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L213",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_size",
+      "target": "wg_easy_values_schema_size_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L228",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_accessmodes",
+      "target": "wg_easy_values_schema_accessmodes_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_accessmodes",
+      "target": "wg_easy_values_schema_accessmodes_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L217",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_accessmodes",
+      "target": "wg_easy_values_schema_accessmodes_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L218",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_accessmodes",
+      "target": "wg_easy_values_schema_accessmodes_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L221",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_accessmodes_items",
+      "target": "wg_easy_values_schema_items_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L695",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ingress_properties",
+      "target": "wg_easy_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L698",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_annotations",
+      "target": "wg_easy_values_schema_annotations_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L696",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_annotations",
+      "target": "wg_easy_values_schema_annotations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L697",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_annotations",
+      "target": "wg_easy_values_schema_annotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L391",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_serviceaccount_properties",
+      "target": "wg_easy_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L420",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L612",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ui_properties",
+      "target": "wg_easy_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L663",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_wireguard_properties",
+      "target": "wg_easy_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L699",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_annotations_additionalproperties",
+      "target": "wg_easy_values_schema_additionalproperties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L435",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_labels_additionalproperties",
+      "target": "wg_easy_values_schema_additionalproperties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L479",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_podannotations_additionalproperties",
+      "target": "wg_easy_values_schema_additionalproperties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L490",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_podlabels_additionalproperties",
+      "target": "wg_easy_values_schema_additionalproperties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L434",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_labels",
+      "target": "wg_easy_values_schema_labels_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L432",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_labels",
+      "target": "wg_easy_values_schema_labels_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L433",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_labels",
+      "target": "wg_easy_values_schema_labels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L431",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_labels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L445",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_selector",
+      "target": "wg_easy_values_schema_selector_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L443",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_selector",
+      "target": "wg_easy_values_schema_selector_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L444",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_selector",
+      "target": "wg_easy_values_schema_selector_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L442",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_selector",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L264",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resourcepolicy",
+      "target": "wg_easy_values_schema_resourcepolicy_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resourcepolicy",
+      "target": "wg_easy_values_schema_resourcepolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L260",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resourcepolicy",
+      "target": "wg_easy_values_schema_resourcepolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L258",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resourcepolicy",
+      "target": "wg_easy_values_schema_resourcepolicy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L259",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resourcepolicy",
+      "target": "wg_easy_values_schema_resourcepolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L277",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_config",
+      "target": "wg_easy_values_schema_config_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L278",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_config",
+      "target": "wg_easy_values_schema_config_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L343",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_config",
+      "target": "wg_easy_values_schema_config_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L275",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_config",
+      "target": "wg_easy_values_schema_config_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L276",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_config",
+      "target": "wg_easy_values_schema_config_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L289",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_config_properties",
+      "target": "wg_easy_values_schema_properties_disable_ipv6",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L279",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_config_properties",
+      "target": "wg_easy_values_schema_properties_host",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L294",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_config_properties",
+      "target": "wg_easy_values_schema_properties_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L284",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_config_properties",
+      "target": "wg_easy_values_schema_properties_insecure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L319",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_host",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L322",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_host",
+      "target": "wg_easy_values_schema_host_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L320",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_host",
+      "target": "wg_easy_values_schema_host_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L321",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_host",
+      "target": "wg_easy_values_schema_host_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L287",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_insecure",
+      "target": "wg_easy_values_schema_insecure_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L285",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_insecure",
+      "target": "wg_easy_values_schema_insecure_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L286",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_insecure",
+      "target": "wg_easy_values_schema_insecure_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L292",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_disable_ipv6",
+      "target": "wg_easy_values_schema_disable_ipv6_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L290",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_disable_ipv6",
+      "target": "wg_easy_values_schema_disable_ipv6_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L291",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_disable_ipv6",
+      "target": "wg_easy_values_schema_disable_ipv6_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L297",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_init",
+      "target": "wg_easy_values_schema_init_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L298",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_init",
+      "target": "wg_easy_values_schema_init_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L340",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_init",
+      "target": "wg_easy_values_schema_init_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L295",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_init",
+      "target": "wg_easy_values_schema_init_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L296",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_init",
+      "target": "wg_easy_values_schema_init_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L324",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_dns",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L299",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L304",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_existingsecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L329",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_ipv4_cidr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L334",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_ipv6_cidr",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L314",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_password",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L309",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_init_properties",
+      "target": "wg_easy_values_schema_properties_username",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L685",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ingress_properties",
+      "target": "wg_easy_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L688",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_enabled",
+      "target": "wg_easy_values_schema_enabled_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L686",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_enabled",
+      "target": "wg_easy_values_schema_enabled_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L687",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_enabled",
+      "target": "wg_easy_values_schema_enabled_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L465",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingsecret",
+      "target": "wg_easy_values_schema_existingsecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L463",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingsecret",
+      "target": "wg_easy_values_schema_existingsecret_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L464",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingsecret",
+      "target": "wg_easy_values_schema_existingsecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L462",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_existingsecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L312",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_username",
+      "target": "wg_easy_values_schema_username_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L310",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_username",
+      "target": "wg_easy_values_schema_username_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L311",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_username",
+      "target": "wg_easy_values_schema_username_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L317",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_password",
+      "target": "wg_easy_values_schema_password_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L315",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_password",
+      "target": "wg_easy_values_schema_password_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L316",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_password",
+      "target": "wg_easy_values_schema_password_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L327",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dns",
+      "target": "wg_easy_values_schema_dns_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L325",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dns",
+      "target": "wg_easy_values_schema_dns_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L326",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_dns",
+      "target": "wg_easy_values_schema_dns_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L332",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ipv4_cidr",
+      "target": "wg_easy_values_schema_ipv4_cidr_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L330",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ipv4_cidr",
+      "target": "wg_easy_values_schema_ipv4_cidr_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L331",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ipv4_cidr",
+      "target": "wg_easy_values_schema_ipv4_cidr_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L337",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ipv6_cidr",
+      "target": "wg_easy_values_schema_ipv6_cidr_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L335",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ipv6_cidr",
+      "target": "wg_easy_values_schema_ipv6_cidr_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L336",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ipv6_cidr",
+      "target": "wg_easy_values_schema_ipv6_cidr_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L364",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvars",
+      "target": "wg_easy_values_schema_extraenvvars_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L348",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvars",
+      "target": "wg_easy_values_schema_extraenvvars_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L349",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvars",
+      "target": "wg_easy_values_schema_extraenvvars_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L346",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvars",
+      "target": "wg_easy_values_schema_extraenvvars_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L347",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvars",
+      "target": "wg_easy_values_schema_extraenvvars_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L369",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvarssecret",
+      "target": "wg_easy_values_schema_extraenvvarssecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L367",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvarssecret",
+      "target": "wg_easy_values_schema_extraenvvarssecret_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L368",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvarssecret",
+      "target": "wg_easy_values_schema_extraenvvarssecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L374",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvarscm",
+      "target": "wg_easy_values_schema_extraenvvarscm_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L372",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvarscm",
+      "target": "wg_easy_values_schema_extraenvvarscm_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L373",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_extraenvvarscm",
+      "target": "wg_easy_values_schema_extraenvvarscm_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L379",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_serviceaccount",
+      "target": "wg_easy_values_schema_serviceaccount_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L380",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_serviceaccount",
+      "target": "wg_easy_values_schema_serviceaccount_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L408",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_serviceaccount",
+      "target": "wg_easy_values_schema_serviceaccount_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L377",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_serviceaccount",
+      "target": "wg_easy_values_schema_serviceaccount_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L378",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_serviceaccount",
+      "target": "wg_easy_values_schema_serviceaccount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L386",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_serviceaccount_properties",
+      "target": "wg_easy_values_schema_properties_automount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L381",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_serviceaccount_properties",
+      "target": "wg_easy_values_schema_properties_create",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L418",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_create",
+      "target": "wg_easy_values_schema_create_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L416",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_create",
+      "target": "wg_easy_values_schema_create_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L417",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_create",
+      "target": "wg_easy_values_schema_create_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L415",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_create",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L389",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_automount",
+      "target": "wg_easy_values_schema_automount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L387",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_automount",
+      "target": "wg_easy_values_schema_automount_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L388",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_automount",
+      "target": "wg_easy_values_schema_automount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L413",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_servicemonitor",
+      "target": "wg_easy_values_schema_servicemonitor_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L414",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_servicemonitor",
+      "target": "wg_easy_values_schema_servicemonitor_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L473",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_servicemonitor",
+      "target": "wg_easy_values_schema_servicemonitor_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L411",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_servicemonitor",
+      "target": "wg_easy_values_schema_servicemonitor_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L412",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_servicemonitor",
+      "target": "wg_easy_values_schema_servicemonitor_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L467",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_existingsecretkey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_interval",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L457",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_metricspath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L452",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_servicemonitor_properties",
+      "target": "wg_easy_values_schema_properties_namespace",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L450",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_interval",
+      "target": "wg_easy_values_schema_interval_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L448",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_interval",
+      "target": "wg_easy_values_schema_interval_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L449",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_interval",
+      "target": "wg_easy_values_schema_interval_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L455",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_namespace",
+      "target": "wg_easy_values_schema_namespace_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L453",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_namespace",
+      "target": "wg_easy_values_schema_namespace_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L454",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_namespace",
+      "target": "wg_easy_values_schema_namespace_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L460",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_metricspath",
+      "target": "wg_easy_values_schema_metricspath_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L458",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_metricspath",
+      "target": "wg_easy_values_schema_metricspath_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L459",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_metricspath",
+      "target": "wg_easy_values_schema_metricspath_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L470",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingsecretkey",
+      "target": "wg_easy_values_schema_existingsecretkey_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L468",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingsecretkey",
+      "target": "wg_easy_values_schema_existingsecretkey_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L469",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_existingsecretkey",
+      "target": "wg_easy_values_schema_existingsecretkey_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L478",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podannotations",
+      "target": "wg_easy_values_schema_podannotations_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L476",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podannotations",
+      "target": "wg_easy_values_schema_podannotations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L477",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podannotations",
+      "target": "wg_easy_values_schema_podannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L489",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podlabels",
+      "target": "wg_easy_values_schema_podlabels_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L487",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podlabels",
+      "target": "wg_easy_values_schema_podlabels_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L488",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podlabels",
+      "target": "wg_easy_values_schema_podlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L500",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podsecuritycontext",
+      "target": "wg_easy_values_schema_podsecuritycontext_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L498",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podsecuritycontext",
+      "target": "wg_easy_values_schema_podsecuritycontext_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L499",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_podsecuritycontext",
+      "target": "wg_easy_values_schema_podsecuritycontext_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L505",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_securitycontext",
+      "target": "wg_easy_values_schema_securitycontext_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L506",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_securitycontext",
+      "target": "wg_easy_values_schema_securitycontext_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L503",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_securitycontext",
+      "target": "wg_easy_values_schema_securitycontext_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L504",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_securitycontext",
+      "target": "wg_easy_values_schema_securitycontext_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L512",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_allowprivilegeescalation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L553",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_capabilities",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L507",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_privileged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L517",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_readonlyrootfilesystem",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L522",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_runasnonroot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L527",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_runasuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L532",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_securitycontext_properties",
+      "target": "wg_easy_values_schema_properties_seccompprofile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L510",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_privileged",
+      "target": "wg_easy_values_schema_privileged_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L508",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_privileged",
+      "target": "wg_easy_values_schema_privileged_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L509",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_privileged",
+      "target": "wg_easy_values_schema_privileged_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L515",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_allowprivilegeescalation",
+      "target": "wg_easy_values_schema_allowprivilegeescalation_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L513",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_allowprivilegeescalation",
+      "target": "wg_easy_values_schema_allowprivilegeescalation_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L514",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_allowprivilegeescalation",
+      "target": "wg_easy_values_schema_allowprivilegeescalation_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L520",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_readonlyrootfilesystem",
+      "target": "wg_easy_values_schema_readonlyrootfilesystem_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L518",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_readonlyrootfilesystem",
+      "target": "wg_easy_values_schema_readonlyrootfilesystem_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L519",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_readonlyrootfilesystem",
+      "target": "wg_easy_values_schema_readonlyrootfilesystem_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L525",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runasnonroot",
+      "target": "wg_easy_values_schema_runasnonroot_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L523",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runasnonroot",
+      "target": "wg_easy_values_schema_runasnonroot_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L524",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runasnonroot",
+      "target": "wg_easy_values_schema_runasnonroot_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L530",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runasuser",
+      "target": "wg_easy_values_schema_runasuser_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L528",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runasuser",
+      "target": "wg_easy_values_schema_runasuser_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L529",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_runasuser",
+      "target": "wg_easy_values_schema_runasuser_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L551",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_seccompprofile",
+      "target": "wg_easy_values_schema_seccompprofile_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L535",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_seccompprofile",
+      "target": "wg_easy_values_schema_seccompprofile_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L536",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_seccompprofile",
+      "target": "wg_easy_values_schema_seccompprofile_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L533",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_seccompprofile",
+      "target": "wg_easy_values_schema_seccompprofile_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L534",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_seccompprofile",
+      "target": "wg_easy_values_schema_seccompprofile_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L546",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_seccompprofile_properties",
+      "target": "wg_easy_values_schema_properties_localhostprofile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L548",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_localhostprofile",
+      "target": "wg_easy_values_schema_localhostprofile_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L547",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_localhostprofile",
+      "target": "wg_easy_values_schema_localhostprofile_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L556",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_capabilities",
+      "target": "wg_easy_values_schema_capabilities_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L557",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_capabilities",
+      "target": "wg_easy_values_schema_capabilities_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L554",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_capabilities",
+      "target": "wg_easy_values_schema_capabilities_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L555",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_capabilities",
+      "target": "wg_easy_values_schema_capabilities_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L558",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_capabilities_properties",
+      "target": "wg_easy_values_schema_properties_add",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L566",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_capabilities_properties",
+      "target": "wg_easy_values_schema_properties_drop",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L564",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_add",
+      "target": "wg_easy_values_schema_add_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L561",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_add",
+      "target": "wg_easy_values_schema_add_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L559",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_add",
+      "target": "wg_easy_values_schema_add_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L560",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_add",
+      "target": "wg_easy_values_schema_add_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L572",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_drop",
+      "target": "wg_easy_values_schema_drop_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L569",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_drop",
+      "target": "wg_easy_values_schema_drop_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L567",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_drop",
+      "target": "wg_easy_values_schema_drop_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L568",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_drop",
+      "target": "wg_easy_values_schema_drop_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L581",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_service",
+      "target": "wg_easy_values_schema_service_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L582",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_service",
+      "target": "wg_easy_values_schema_service_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L678",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_service",
+      "target": "wg_easy_values_schema_service_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L579",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_service",
+      "target": "wg_easy_values_schema_service_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L580",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_service",
+      "target": "wg_easy_values_schema_service_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L583",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_service_properties",
+      "target": "wg_easy_values_schema_properties_ui",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L626",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_service_properties",
+      "target": "wg_easy_values_schema_properties_wireguard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L586",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ui",
+      "target": "wg_easy_values_schema_ui_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L587",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ui",
+      "target": "wg_easy_values_schema_ui_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L624",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ui",
+      "target": "wg_easy_values_schema_ui_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L584",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ui",
+      "target": "wg_easy_values_schema_ui_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L585",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ui",
+      "target": "wg_easy_values_schema_ui_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L605",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ui_properties",
+      "target": "wg_easy_values_schema_properties_nodeport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L598",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ui_properties",
+      "target": "wg_easy_values_schema_properties_port",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L646",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_port",
+      "target": "wg_easy_values_schema_port_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L645",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_port",
+      "target": "wg_easy_values_schema_port_maximum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L644",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_port",
+      "target": "wg_easy_values_schema_port_minimum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L642",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_port",
+      "target": "wg_easy_values_schema_port_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L643",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_port",
+      "target": "wg_easy_values_schema_port_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L641",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_wireguard_properties",
+      "target": "wg_easy_values_schema_properties_port",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L653",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nodeport",
+      "target": "wg_easy_values_schema_nodeport_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L652",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nodeport",
+      "target": "wg_easy_values_schema_nodeport_maximum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L651",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nodeport",
+      "target": "wg_easy_values_schema_nodeport_minimum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L649",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nodeport",
+      "target": "wg_easy_values_schema_nodeport_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L650",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_nodeport",
+      "target": "wg_easy_values_schema_nodeport_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L648",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_wireguard_properties",
+      "target": "wg_easy_values_schema_properties_nodeport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L629",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_wireguard",
+      "target": "wg_easy_values_schema_wireguard_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L630",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_wireguard",
+      "target": "wg_easy_values_schema_wireguard_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L675",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_wireguard",
+      "target": "wg_easy_values_schema_wireguard_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L627",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_wireguard",
+      "target": "wg_easy_values_schema_wireguard_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L628",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_wireguard",
+      "target": "wg_easy_values_schema_wireguard_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L655",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_wireguard_properties",
+      "target": "wg_easy_values_schema_properties_externalips",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L658",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_externalips",
+      "target": "wg_easy_values_schema_externalips_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L659",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_externalips",
+      "target": "wg_easy_values_schema_externalips_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L656",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_externalips",
+      "target": "wg_easy_values_schema_externalips_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L657",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_externalips",
+      "target": "wg_easy_values_schema_externalips_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L683",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ingress",
+      "target": "wg_easy_values_schema_ingress_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L684",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ingress",
+      "target": "wg_easy_values_schema_ingress_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L749",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ingress",
+      "target": "wg_easy_values_schema_ingress_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L681",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ingress",
+      "target": "wg_easy_values_schema_ingress_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L682",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_ingress",
+      "target": "wg_easy_values_schema_ingress_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L690",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ingress_properties",
+      "target": "wg_easy_values_schema_properties_classname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L706",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ingress_properties",
+      "target": "wg_easy_values_schema_properties_hosts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L740",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_ingress_properties",
+      "target": "wg_easy_values_schema_properties_tls",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L693",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_classname",
+      "target": "wg_easy_values_schema_classname_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L691",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_classname",
+      "target": "wg_easy_values_schema_classname_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L692",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_classname",
+      "target": "wg_easy_values_schema_classname_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L709",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_hosts",
+      "target": "wg_easy_values_schema_hosts_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L707",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_hosts",
+      "target": "wg_easy_values_schema_hosts_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L708",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_hosts",
+      "target": "wg_easy_values_schema_hosts_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L746",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tls",
+      "target": "wg_easy_values_schema_tls_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L743",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tls",
+      "target": "wg_easy_values_schema_tls_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L741",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tls",
+      "target": "wg_easy_values_schema_tls_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L742",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_tls",
+      "target": "wg_easy_values_schema_tls_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L752",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resources",
+      "target": "wg_easy_values_schema_resources_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wg-easy/values.schema.json",
+      "source_location": "L753",
+      "weight": 1.0,
+      "source": "wg_easy_values_schema_properties_resources",
+      "target": "wg_easy_values_schema_resources_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/install.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_install_sh_verify_install",
+      "target": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_install_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_uninstall_sh_verify_uninstall",
+      "target": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_uninstall_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_yellow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify",
+      "target": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L31",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L59",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L70",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L41",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L129",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wireguard_samples_verify_verify_sh__entry",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_yellow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L23",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L26",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/samples/verify/verify.sh",
+      "source_location": "L19",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wireguard_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wireguard_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "wireguard_values_schema",
+      "target": "wireguard_values_schema_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "wireguard_values_schema",
+      "target": "wireguard_values_schema_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "wireguard_values_schema",
+      "target": "wireguard_values_schema_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "wireguard_values_schema",
+      "target": "wireguard_values_schema_schema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "wireguard_values_schema",
+      "target": "wireguard_values_schema_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "wireguard_values_schema",
+      "target": "wireguard_values_schema_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L789",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_affinity",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L706",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_autoscaling",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_commonannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_commonlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L691",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_customlivenessprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L696",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_customreadinessprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L701",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_customstartupprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_dnsconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L88",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_dnspolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L753",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_extravolumemounts",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L733",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_extravolumes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L68",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_fullnameoverride",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L143",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_hostnetwork",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_image",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L45",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_imagepullsecrets",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L164",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_initcontainers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L580",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_livenessprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L63",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_nameoverride",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L776",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_nodeselector",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L445",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_podannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L450",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_podlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L455",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_podsecuritycontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L802",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_priorityclassname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L617",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_readinessprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L83",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_replicacount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L575",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_resources",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L461",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_securitycontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L539",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_service",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L418",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_serviceaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L173",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_sidecars",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L654",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_startupprobe",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L781",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_tolerations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L794",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_topologyspreadconstraints",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L148",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_updatestrategy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L182",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties",
+      "target": "wireguard_values_schema_properties_wireguard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_image",
+      "target": "wireguard_values_schema_image_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_image",
+      "target": "wireguard_values_schema_image_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L40",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_image",
+      "target": "wireguard_values_schema_image_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_image",
+      "target": "wireguard_values_schema_image_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_image",
+      "target": "wireguard_values_schema_image_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_image_properties",
+      "target": "wireguard_values_schema_properties_pullpolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_image_properties",
+      "target": "wireguard_values_schema_properties_registry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_image_properties",
+      "target": "wireguard_values_schema_properties_repository",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_image_properties",
+      "target": "wireguard_values_schema_properties_tag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_registry",
+      "target": "wireguard_values_schema_registry_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_registry",
+      "target": "wireguard_values_schema_registry_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_registry",
+      "target": "wireguard_values_schema_registry_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_registry",
+      "target": "wireguard_values_schema_registry_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_repository",
+      "target": "wireguard_values_schema_repository_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_repository",
+      "target": "wireguard_values_schema_repository_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_repository",
+      "target": "wireguard_values_schema_repository_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L27",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pullpolicy",
+      "target": "wireguard_values_schema_pullpolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L28",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pullpolicy",
+      "target": "wireguard_values_schema_pullpolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pullpolicy",
+      "target": "wireguard_values_schema_pullpolicy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pullpolicy",
+      "target": "wireguard_values_schema_pullpolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tag",
+      "target": "wireguard_values_schema_tag_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tag",
+      "target": "wireguard_values_schema_tag_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L35",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tag",
+      "target": "wireguard_values_schema_tag_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L61",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_imagepullsecrets",
+      "target": "wireguard_values_schema_imagepullsecrets_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_imagepullsecrets",
+      "target": "wireguard_values_schema_imagepullsecrets_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_imagepullsecrets",
+      "target": "wireguard_values_schema_imagepullsecrets_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_imagepullsecrets",
+      "target": "wireguard_values_schema_imagepullsecrets_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_imagepullsecrets",
+      "target": "wireguard_values_schema_imagepullsecrets_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_imagepullsecrets_items",
+      "target": "wireguard_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_imagepullsecrets_items",
+      "target": "wireguard_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_imagepullsecrets_items",
+      "target": "wireguard_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_imagepullsecrets_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L569",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_externalips_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L212",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extraenvvars_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L758",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extravolumemounts_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L738",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extravolumes_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L169",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_initcontainers_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L109",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_nameservers_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_options_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L117",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_searches_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L178",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_sidecars_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L786",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_tolerations_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L799",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_topologyspreadconstraints_items",
+      "target": "wireguard_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L773",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extravolumemounts_items",
+      "target": "wireguard_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L750",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extravolumes_items",
+      "target": "wireguard_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L170",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_initcontainers_items",
+      "target": "wireguard_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L137",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_options_items",
+      "target": "wireguard_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L179",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_sidecars_items",
+      "target": "wireguard_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L213",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extraenvvars_items",
+      "target": "wireguard_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L759",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extravolumemounts_items",
+      "target": "wireguard_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L739",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_extravolumes_items",
+      "target": "wireguard_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L764",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_items_properties",
+      "target": "wireguard_values_schema_properties_mountpath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L760",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_items_properties",
+      "target": "wireguard_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L768",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_items_properties",
+      "target": "wireguard_values_schema_properties_readonly",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L744",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_items_properties",
+      "target": "wireguard_values_schema_properties_secret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_items_properties",
+      "target": "wireguard_values_schema_properties_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_options_items",
+      "target": "wireguard_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L441",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_name",
+      "target": "wireguard_values_schema_name_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L762",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_name",
+      "target": "wireguard_values_schema_name_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L761",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_name",
+      "target": "wireguard_values_schema_name_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L438",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_serviceaccount_properties",
+      "target": "wireguard_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L136",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_options_items",
+      "target": "wireguard_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L66",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameoverride",
+      "target": "wireguard_values_schema_nameoverride_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L65",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameoverride",
+      "target": "wireguard_values_schema_nameoverride_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameoverride",
+      "target": "wireguard_values_schema_nameoverride_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L71",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_fullnameoverride",
+      "target": "wireguard_values_schema_fullnameoverride_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_fullnameoverride",
+      "target": "wireguard_values_schema_fullnameoverride_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L69",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_fullnameoverride",
+      "target": "wireguard_values_schema_fullnameoverride_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_commonlabels",
+      "target": "wireguard_values_schema_commonlabels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_commonlabels",
+      "target": "wireguard_values_schema_commonlabels_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_commonlabels",
+      "target": "wireguard_values_schema_commonlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_commonannotations",
+      "target": "wireguard_values_schema_commonannotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_commonannotations",
+      "target": "wireguard_values_schema_commonannotations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_commonannotations",
+      "target": "wireguard_values_schema_commonannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L86",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_replicacount",
+      "target": "wireguard_values_schema_replicacount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_replicacount",
+      "target": "wireguard_values_schema_replicacount_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L84",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_replicacount",
+      "target": "wireguard_values_schema_replicacount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnspolicy",
+      "target": "wireguard_values_schema_dnspolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L92",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnspolicy",
+      "target": "wireguard_values_schema_dnspolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnspolicy",
+      "target": "wireguard_values_schema_dnspolicy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L89",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnspolicy",
+      "target": "wireguard_values_schema_dnspolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L141",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnsconfig",
+      "target": "wireguard_values_schema_dnsconfig_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L102",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnsconfig",
+      "target": "wireguard_values_schema_dnsconfig_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L103",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnsconfig",
+      "target": "wireguard_values_schema_dnsconfig_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L101",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnsconfig",
+      "target": "wireguard_values_schema_dnsconfig_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dnsconfig",
+      "target": "wireguard_values_schema_dnsconfig_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L104",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_dnsconfig_properties",
+      "target": "wireguard_values_schema_properties_nameservers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L120",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_dnsconfig_properties",
+      "target": "wireguard_values_schema_properties_options",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L112",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_dnsconfig_properties",
+      "target": "wireguard_values_schema_properties_searches",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L107",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameservers",
+      "target": "wireguard_values_schema_nameservers_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameservers",
+      "target": "wireguard_values_schema_nameservers_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameservers",
+      "target": "wireguard_values_schema_nameservers_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L105",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nameservers",
+      "target": "wireguard_values_schema_nameservers_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L115",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_searches",
+      "target": "wireguard_values_schema_searches_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L116",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_searches",
+      "target": "wireguard_values_schema_searches_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_searches",
+      "target": "wireguard_values_schema_searches_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L113",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_searches",
+      "target": "wireguard_values_schema_searches_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L123",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_options",
+      "target": "wireguard_values_schema_options_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_options",
+      "target": "wireguard_values_schema_options_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L122",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_options",
+      "target": "wireguard_values_schema_options_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_options",
+      "target": "wireguard_values_schema_options_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_hostnetwork",
+      "target": "wireguard_values_schema_hostnetwork_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L144",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_hostnetwork",
+      "target": "wireguard_values_schema_hostnetwork_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L145",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_hostnetwork",
+      "target": "wireguard_values_schema_hostnetwork_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L151",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_updatestrategy",
+      "target": "wireguard_values_schema_updatestrategy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L152",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_updatestrategy",
+      "target": "wireguard_values_schema_updatestrategy_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_updatestrategy",
+      "target": "wireguard_values_schema_updatestrategy_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L149",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_updatestrategy",
+      "target": "wireguard_values_schema_updatestrategy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L153",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_updatestrategy_properties",
+      "target": "wireguard_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L547",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_type",
+      "target": "wireguard_values_schema_type_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L548",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_type",
+      "target": "wireguard_values_schema_type_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L546",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_type",
+      "target": "wireguard_values_schema_type_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L545",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_type",
+      "target": "wireguard_values_schema_type_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L497",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_seccompprofile_properties",
+      "target": "wireguard_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L544",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_service_properties",
+      "target": "wireguard_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initcontainers",
+      "target": "wireguard_values_schema_initcontainers_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L168",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initcontainers",
+      "target": "wireguard_values_schema_initcontainers_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L166",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initcontainers",
+      "target": "wireguard_values_schema_initcontainers_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L165",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initcontainers",
+      "target": "wireguard_values_schema_initcontainers_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L176",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_sidecars",
+      "target": "wireguard_values_schema_sidecars_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L177",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_sidecars",
+      "target": "wireguard_values_schema_sidecars_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L175",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_sidecars",
+      "target": "wireguard_values_schema_sidecars_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L174",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_sidecars",
+      "target": "wireguard_values_schema_sidecars_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L185",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_wireguard",
+      "target": "wireguard_values_schema_wireguard_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L186",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_wireguard",
+      "target": "wireguard_values_schema_wireguard_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_wireguard",
+      "target": "wireguard_values_schema_wireguard_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_wireguard",
+      "target": "wireguard_values_schema_wireguard_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L197",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_allowedips",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L352",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_client",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L192",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_dns",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_existingsecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L207",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_extraenvvars",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L232",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_extraenvvarscm",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L227",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_extraenvvarssecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_listenport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L247",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_pgid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L242",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_puid",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L252",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_server",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_wireguard_properties",
+      "target": "wireguard_values_schema_properties_timezone",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L190",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_timezone",
+      "target": "wireguard_values_schema_timezone_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_timezone",
+      "target": "wireguard_values_schema_timezone_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L188",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_timezone",
+      "target": "wireguard_values_schema_timezone_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L195",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dns",
+      "target": "wireguard_values_schema_dns_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L194",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dns",
+      "target": "wireguard_values_schema_dns_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L193",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_dns",
+      "target": "wireguard_values_schema_dns_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_allowedips",
+      "target": "wireguard_values_schema_allowedips_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_allowedips",
+      "target": "wireguard_values_schema_allowedips_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L198",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_allowedips",
+      "target": "wireguard_values_schema_allowedips_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L205",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_listenport",
+      "target": "wireguard_values_schema_listenport_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L204",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_listenport",
+      "target": "wireguard_values_schema_listenport_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L203",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_listenport",
+      "target": "wireguard_values_schema_listenport_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L210",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvars",
+      "target": "wireguard_values_schema_extraenvvars_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L211",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvars",
+      "target": "wireguard_values_schema_extraenvvars_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L209",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvars",
+      "target": "wireguard_values_schema_extraenvvars_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L208",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvars",
+      "target": "wireguard_values_schema_extraenvvars_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L230",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvarssecret",
+      "target": "wireguard_values_schema_extraenvvarssecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L229",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvarssecret",
+      "target": "wireguard_values_schema_extraenvvarssecret_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L228",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvarssecret",
+      "target": "wireguard_values_schema_extraenvvarssecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L235",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvarscm",
+      "target": "wireguard_values_schema_extraenvvarscm_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L234",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvarscm",
+      "target": "wireguard_values_schema_extraenvvarscm_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L233",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extraenvvarscm",
+      "target": "wireguard_values_schema_extraenvvarscm_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L240",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_existingsecret",
+      "target": "wireguard_values_schema_existingsecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L239",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_existingsecret",
+      "target": "wireguard_values_schema_existingsecret_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L238",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_existingsecret",
+      "target": "wireguard_values_schema_existingsecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L245",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_puid",
+      "target": "wireguard_values_schema_puid_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L244",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_puid",
+      "target": "wireguard_values_schema_puid_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L243",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_puid",
+      "target": "wireguard_values_schema_puid_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L250",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pgid",
+      "target": "wireguard_values_schema_pgid_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L249",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pgid",
+      "target": "wireguard_values_schema_pgid_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L248",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_pgid",
+      "target": "wireguard_values_schema_pgid_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L255",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_server",
+      "target": "wireguard_values_schema_server_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L256",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_server",
+      "target": "wireguard_values_schema_server_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L254",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_server",
+      "target": "wireguard_values_schema_server_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L253",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_server",
+      "target": "wireguard_values_schema_server_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L318",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_server_properties",
+      "target": "wireguard_values_schema_properties_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L257",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_server_properties",
+      "target": "wireguard_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L262",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_server_properties",
+      "target": "wireguard_values_schema_properties_storage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L711",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_autoscaling_properties",
+      "target": "wireguard_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L357",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_client_properties",
+      "target": "wireguard_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L585",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_livenessprobe_properties",
+      "target": "wireguard_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L662",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_enabled",
+      "target": "wireguard_values_schema_enabled_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L360",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_enabled",
+      "target": "wireguard_values_schema_enabled_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L713",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_enabled",
+      "target": "wireguard_values_schema_enabled_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L712",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_enabled",
+      "target": "wireguard_values_schema_enabled_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L622",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_readinessprobe_properties",
+      "target": "wireguard_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L659",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_startupprobe_properties",
+      "target": "wireguard_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_storage",
+      "target": "wireguard_values_schema_storage_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L266",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_storage",
+      "target": "wireguard_values_schema_storage_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L264",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_storage",
+      "target": "wireguard_values_schema_storage_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L263",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_storage",
+      "target": "wireguard_values_schema_storage_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L362",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_client_properties",
+      "target": "wireguard_values_schema_properties_config",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L365",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_config",
+      "target": "wireguard_values_schema_config_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L366",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_config",
+      "target": "wireguard_values_schema_config_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L364",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_config",
+      "target": "wireguard_values_schema_config_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L363",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_config",
+      "target": "wireguard_values_schema_config_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L355",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_client",
+      "target": "wireguard_values_schema_client_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L356",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_client",
+      "target": "wireguard_values_schema_client_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L354",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_client",
+      "target": "wireguard_values_schema_client_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L353",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_client",
+      "target": "wireguard_values_schema_client_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L421",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_serviceaccount",
+      "target": "wireguard_values_schema_serviceaccount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L422",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_serviceaccount",
+      "target": "wireguard_values_schema_serviceaccount_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L420",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_serviceaccount",
+      "target": "wireguard_values_schema_serviceaccount_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L419",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_serviceaccount",
+      "target": "wireguard_values_schema_serviceaccount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L433",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_serviceaccount_properties",
+      "target": "wireguard_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L428",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_serviceaccount_properties",
+      "target": "wireguard_values_schema_properties_automount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L423",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_serviceaccount_properties",
+      "target": "wireguard_values_schema_properties_create",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L426",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_create",
+      "target": "wireguard_values_schema_create_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L425",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_create",
+      "target": "wireguard_values_schema_create_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L424",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_create",
+      "target": "wireguard_values_schema_create_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L431",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_automount",
+      "target": "wireguard_values_schema_automount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L430",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_automount",
+      "target": "wireguard_values_schema_automount_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L429",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_automount",
+      "target": "wireguard_values_schema_automount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L436",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_annotations",
+      "target": "wireguard_values_schema_annotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L435",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_annotations",
+      "target": "wireguard_values_schema_annotations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L434",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_annotations",
+      "target": "wireguard_values_schema_annotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L448",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podannotations",
+      "target": "wireguard_values_schema_podannotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L447",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podannotations",
+      "target": "wireguard_values_schema_podannotations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L446",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podannotations",
+      "target": "wireguard_values_schema_podannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L453",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podlabels",
+      "target": "wireguard_values_schema_podlabels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L452",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podlabels",
+      "target": "wireguard_values_schema_podlabels_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L451",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podlabels",
+      "target": "wireguard_values_schema_podlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L459",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podsecuritycontext",
+      "target": "wireguard_values_schema_podsecuritycontext_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L458",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podsecuritycontext",
+      "target": "wireguard_values_schema_podsecuritycontext_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L457",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podsecuritycontext",
+      "target": "wireguard_values_schema_podsecuritycontext_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L456",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_podsecuritycontext",
+      "target": "wireguard_values_schema_podsecuritycontext_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L465",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_securitycontext",
+      "target": "wireguard_values_schema_securitycontext_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L464",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_securitycontext",
+      "target": "wireguard_values_schema_securitycontext_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L466",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_securitycontext",
+      "target": "wireguard_values_schema_securitycontext_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L463",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_securitycontext",
+      "target": "wireguard_values_schema_securitycontext_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L462",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_securitycontext",
+      "target": "wireguard_values_schema_securitycontext_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L472",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_allowprivilegeescalation",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L513",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_capabilities",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L467",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_privileged",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L477",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_readonlyrootfilesystem",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L482",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_runasnonroot",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L487",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_runasuser",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L492",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_securitycontext_properties",
+      "target": "wireguard_values_schema_properties_seccompprofile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L470",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_privileged",
+      "target": "wireguard_values_schema_privileged_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L469",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_privileged",
+      "target": "wireguard_values_schema_privileged_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L468",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_privileged",
+      "target": "wireguard_values_schema_privileged_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L475",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_allowprivilegeescalation",
+      "target": "wireguard_values_schema_allowprivilegeescalation_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L474",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_allowprivilegeescalation",
+      "target": "wireguard_values_schema_allowprivilegeescalation_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L473",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_allowprivilegeescalation",
+      "target": "wireguard_values_schema_allowprivilegeescalation_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L480",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readonlyrootfilesystem",
+      "target": "wireguard_values_schema_readonlyrootfilesystem_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L479",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readonlyrootfilesystem",
+      "target": "wireguard_values_schema_readonlyrootfilesystem_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L478",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readonlyrootfilesystem",
+      "target": "wireguard_values_schema_readonlyrootfilesystem_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L485",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_runasnonroot",
+      "target": "wireguard_values_schema_runasnonroot_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L484",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_runasnonroot",
+      "target": "wireguard_values_schema_runasnonroot_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L483",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_runasnonroot",
+      "target": "wireguard_values_schema_runasnonroot_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L490",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_runasuser",
+      "target": "wireguard_values_schema_runasuser_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L489",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_runasuser",
+      "target": "wireguard_values_schema_runasuser_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L488",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_runasuser",
+      "target": "wireguard_values_schema_runasuser_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L511",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_seccompprofile",
+      "target": "wireguard_values_schema_seccompprofile_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L495",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_seccompprofile",
+      "target": "wireguard_values_schema_seccompprofile_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L496",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_seccompprofile",
+      "target": "wireguard_values_schema_seccompprofile_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L494",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_seccompprofile",
+      "target": "wireguard_values_schema_seccompprofile_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L493",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_seccompprofile",
+      "target": "wireguard_values_schema_seccompprofile_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L506",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_seccompprofile_properties",
+      "target": "wireguard_values_schema_properties_localhostprofile",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L508",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_localhostprofile",
+      "target": "wireguard_values_schema_localhostprofile_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L507",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_localhostprofile",
+      "target": "wireguard_values_schema_localhostprofile_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L517",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_capabilities",
+      "target": "wireguard_values_schema_capabilities_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L516",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_capabilities",
+      "target": "wireguard_values_schema_capabilities_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L518",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_capabilities",
+      "target": "wireguard_values_schema_capabilities_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L515",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_capabilities",
+      "target": "wireguard_values_schema_capabilities_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L514",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_capabilities",
+      "target": "wireguard_values_schema_capabilities_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L519",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_capabilities_properties",
+      "target": "wireguard_values_schema_properties_add",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L527",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_capabilities_properties",
+      "target": "wireguard_values_schema_properties_drop",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L522",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_add",
+      "target": "wireguard_values_schema_add_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L523",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_add",
+      "target": "wireguard_values_schema_add_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L521",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_add",
+      "target": "wireguard_values_schema_add_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L520",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_add",
+      "target": "wireguard_values_schema_add_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L530",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_drop",
+      "target": "wireguard_values_schema_drop_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L531",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_drop",
+      "target": "wireguard_values_schema_drop_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L529",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_drop",
+      "target": "wireguard_values_schema_drop_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L528",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_drop",
+      "target": "wireguard_values_schema_drop_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L542",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_service",
+      "target": "wireguard_values_schema_service_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L543",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_service",
+      "target": "wireguard_values_schema_service_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L541",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_service",
+      "target": "wireguard_values_schema_service_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L540",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_service",
+      "target": "wireguard_values_schema_service_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L564",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_service_properties",
+      "target": "wireguard_values_schema_properties_externalips",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L559",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_service_properties",
+      "target": "wireguard_values_schema_properties_nodeport",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L554",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_service_properties",
+      "target": "wireguard_values_schema_properties_port",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L557",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_port",
+      "target": "wireguard_values_schema_port_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L556",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_port",
+      "target": "wireguard_values_schema_port_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L555",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_port",
+      "target": "wireguard_values_schema_port_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L562",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nodeport",
+      "target": "wireguard_values_schema_nodeport_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L561",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nodeport",
+      "target": "wireguard_values_schema_nodeport_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L560",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nodeport",
+      "target": "wireguard_values_schema_nodeport_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L571",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_externalips",
+      "target": "wireguard_values_schema_externalips_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L567",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_externalips",
+      "target": "wireguard_values_schema_externalips_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L568",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_externalips",
+      "target": "wireguard_values_schema_externalips_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L566",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_externalips",
+      "target": "wireguard_values_schema_externalips_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L565",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_externalips",
+      "target": "wireguard_values_schema_externalips_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L578",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_resources",
+      "target": "wireguard_values_schema_resources_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L577",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_resources",
+      "target": "wireguard_values_schema_resources_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L576",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_resources",
+      "target": "wireguard_values_schema_resources_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L583",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_livenessprobe",
+      "target": "wireguard_values_schema_livenessprobe_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L584",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_livenessprobe",
+      "target": "wireguard_values_schema_livenessprobe_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L582",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_livenessprobe",
+      "target": "wireguard_values_schema_livenessprobe_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L581",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_livenessprobe",
+      "target": "wireguard_values_schema_livenessprobe_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L605",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_livenessprobe_properties",
+      "target": "wireguard_values_schema_properties_failurethreshold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L590",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_livenessprobe_properties",
+      "target": "wireguard_values_schema_properties_initialdelayseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L595",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_livenessprobe_properties",
+      "target": "wireguard_values_schema_properties_periodseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L610",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_livenessprobe_properties",
+      "target": "wireguard_values_schema_properties_successthreshold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L600",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_livenessprobe_properties",
+      "target": "wireguard_values_schema_properties_timeoutseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L667",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initialdelayseconds",
+      "target": "wireguard_values_schema_initialdelayseconds_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L666",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initialdelayseconds",
+      "target": "wireguard_values_schema_initialdelayseconds_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L665",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_initialdelayseconds",
+      "target": "wireguard_values_schema_initialdelayseconds_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L627",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_readinessprobe_properties",
+      "target": "wireguard_values_schema_properties_initialdelayseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L664",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_startupprobe_properties",
+      "target": "wireguard_values_schema_properties_initialdelayseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L672",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_periodseconds",
+      "target": "wireguard_values_schema_periodseconds_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L671",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_periodseconds",
+      "target": "wireguard_values_schema_periodseconds_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L670",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_periodseconds",
+      "target": "wireguard_values_schema_periodseconds_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L632",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_readinessprobe_properties",
+      "target": "wireguard_values_schema_properties_periodseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L669",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_startupprobe_properties",
+      "target": "wireguard_values_schema_properties_periodseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L677",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_timeoutseconds",
+      "target": "wireguard_values_schema_timeoutseconds_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L676",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_timeoutseconds",
+      "target": "wireguard_values_schema_timeoutseconds_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L675",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_timeoutseconds",
+      "target": "wireguard_values_schema_timeoutseconds_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L637",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_readinessprobe_properties",
+      "target": "wireguard_values_schema_properties_timeoutseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L674",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_startupprobe_properties",
+      "target": "wireguard_values_schema_properties_timeoutseconds",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L682",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_failurethreshold",
+      "target": "wireguard_values_schema_failurethreshold_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L681",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_failurethreshold",
+      "target": "wireguard_values_schema_failurethreshold_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L680",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_failurethreshold",
+      "target": "wireguard_values_schema_failurethreshold_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L642",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_readinessprobe_properties",
+      "target": "wireguard_values_schema_properties_failurethreshold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L679",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_startupprobe_properties",
+      "target": "wireguard_values_schema_properties_failurethreshold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L687",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_successthreshold",
+      "target": "wireguard_values_schema_successthreshold_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L686",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_successthreshold",
+      "target": "wireguard_values_schema_successthreshold_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L685",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_successthreshold",
+      "target": "wireguard_values_schema_successthreshold_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L647",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_readinessprobe_properties",
+      "target": "wireguard_values_schema_properties_successthreshold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L684",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_startupprobe_properties",
+      "target": "wireguard_values_schema_properties_successthreshold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L620",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readinessprobe",
+      "target": "wireguard_values_schema_readinessprobe_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L621",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readinessprobe",
+      "target": "wireguard_values_schema_readinessprobe_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L619",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readinessprobe",
+      "target": "wireguard_values_schema_readinessprobe_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L618",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readinessprobe",
+      "target": "wireguard_values_schema_readinessprobe_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L657",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_startupprobe",
+      "target": "wireguard_values_schema_startupprobe_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L658",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_startupprobe",
+      "target": "wireguard_values_schema_startupprobe_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L656",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_startupprobe",
+      "target": "wireguard_values_schema_startupprobe_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L655",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_startupprobe",
+      "target": "wireguard_values_schema_startupprobe_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L694",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customlivenessprobe",
+      "target": "wireguard_values_schema_customlivenessprobe_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L693",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customlivenessprobe",
+      "target": "wireguard_values_schema_customlivenessprobe_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L692",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customlivenessprobe",
+      "target": "wireguard_values_schema_customlivenessprobe_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L699",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customreadinessprobe",
+      "target": "wireguard_values_schema_customreadinessprobe_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L698",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customreadinessprobe",
+      "target": "wireguard_values_schema_customreadinessprobe_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L697",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customreadinessprobe",
+      "target": "wireguard_values_schema_customreadinessprobe_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L704",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customstartupprobe",
+      "target": "wireguard_values_schema_customstartupprobe_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L703",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customstartupprobe",
+      "target": "wireguard_values_schema_customstartupprobe_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L702",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_customstartupprobe",
+      "target": "wireguard_values_schema_customstartupprobe_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L709",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_autoscaling",
+      "target": "wireguard_values_schema_autoscaling_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L710",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_autoscaling",
+      "target": "wireguard_values_schema_autoscaling_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L708",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_autoscaling",
+      "target": "wireguard_values_schema_autoscaling_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L707",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_autoscaling",
+      "target": "wireguard_values_schema_autoscaling_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L719",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_autoscaling_properties",
+      "target": "wireguard_values_schema_properties_maxreplicas",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L715",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_autoscaling_properties",
+      "target": "wireguard_values_schema_properties_minreplicas",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L723",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_autoscaling_properties",
+      "target": "wireguard_values_schema_properties_targetcpuutilizationpercentage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L727",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_autoscaling_properties",
+      "target": "wireguard_values_schema_properties_targetmemoryutilizationpercentage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L717",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_minreplicas",
+      "target": "wireguard_values_schema_minreplicas_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L716",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_minreplicas",
+      "target": "wireguard_values_schema_minreplicas_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L721",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_maxreplicas",
+      "target": "wireguard_values_schema_maxreplicas_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L720",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_maxreplicas",
+      "target": "wireguard_values_schema_maxreplicas_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L725",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_targetcpuutilizationpercentage",
+      "target": "wireguard_values_schema_targetcpuutilizationpercentage_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L724",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_targetcpuutilizationpercentage",
+      "target": "wireguard_values_schema_targetcpuutilizationpercentage_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L729",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_targetmemoryutilizationpercentage",
+      "target": "wireguard_values_schema_targetmemoryutilizationpercentage_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L728",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_targetmemoryutilizationpercentage",
+      "target": "wireguard_values_schema_targetmemoryutilizationpercentage_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L736",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumes",
+      "target": "wireguard_values_schema_extravolumes_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L737",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumes",
+      "target": "wireguard_values_schema_extravolumes_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L735",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumes",
+      "target": "wireguard_values_schema_extravolumes_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L734",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumes",
+      "target": "wireguard_values_schema_extravolumes_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L747",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_secret",
+      "target": "wireguard_values_schema_secret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L746",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_secret",
+      "target": "wireguard_values_schema_secret_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L745",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_secret",
+      "target": "wireguard_values_schema_secret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L756",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumemounts",
+      "target": "wireguard_values_schema_extravolumemounts_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L757",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumemounts",
+      "target": "wireguard_values_schema_extravolumemounts_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L755",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumemounts",
+      "target": "wireguard_values_schema_extravolumemounts_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L754",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_extravolumemounts",
+      "target": "wireguard_values_schema_extravolumemounts_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L766",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_mountpath",
+      "target": "wireguard_values_schema_mountpath_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L765",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_mountpath",
+      "target": "wireguard_values_schema_mountpath_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L770",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readonly",
+      "target": "wireguard_values_schema_readonly_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L769",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_readonly",
+      "target": "wireguard_values_schema_readonly_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L779",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nodeselector",
+      "target": "wireguard_values_schema_nodeselector_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L778",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nodeselector",
+      "target": "wireguard_values_schema_nodeselector_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L777",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_nodeselector",
+      "target": "wireguard_values_schema_nodeselector_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L784",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tolerations",
+      "target": "wireguard_values_schema_tolerations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L785",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tolerations",
+      "target": "wireguard_values_schema_tolerations_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L783",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tolerations",
+      "target": "wireguard_values_schema_tolerations_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L782",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_tolerations",
+      "target": "wireguard_values_schema_tolerations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L792",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_affinity",
+      "target": "wireguard_values_schema_affinity_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L791",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_affinity",
+      "target": "wireguard_values_schema_affinity_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L790",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_affinity",
+      "target": "wireguard_values_schema_affinity_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L797",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_topologyspreadconstraints",
+      "target": "wireguard_values_schema_topologyspreadconstraints_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L798",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_topologyspreadconstraints",
+      "target": "wireguard_values_schema_topologyspreadconstraints_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L796",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_topologyspreadconstraints",
+      "target": "wireguard_values_schema_topologyspreadconstraints_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L795",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_topologyspreadconstraints",
+      "target": "wireguard_values_schema_topologyspreadconstraints_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wireguard/values.schema.json",
+      "source_location": "L803",
+      "weight": 1.0,
+      "source": "wireguard_values_schema_properties_priorityclassname",
+      "target": "wireguard_values_schema_priorityclassname_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/install.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_install_sh_verify_install",
+      "target": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_install_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/uninstall.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_uninstall_sh_verify_uninstall",
+      "target": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_uninstall_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_yellow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify",
+      "target": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L33",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L73",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L126",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L52",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L141",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_charts_wordpress_samples_verify_verify_sh__entry",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_yellow",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L25",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_red",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L28",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_green",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/samples/verify/verify.sh",
+      "source_location": "L18",
+      "weight": 1.0,
+      "context": "call",
+      "source": "charts_wordpress_samples_verify_verify_sh_verify_verify_check_logs",
+      "target": "charts_wordpress_samples_verify_verify_sh_verify_verify_bold",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "wordpress_values_schema",
+      "target": "wordpress_values_schema_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "wordpress_values_schema",
+      "target": "wordpress_values_schema_schema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "wordpress_values_schema",
+      "target": "wordpress_values_schema_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L932",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_apache",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L237",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_args",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L133",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_clusterdomain",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L229",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_command",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L167",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_commonannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L160",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_commonlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_controllertype",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L155",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_customannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L150",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_customlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L142",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_dnsconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L138",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_dnspolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L245",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_extraenvvars",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L269",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_extraenvvarscm",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L264",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_extraenvvarssecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L128",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_fullnameoverride",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L146",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_hostnetwork",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L70",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_image",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L105",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_imagepullsecrets",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L213",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_initcontainers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L123",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_nameoverride",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1048",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_podannotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1053",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_podlabels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1058",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_podsecuritycontext",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L14",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_replicacount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1024",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_serviceaccount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L221",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_sidecars",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_statefulset",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L969",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_storage",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L174",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_updatestrategy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L274",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties",
+      "target": "wordpress_values_schema_properties_wordpress",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_controllertype",
+      "target": "wordpress_values_schema_controllertype_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_controllertype",
+      "target": "wordpress_values_schema_controllertype_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_controllertype",
+      "target": "wordpress_values_schema_controllertype_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_controllertype",
+      "target": "wordpress_values_schema_controllertype_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_replicacount",
+      "target": "wordpress_values_schema_replicacount_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L16",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_replicacount",
+      "target": "wordpress_values_schema_replicacount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L15",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_replicacount",
+      "target": "wordpress_values_schema_replicacount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_statefulset",
+      "target": "wordpress_values_schema_statefulset_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_statefulset",
+      "target": "wordpress_values_schema_statefulset_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_statefulset",
+      "target": "wordpress_values_schema_statefulset_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L46",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_statefulset_properties",
+      "target": "wordpress_values_schema_properties_persistentvolumeclaimretentionpolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_statefulset_properties",
+      "target": "wordpress_values_schema_properties_podmanagementpolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_statefulset_properties",
+      "target": "wordpress_values_schema_properties_updatestrategy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podmanagementpolicy",
+      "target": "wordpress_values_schema_podmanagementpolicy_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podmanagementpolicy",
+      "target": "wordpress_values_schema_podmanagementpolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podmanagementpolicy",
+      "target": "wordpress_values_schema_podmanagementpolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podmanagementpolicy",
+      "target": "wordpress_values_schema_podmanagementpolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L34",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_updatestrategy",
+      "target": "wordpress_values_schema_updatestrategy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L176",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_updatestrategy",
+      "target": "wordpress_values_schema_updatestrategy_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L175",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_updatestrategy",
+      "target": "wordpress_values_schema_updatestrategy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L186",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_updatestrategy_properties",
+      "target": "wordpress_values_schema_properties_rollingupdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L177",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_updatestrategy_properties",
+      "target": "wordpress_values_schema_properties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L184",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_type",
+      "target": "wordpress_values_schema_type_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L183",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_type",
+      "target": "wordpress_values_schema_type_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L179",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_type",
+      "target": "wordpress_values_schema_type_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L178",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_type",
+      "target": "wordpress_values_schema_type_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L48",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_persistentvolumeclaimretentionpolicy",
+      "target": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L49",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_persistentvolumeclaimretentionpolicy",
+      "target": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L47",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_persistentvolumeclaimretentionpolicy",
+      "target": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L50",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_properties",
+      "target": "wordpress_values_schema_properties_whendeleted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L58",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_persistentvolumeclaimretentionpolicy_properties",
+      "target": "wordpress_values_schema_properties_whenscaled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L56",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_whendeleted",
+      "target": "wordpress_values_schema_whendeleted_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L52",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_whendeleted",
+      "target": "wordpress_values_schema_whendeleted_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L51",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_whendeleted",
+      "target": "wordpress_values_schema_whendeleted_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_whenscaled",
+      "target": "wordpress_values_schema_whenscaled_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L60",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_whenscaled",
+      "target": "wordpress_values_schema_whenscaled_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L59",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_whenscaled",
+      "target": "wordpress_values_schema_whenscaled_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L283",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_image",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L285",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_image",
+      "target": "wordpress_values_schema_image_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_image",
+      "target": "wordpress_values_schema_image_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L284",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_image",
+      "target": "wordpress_values_schema_image_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L83",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_image_properties",
+      "target": "wordpress_values_schema_properties_pullpolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L73",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_image_properties",
+      "target": "wordpress_values_schema_properties_registry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L78",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_image_properties",
+      "target": "wordpress_values_schema_properties_repository",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L93",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_image_properties",
+      "target": "wordpress_values_schema_properties_tag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L76",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_registry",
+      "target": "wordpress_values_schema_registry_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L75",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_registry",
+      "target": "wordpress_values_schema_registry_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L74",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_registry",
+      "target": "wordpress_values_schema_registry_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L81",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repository",
+      "target": "wordpress_values_schema_repository_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L80",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repository",
+      "target": "wordpress_values_schema_repository_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L79",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repository",
+      "target": "wordpress_values_schema_repository_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L91",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pullpolicy",
+      "target": "wordpress_values_schema_pullpolicy_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L90",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pullpolicy",
+      "target": "wordpress_values_schema_pullpolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L85",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pullpolicy",
+      "target": "wordpress_values_schema_pullpolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L84",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pullpolicy",
+      "target": "wordpress_values_schema_pullpolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L96",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_tag",
+      "target": "wordpress_values_schema_tag_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L95",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_tag",
+      "target": "wordpress_values_schema_tag_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L94",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_tag",
+      "target": "wordpress_values_schema_tag_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L121",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_imagepullsecrets",
+      "target": "wordpress_values_schema_imagepullsecrets_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L108",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_imagepullsecrets",
+      "target": "wordpress_values_schema_imagepullsecrets_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L109",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_imagepullsecrets",
+      "target": "wordpress_values_schema_imagepullsecrets_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L106",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_imagepullsecrets",
+      "target": "wordpress_values_schema_imagepullsecrets_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L107",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_imagepullsecrets",
+      "target": "wordpress_values_schema_imagepullsecrets_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L111",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_imagepullsecrets_items",
+      "target": "wordpress_values_schema_items_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L112",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_imagepullsecrets_items",
+      "target": "wordpress_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L119",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_imagepullsecrets_items",
+      "target": "wordpress_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L110",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_imagepullsecrets_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L989",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_accessmodes_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L240",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_args_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L232",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_command_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L248",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_extraenvvars_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L216",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_initcontainers_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L867",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_mupluginsconfigmaps_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L552",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_plugins_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L224",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_sidecars_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L601",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_themes_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L680",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_users_items",
+      "target": "wordpress_values_schema_items_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L249",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_extraenvvars_items",
+      "target": "wordpress_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L611",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_activate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L749",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_applicationpassword",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L615",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_autoupdate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L690",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_displayname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L686",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_email",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L694",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_firstname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L873",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L698",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_lastname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L869",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L570",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_networkactivate",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L619",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_networkenable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L702",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_role",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L713",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_sendemail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L721",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_sites",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L630",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_slug",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L717",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_superadmin",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L682",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_username",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L253",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_value",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L607",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_items_properties",
+      "target": "wordpress_values_schema_properties_version",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L868",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_mupluginsconfigmaps_items",
+      "target": "wordpress_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L553",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_plugins_items",
+      "target": "wordpress_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L602",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_themes_items",
+      "target": "wordpress_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L681",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_users_items",
+      "target": "wordpress_values_schema_items_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L821",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_configextraconfigmap_properties",
+      "target": "wordpress_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L837",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_configextrasecret_properties",
+      "target": "wordpress_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1044",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_name",
+      "target": "wordpress_values_schema_name_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1043",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_name",
+      "target": "wordpress_values_schema_name_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L114",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_name",
+      "target": "wordpress_values_schema_name_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1042",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_name",
+      "target": "wordpress_values_schema_name_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1041",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_serviceaccount_properties",
+      "target": "wordpress_values_schema_properties_name",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L257",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_extraenvvars_items",
+      "target": "wordpress_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L878",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_mupluginsconfigmaps_items",
+      "target": "wordpress_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L586",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_plugins_items",
+      "target": "wordpress_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L635",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_themes_items",
+      "target": "wordpress_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L786",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_users_items",
+      "target": "wordpress_values_schema_items_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L126",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_nameoverride",
+      "target": "wordpress_values_schema_nameoverride_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L125",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_nameoverride",
+      "target": "wordpress_values_schema_nameoverride_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L124",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_nameoverride",
+      "target": "wordpress_values_schema_nameoverride_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L131",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_fullnameoverride",
+      "target": "wordpress_values_schema_fullnameoverride_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L130",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_fullnameoverride",
+      "target": "wordpress_values_schema_fullnameoverride_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L129",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_fullnameoverride",
+      "target": "wordpress_values_schema_fullnameoverride_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L136",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_clusterdomain",
+      "target": "wordpress_values_schema_clusterdomain_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L135",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_clusterdomain",
+      "target": "wordpress_values_schema_clusterdomain_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L134",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_clusterdomain",
+      "target": "wordpress_values_schema_clusterdomain_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L140",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_dnspolicy",
+      "target": "wordpress_values_schema_dnspolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L139",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_dnspolicy",
+      "target": "wordpress_values_schema_dnspolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L144",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_dnsconfig",
+      "target": "wordpress_values_schema_dnsconfig_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L143",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_dnsconfig",
+      "target": "wordpress_values_schema_dnsconfig_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L148",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_hostnetwork",
+      "target": "wordpress_values_schema_hostnetwork_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L147",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_hostnetwork",
+      "target": "wordpress_values_schema_hostnetwork_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L153",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customlabels",
+      "target": "wordpress_values_schema_customlabels_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L152",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customlabels",
+      "target": "wordpress_values_schema_customlabels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L151",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customlabels",
+      "target": "wordpress_values_schema_customlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L158",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customannotations",
+      "target": "wordpress_values_schema_customannotations_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L157",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customannotations",
+      "target": "wordpress_values_schema_customannotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L156",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customannotations",
+      "target": "wordpress_values_schema_customannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L163",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_commonlabels",
+      "target": "wordpress_values_schema_commonlabels_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L162",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_commonlabels",
+      "target": "wordpress_values_schema_commonlabels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L161",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_commonlabels",
+      "target": "wordpress_values_schema_commonlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L164",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_commonlabels_additionalproperties",
+      "target": "wordpress_values_schema_additionalproperties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L171",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_commonannotations_additionalproperties",
+      "target": "wordpress_values_schema_additionalproperties_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L170",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_commonannotations",
+      "target": "wordpress_values_schema_commonannotations_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L169",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_commonannotations",
+      "target": "wordpress_values_schema_commonannotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L168",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_commonannotations",
+      "target": "wordpress_values_schema_commonannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L188",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_rollingupdate",
+      "target": "wordpress_values_schema_rollingupdate_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_rollingupdate",
+      "target": "wordpress_values_schema_rollingupdate_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L189",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_rollingupdate_properties",
+      "target": "wordpress_values_schema_properties_maxsurge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L199",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_rollingupdate_properties",
+      "target": "wordpress_values_schema_properties_maxunavailable",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L190",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_maxsurge",
+      "target": "wordpress_values_schema_maxsurge_oneof",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L200",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_maxunavailable",
+      "target": "wordpress_values_schema_maxunavailable_oneof",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L219",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_initcontainers",
+      "target": "wordpress_values_schema_initcontainers_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L218",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_initcontainers",
+      "target": "wordpress_values_schema_initcontainers_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L215",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_initcontainers",
+      "target": "wordpress_values_schema_initcontainers_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L214",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_initcontainers",
+      "target": "wordpress_values_schema_initcontainers_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L227",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_sidecars",
+      "target": "wordpress_values_schema_sidecars_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L226",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_sidecars",
+      "target": "wordpress_values_schema_sidecars_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L223",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_sidecars",
+      "target": "wordpress_values_schema_sidecars_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L222",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_sidecars",
+      "target": "wordpress_values_schema_sidecars_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L235",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_command",
+      "target": "wordpress_values_schema_command_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L234",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_command",
+      "target": "wordpress_values_schema_command_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L231",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_command",
+      "target": "wordpress_values_schema_command_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L230",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_command",
+      "target": "wordpress_values_schema_command_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L243",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_args",
+      "target": "wordpress_values_schema_args_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L242",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_args",
+      "target": "wordpress_values_schema_args_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L239",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_args",
+      "target": "wordpress_values_schema_args_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L238",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_args",
+      "target": "wordpress_values_schema_args_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L262",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvars",
+      "target": "wordpress_values_schema_extraenvvars_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L261",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvars",
+      "target": "wordpress_values_schema_extraenvvars_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L247",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvars",
+      "target": "wordpress_values_schema_extraenvvars_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L246",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvars",
+      "target": "wordpress_values_schema_extraenvvars_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L254",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_value",
+      "target": "wordpress_values_schema_value_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L267",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvarssecret",
+      "target": "wordpress_values_schema_extraenvvarssecret_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L266",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvarssecret",
+      "target": "wordpress_values_schema_extraenvvarssecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L265",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvarssecret",
+      "target": "wordpress_values_schema_extraenvvarssecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L272",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvarscm",
+      "target": "wordpress_values_schema_extraenvvarscm_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L271",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvarscm",
+      "target": "wordpress_values_schema_extraenvvarscm_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L270",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_extraenvvarscm",
+      "target": "wordpress_values_schema_extraenvvarscm_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L279",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_wordpress",
+      "target": "wordpress_values_schema_wordpress_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L276",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_wordpress",
+      "target": "wordpress_values_schema_wordpress_required",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L275",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_wordpress",
+      "target": "wordpress_values_schema_wordpress_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L647",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_composer",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L813",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_configextra",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L817",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_configextraconfigmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L808",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_configextrainject",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L833",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_configextrasecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L858",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_debug",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L849",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_htaccess",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L853",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_htaccessconfigmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L280",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_init",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L799",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_language",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L863",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_mupluginsconfigmaps",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L528",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_permalinks",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L549",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_plugins",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L593",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_pluginsprune",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L884",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_smtp",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L794",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_tableprefix",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L598",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_themes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L642",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_themesprune",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L803",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_url",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L677",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_wordpress_properties",
+      "target": "wordpress_values_schema_properties_users",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L282",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_init",
+      "target": "wordpress_values_schema_init_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L281",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_init",
+      "target": "wordpress_values_schema_init_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L464",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_applicationpassword",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L377",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_custominitconfigmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L373",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_custominitscript",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L368",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_debug",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L352",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_email",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L313",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L318",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_existingsecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L356",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_firstname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L500",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_jwt",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L360",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_lastname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L393",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_multisites",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L348",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_password",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L323",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_secretkeys",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L364",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_title",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L344",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_init_properties",
+      "target": "wordpress_values_schema_properties_username",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L316",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_enabled",
+      "target": "wordpress_values_schema_enabled_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L315",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_enabled",
+      "target": "wordpress_values_schema_enabled_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L890",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_enabled",
+      "target": "wordpress_values_schema_enabled_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L889",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_enabled",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L321",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingsecret",
+      "target": "wordpress_values_schema_existingsecret_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L320",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingsecret",
+      "target": "wordpress_values_schema_existingsecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L917",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingsecret",
+      "target": "wordpress_values_schema_existingsecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L916",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_existingsecret",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L325",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_secretkeys",
+      "target": "wordpress_values_schema_secretkeys_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L326",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_secretkeys",
+      "target": "wordpress_values_schema_secretkeys_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L324",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_secretkeys",
+      "target": "wordpress_values_schema_secretkeys_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L346",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_username",
+      "target": "wordpress_values_schema_username_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L911",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_username",
+      "target": "wordpress_values_schema_username_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L910",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_username",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L350",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_password",
+      "target": "wordpress_values_schema_password_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L914",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_password",
+      "target": "wordpress_values_schema_password_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L913",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_password",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L354",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_email",
+      "target": "wordpress_values_schema_email_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L353",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_email",
+      "target": "wordpress_values_schema_email_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L358",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_firstname",
+      "target": "wordpress_values_schema_firstname_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L357",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_firstname",
+      "target": "wordpress_values_schema_firstname_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L362",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_lastname",
+      "target": "wordpress_values_schema_lastname_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L361",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_lastname",
+      "target": "wordpress_values_schema_lastname_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L366",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_title",
+      "target": "wordpress_values_schema_title_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L365",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_title",
+      "target": "wordpress_values_schema_title_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L861",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_debug",
+      "target": "wordpress_values_schema_debug_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L860",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_debug",
+      "target": "wordpress_values_schema_debug_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L859",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_debug",
+      "target": "wordpress_values_schema_debug_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L375",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_custominitscript",
+      "target": "wordpress_values_schema_custominitscript_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L374",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_custominitscript",
+      "target": "wordpress_values_schema_custominitscript_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L379",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_custominitconfigmap",
+      "target": "wordpress_values_schema_custominitconfigmap_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L380",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_custominitconfigmap",
+      "target": "wordpress_values_schema_custominitconfigmap_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L378",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_custominitconfigmap",
+      "target": "wordpress_values_schema_custominitconfigmap_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L457",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_multisites",
+      "target": "wordpress_values_schema_multisites_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L395",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_multisites",
+      "target": "wordpress_values_schema_multisites_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L396",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_multisites",
+      "target": "wordpress_values_schema_multisites_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L394",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_multisites",
+      "target": "wordpress_values_schema_multisites_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L466",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_applicationpassword",
+      "target": "wordpress_values_schema_applicationpassword_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L467",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_applicationpassword",
+      "target": "wordpress_values_schema_applicationpassword_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L465",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_applicationpassword",
+      "target": "wordpress_values_schema_applicationpassword_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L502",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_jwt",
+      "target": "wordpress_values_schema_jwt_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L503",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_jwt",
+      "target": "wordpress_values_schema_jwt_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L501",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_jwt",
+      "target": "wordpress_values_schema_jwt_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L530",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_permalinks",
+      "target": "wordpress_values_schema_permalinks_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L529",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_permalinks",
+      "target": "wordpress_values_schema_permalinks_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L543",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_permalinks_properties",
+      "target": "wordpress_values_schema_properties_customstructure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L531",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_permalinks_properties",
+      "target": "wordpress_values_schema_properties_structure",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L541",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_structure",
+      "target": "wordpress_values_schema_structure_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L540",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_structure",
+      "target": "wordpress_values_schema_structure_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L533",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_structure",
+      "target": "wordpress_values_schema_structure_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L532",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_structure",
+      "target": "wordpress_values_schema_structure_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L545",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customstructure",
+      "target": "wordpress_values_schema_customstructure_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L544",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customstructure",
+      "target": "wordpress_values_schema_customstructure_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L591",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_plugins",
+      "target": "wordpress_values_schema_plugins_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L590",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_plugins",
+      "target": "wordpress_values_schema_plugins_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L551",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_plugins",
+      "target": "wordpress_values_schema_plugins_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L550",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_plugins",
+      "target": "wordpress_values_schema_plugins_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L596",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pluginsprune",
+      "target": "wordpress_values_schema_pluginsprune_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L595",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pluginsprune",
+      "target": "wordpress_values_schema_pluginsprune_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L594",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_pluginsprune",
+      "target": "wordpress_values_schema_pluginsprune_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L640",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themes",
+      "target": "wordpress_values_schema_themes_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L639",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themes",
+      "target": "wordpress_values_schema_themes_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L600",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themes",
+      "target": "wordpress_values_schema_themes_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L599",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themes",
+      "target": "wordpress_values_schema_themes_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L645",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themesprune",
+      "target": "wordpress_values_schema_themesprune_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L644",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themesprune",
+      "target": "wordpress_values_schema_themesprune_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L643",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_themesprune",
+      "target": "wordpress_values_schema_themesprune_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L673",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_composer",
+      "target": "wordpress_values_schema_composer_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L649",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_composer",
+      "target": "wordpress_values_schema_composer_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L648",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_composer",
+      "target": "wordpress_values_schema_composer_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L650",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_composer_properties",
+      "target": "wordpress_values_schema_properties_repositories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L670",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repositories",
+      "target": "wordpress_values_schema_repositories_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L669",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repositories",
+      "target": "wordpress_values_schema_repositories_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L652",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repositories",
+      "target": "wordpress_values_schema_repositories_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L651",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_repositories",
+      "target": "wordpress_values_schema_repositories_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L674",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_composer_default",
+      "target": "wordpress_values_schema_default_repositories",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L792",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_users",
+      "target": "wordpress_values_schema_users_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L791",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_users",
+      "target": "wordpress_values_schema_users_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L679",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_users",
+      "target": "wordpress_values_schema_users_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L678",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_users",
+      "target": "wordpress_values_schema_users_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L797",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_tableprefix",
+      "target": "wordpress_values_schema_tableprefix_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L796",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_tableprefix",
+      "target": "wordpress_values_schema_tableprefix_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L795",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_tableprefix",
+      "target": "wordpress_values_schema_tableprefix_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L801",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_language",
+      "target": "wordpress_values_schema_language_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L800",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_language",
+      "target": "wordpress_values_schema_language_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L805",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_url",
+      "target": "wordpress_values_schema_url_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L806",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_url",
+      "target": "wordpress_values_schema_url_minlength",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L804",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_url",
+      "target": "wordpress_values_schema_url_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L811",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextrainject",
+      "target": "wordpress_values_schema_configextrainject_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L810",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextrainject",
+      "target": "wordpress_values_schema_configextrainject_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L809",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextrainject",
+      "target": "wordpress_values_schema_configextrainject_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L815",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextra",
+      "target": "wordpress_values_schema_configextra_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L814",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextra",
+      "target": "wordpress_values_schema_configextra_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L819",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextraconfigmap",
+      "target": "wordpress_values_schema_configextraconfigmap_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L820",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextraconfigmap",
+      "target": "wordpress_values_schema_configextraconfigmap_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L818",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextraconfigmap",
+      "target": "wordpress_values_schema_configextraconfigmap_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L826",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_configextraconfigmap_properties",
+      "target": "wordpress_values_schema_properties_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L842",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_configextrasecret_properties",
+      "target": "wordpress_values_schema_properties_key",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L845",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_key",
+      "target": "wordpress_values_schema_key_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L844",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_key",
+      "target": "wordpress_values_schema_key_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L843",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_key",
+      "target": "wordpress_values_schema_key_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L835",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextrasecret",
+      "target": "wordpress_values_schema_configextrasecret_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L836",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextrasecret",
+      "target": "wordpress_values_schema_configextrasecret_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L834",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_configextrasecret",
+      "target": "wordpress_values_schema_configextrasecret_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L851",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_htaccess",
+      "target": "wordpress_values_schema_htaccess_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L850",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_htaccess",
+      "target": "wordpress_values_schema_htaccess_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L856",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_htaccessconfigmap",
+      "target": "wordpress_values_schema_htaccessconfigmap_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L855",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_htaccessconfigmap",
+      "target": "wordpress_values_schema_htaccessconfigmap_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L854",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_htaccessconfigmap",
+      "target": "wordpress_values_schema_htaccessconfigmap_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L882",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_mupluginsconfigmaps",
+      "target": "wordpress_values_schema_mupluginsconfigmaps_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L865",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_mupluginsconfigmaps",
+      "target": "wordpress_values_schema_mupluginsconfigmaps_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L866",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_mupluginsconfigmaps",
+      "target": "wordpress_values_schema_mupluginsconfigmaps_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L864",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_mupluginsconfigmaps",
+      "target": "wordpress_values_schema_mupluginsconfigmaps_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L887",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_smtp",
+      "target": "wordpress_values_schema_smtp_additionalproperties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L886",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_smtp",
+      "target": "wordpress_values_schema_smtp_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L888",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_smtp",
+      "target": "wordpress_values_schema_smtp_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L885",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_smtp",
+      "target": "wordpress_values_schema_smtp_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L907",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_auth",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L898",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_encryption",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L925",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_existingsecretfromemailkey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L919",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_existingsecretpasswordkey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L922",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_existingsecretusernamekey",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L901",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_fromemail",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L904",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_fromname",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L892",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_host",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L895",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_smtp_properties",
+      "target": "wordpress_values_schema_properties_port",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L893",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_host",
+      "target": "wordpress_values_schema_host_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L896",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_port",
+      "target": "wordpress_values_schema_port_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L899",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_encryption",
+      "target": "wordpress_values_schema_encryption_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L902",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_fromemail",
+      "target": "wordpress_values_schema_fromemail_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L905",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_fromname",
+      "target": "wordpress_values_schema_fromname_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L908",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_auth",
+      "target": "wordpress_values_schema_auth_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L920",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingsecretpasswordkey",
+      "target": "wordpress_values_schema_existingsecretpasswordkey_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L923",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingsecretusernamekey",
+      "target": "wordpress_values_schema_existingsecretusernamekey_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L926",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingsecretfromemailkey",
+      "target": "wordpress_values_schema_existingsecretfromemailkey_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L934",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_apache",
+      "target": "wordpress_values_schema_apache_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L933",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_apache",
+      "target": "wordpress_values_schema_apache_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L940",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_customdefaultsiteconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L944",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_customdefaultsiteconfigmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L958",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_customphpconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L962",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_customphpconfigmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L949",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_customportsconfig",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L953",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_customportsconfigmap",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L935",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_apache_properties",
+      "target": "wordpress_values_schema_properties_servername",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L938",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_servername",
+      "target": "wordpress_values_schema_servername_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L937",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_servername",
+      "target": "wordpress_values_schema_servername_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L936",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_servername",
+      "target": "wordpress_values_schema_servername_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L942",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customdefaultsiteconfig",
+      "target": "wordpress_values_schema_customdefaultsiteconfig_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L941",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customdefaultsiteconfig",
+      "target": "wordpress_values_schema_customdefaultsiteconfig_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L947",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customdefaultsiteconfigmap",
+      "target": "wordpress_values_schema_customdefaultsiteconfigmap_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L946",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customdefaultsiteconfigmap",
+      "target": "wordpress_values_schema_customdefaultsiteconfigmap_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L945",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customdefaultsiteconfigmap",
+      "target": "wordpress_values_schema_customdefaultsiteconfigmap_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L951",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customportsconfig",
+      "target": "wordpress_values_schema_customportsconfig_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L950",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customportsconfig",
+      "target": "wordpress_values_schema_customportsconfig_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L956",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customportsconfigmap",
+      "target": "wordpress_values_schema_customportsconfigmap_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L955",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customportsconfigmap",
+      "target": "wordpress_values_schema_customportsconfigmap_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L954",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customportsconfigmap",
+      "target": "wordpress_values_schema_customportsconfigmap_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L960",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customphpconfig",
+      "target": "wordpress_values_schema_customphpconfig_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L959",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customphpconfig",
+      "target": "wordpress_values_schema_customphpconfig_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L965",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customphpconfigmap",
+      "target": "wordpress_values_schema_customphpconfigmap_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L964",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customphpconfigmap",
+      "target": "wordpress_values_schema_customphpconfigmap_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L963",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_customphpconfigmap",
+      "target": "wordpress_values_schema_customphpconfigmap_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L971",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_storage",
+      "target": "wordpress_values_schema_storage_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L970",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_storage",
+      "target": "wordpress_values_schema_storage_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L986",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_accessmodes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1001",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L972",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_existingclaim",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1005",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_labels",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1013",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_resourcepolicy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1009",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_selector",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L981",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_size",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L976",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_storage_properties",
+      "target": "wordpress_values_schema_properties_storageclass",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L974",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingclaim",
+      "target": "wordpress_values_schema_existingclaim_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L973",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_existingclaim",
+      "target": "wordpress_values_schema_existingclaim_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L979",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_storageclass",
+      "target": "wordpress_values_schema_storageclass_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L978",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_storageclass",
+      "target": "wordpress_values_schema_storageclass_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L977",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_storageclass",
+      "target": "wordpress_values_schema_storageclass_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L984",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_size",
+      "target": "wordpress_values_schema_size_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L983",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_size",
+      "target": "wordpress_values_schema_size_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L982",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_size",
+      "target": "wordpress_values_schema_size_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L997",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_accessmodes",
+      "target": "wordpress_values_schema_accessmodes_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L996",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_accessmodes",
+      "target": "wordpress_values_schema_accessmodes_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L988",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_accessmodes",
+      "target": "wordpress_values_schema_accessmodes_items",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L987",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_accessmodes",
+      "target": "wordpress_values_schema_accessmodes_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L990",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_accessmodes_items",
+      "target": "wordpress_values_schema_items_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1039",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_annotations",
+      "target": "wordpress_values_schema_annotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1038",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_annotations",
+      "target": "wordpress_values_schema_annotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1037",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_serviceaccount_properties",
+      "target": "wordpress_values_schema_properties_annotations",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1007",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_labels",
+      "target": "wordpress_values_schema_labels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1006",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_labels",
+      "target": "wordpress_values_schema_labels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1011",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_selector",
+      "target": "wordpress_values_schema_selector_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1010",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_selector",
+      "target": "wordpress_values_schema_selector_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1020",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_resourcepolicy",
+      "target": "wordpress_values_schema_resourcepolicy_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1019",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_resourcepolicy",
+      "target": "wordpress_values_schema_resourcepolicy_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1015",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_resourcepolicy",
+      "target": "wordpress_values_schema_resourcepolicy_enum",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1014",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_resourcepolicy",
+      "target": "wordpress_values_schema_resourcepolicy_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1026",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_serviceaccount",
+      "target": "wordpress_values_schema_serviceaccount_properties",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1025",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_serviceaccount",
+      "target": "wordpress_values_schema_serviceaccount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1032",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_serviceaccount_properties",
+      "target": "wordpress_values_schema_properties_automount",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1027",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_serviceaccount_properties",
+      "target": "wordpress_values_schema_properties_create",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1030",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_create",
+      "target": "wordpress_values_schema_create_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1029",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_create",
+      "target": "wordpress_values_schema_create_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1028",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_create",
+      "target": "wordpress_values_schema_create_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1035",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_automount",
+      "target": "wordpress_values_schema_automount_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1034",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_automount",
+      "target": "wordpress_values_schema_automount_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1033",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_automount",
+      "target": "wordpress_values_schema_automount_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1051",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podannotations",
+      "target": "wordpress_values_schema_podannotations_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1050",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podannotations",
+      "target": "wordpress_values_schema_podannotations_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1049",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podannotations",
+      "target": "wordpress_values_schema_podannotations_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1056",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podlabels",
+      "target": "wordpress_values_schema_podlabels_default",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1055",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podlabels",
+      "target": "wordpress_values_schema_podlabels_description",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1054",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podlabels",
+      "target": "wordpress_values_schema_podlabels_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "charts/wordpress/values.schema.json",
+      "source_location": "L1059",
+      "weight": 1.0,
+      "source": "wordpress_values_schema_properties_podsecuritycontext",
+      "target": "wordpress_values_schema_podsecuritycontext_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L3",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_bootstrap_sha",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_changelog_sections",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L8",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_draft",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_include_component_in_tag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_include_v_in_tag",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_packages",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L4",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_release_type",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_schema",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L6",
+      "weight": 1.0,
+      "source": "release_please_config",
+      "target": "release_please_config_separate_pull_requests",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L36",
+      "weight": 1.0,
+      "source": "release_please_config_packages",
+      "target": "release_please_config_packages_charts_wg_easy",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "release_please_config_packages",
+      "target": "release_please_config_packages_charts_wireguard",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "release_please_config_packages",
+      "target": "release_please_config_packages_charts_wordpress",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L24",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wordpress",
+      "target": "release_please_config_charts_wordpress_changelog_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wordpress",
+      "target": "release_please_config_charts_wordpress_component",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L25",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wordpress",
+      "target": "release_please_config_charts_wordpress_extra_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L31",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wireguard",
+      "target": "release_please_config_charts_wireguard_changelog_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wireguard",
+      "target": "release_please_config_charts_wireguard_component",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L32",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wireguard",
+      "target": "release_please_config_charts_wireguard_extra_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L38",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wg_easy",
+      "target": "release_please_config_charts_wg_easy_changelog_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L37",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wg_easy",
+      "target": "release_please_config_charts_wg_easy_component",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "release-please-config.json",
+      "source_location": "L39",
+      "weight": 1.0,
+      "source": "release_please_config_packages_charts_wg_easy",
+      "target": "release_please_config_charts_wg_easy_extra_files",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L23",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_assignees",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L26",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_custommanagers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L13",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_enabledmanagers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L2",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_extends",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L5",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_gitignoredauthors",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L64",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_packagerules",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L19",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_pindigests",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_platformautomerge",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L21",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_prconcurrentlimit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L20",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_prhourlylimit",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L10",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_rebasewhen",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_semanticcommits",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L12",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_semanticcommitscope",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "renovate.json",
+      "source_location": "L22",
+      "weight": 1.0,
+      "source": "renovate",
+      "target": "renovate_timezone",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L17",
+      "weight": 1.0,
+      "source": "scripts_helmlint",
+      "target": "scripts_helmlint_chart_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L11",
+      "weight": 1.0,
+      "source": "scripts_helmlint",
+      "target": "scripts_helmlint_contains_element",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L9",
+      "weight": 1.0,
+      "source": "scripts_helmlint",
+      "target": "scripts_helmlint_cwd_abspath",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "defines",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L7",
+      "weight": 1.0,
+      "source": "scripts_helmlint",
+      "target": "scripts_helmlint_path",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L1",
+      "weight": 1.0,
+      "source": "scripts_helmlint",
+      "target": "users_timon_homelab_helm_charts_scripts_helmlint_sh__entry",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/helmlint.sh",
+      "source_location": "L34",
+      "weight": 1.0,
+      "context": "call",
+      "source": "users_timon_homelab_helm_charts_scripts_helmlint_sh__entry",
+      "target": "scripts_helmlint_contains_element",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L29",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_check_special_chars_quoted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L269",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_main",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L187",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_validate_category",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L42",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_validate_changes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L201",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_validate_chart_yaml",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L99",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_validate_images",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L127",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_validate_links",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "contains",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L157",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations",
+      "target": "scripts_validate_artifacthub_annotations_validate_maintainers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L30",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_30",
+      "target": "scripts_validate_artifacthub_annotations_check_special_chars_quoted",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L43",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_43",
+      "target": "scripts_validate_artifacthub_annotations_validate_changes",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L100",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_100",
+      "target": "scripts_validate_artifacthub_annotations_validate_images",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L128",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_128",
+      "target": "scripts_validate_artifacthub_annotations_validate_links",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L158",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_158",
+      "target": "scripts_validate_artifacthub_annotations_validate_maintainers",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L188",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_188",
+      "target": "scripts_validate_artifacthub_annotations_validate_category",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L252",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_validate_chart_yaml",
+      "target": "scripts_validate_artifacthub_annotations_validate_category",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "calls",
+      "context": "call",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L288",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_main",
+      "target": "scripts_validate_artifacthub_annotations_validate_chart_yaml",
+      "confidence_score": 1.0
+    },
+    {
+      "relation": "rationale_for",
+      "confidence": "EXTRACTED",
+      "source_file": "scripts/validate-artifacthub-annotations.py",
+      "source_location": "L202",
+      "weight": 1.0,
+      "source": "scripts_validate_artifacthub_annotations_rationale_202",
+      "target": "scripts_validate_artifacthub_annotations_validate_chart_yaml",
+      "confidence_score": 1.0
+    }
+  ],
+  "hyperedges": [],
+  "built_at_commit": "d585e011393ad25b7089591eed33511c372d1ddf"
+}

--- a/graphify-out/manifest.json
+++ b/graphify-out/manifest.json
@@ -1,0 +1,102 @@
+{
+  ".claude/settings.local.json": {
+    "mtime": 1780445496.3902566,
+    "ast_hash": "5999fe16a4639f58faf53a6bdac8b7d0",
+    "semantic_hash": "5999fe16a4639f58faf53a6bdac8b7d0"
+  },
+  ".github/scripts/sync-artifacthub-changes.py": {
+    "mtime": 1780483798.951804,
+    "ast_hash": "86326a54a2b07551ceb26c0db010e6bb",
+    "semantic_hash": "86326a54a2b07551ceb26c0db010e6bb"
+  },
+  ".release-please-manifest.json": {
+    "mtime": 1781184949.505231,
+    "ast_hash": "21a755e2ee059b5201691b2f0af19232",
+    "semantic_hash": "21a755e2ee059b5201691b2f0af19232"
+  },
+  ".vscode/tasks.json": {
+    "mtime": 1773434862.322702,
+    "ast_hash": "6f70b620b730783b61472a49f09d3246",
+    "semantic_hash": "6f70b620b730783b61472a49f09d3246"
+  },
+  "charts/wg-easy/samples/verify/install.sh": {
+    "mtime": 1781183666.6213193,
+    "ast_hash": "5cca5c29ebc10738fd5d47e6bb4f24c3",
+    "semantic_hash": "5cca5c29ebc10738fd5d47e6bb4f24c3"
+  },
+  "charts/wg-easy/samples/verify/uninstall.sh": {
+    "mtime": 1781183666.6226301,
+    "ast_hash": "ed061b45688efdfc11c5e850a43c8c4f",
+    "semantic_hash": "ed061b45688efdfc11c5e850a43c8c4f"
+  },
+  "charts/wg-easy/samples/verify/verify.sh": {
+    "mtime": 1781183666.6236959,
+    "ast_hash": "94e05a458abbfe97171f9f0081057f79",
+    "semantic_hash": "94e05a458abbfe97171f9f0081057f79"
+  },
+  "charts/wg-easy/values.schema.json": {
+    "mtime": 1781173026.0747762,
+    "ast_hash": "ef3906de651631036325537c37871896",
+    "semantic_hash": "ef3906de651631036325537c37871896"
+  },
+  "charts/wireguard/samples/verify/install.sh": {
+    "mtime": 1781183666.6257472,
+    "ast_hash": "ed49b2648f14b52a69dfe10abc25cad3",
+    "semantic_hash": "ed49b2648f14b52a69dfe10abc25cad3"
+  },
+  "charts/wireguard/samples/verify/uninstall.sh": {
+    "mtime": 1781183666.6264036,
+    "ast_hash": "9857e9bd2ecc774b9f256e08dd9f4e0f",
+    "semantic_hash": "9857e9bd2ecc774b9f256e08dd9f4e0f"
+  },
+  "charts/wireguard/samples/verify/verify.sh": {
+    "mtime": 1781183666.6271164,
+    "ast_hash": "050a19c1ad8b9153b4ccefadac8ab8ea",
+    "semantic_hash": "050a19c1ad8b9153b4ccefadac8ab8ea"
+  },
+  "charts/wireguard/values.schema.json": {
+    "mtime": 1781184949.5080051,
+    "ast_hash": "1fff8e0f7c9263dd5a5833d68c09b70f",
+    "semantic_hash": "1fff8e0f7c9263dd5a5833d68c09b70f"
+  },
+  "charts/wordpress/samples/verify/install.sh": {
+    "mtime": 1779706937.2233138,
+    "ast_hash": "dd97d235c563fa4ac3f15fd48708d7a2",
+    "semantic_hash": "dd97d235c563fa4ac3f15fd48708d7a2"
+  },
+  "charts/wordpress/samples/verify/uninstall.sh": {
+    "mtime": 1780483798.9558637,
+    "ast_hash": "049b6f6c450cbb489505973760c30837",
+    "semantic_hash": "049b6f6c450cbb489505973760c30837"
+  },
+  "charts/wordpress/samples/verify/verify.sh": {
+    "mtime": 1780483798.9565647,
+    "ast_hash": "1da20c84abefd054b79aa07903947948",
+    "semantic_hash": "1da20c84abefd054b79aa07903947948"
+  },
+  "charts/wordpress/values.schema.json": {
+    "mtime": 1780483798.9594195,
+    "ast_hash": "2190a3148c8d3e06705417935f75c613",
+    "semantic_hash": "2190a3148c8d3e06705417935f75c613"
+  },
+  "release-please-config.json": {
+    "mtime": 1780483798.960231,
+    "ast_hash": "960bdc9894c1066bf13362229068929f",
+    "semantic_hash": "960bdc9894c1066bf13362229068929f"
+  },
+  "renovate.json": {
+    "mtime": 1781214979.9115264,
+    "ast_hash": "3e14fa7bcafeeacad7599bcd5fdb614c",
+    "semantic_hash": "3e14fa7bcafeeacad7599bcd5fdb614c"
+  },
+  "scripts/helmlint.sh": {
+    "mtime": 1779749336.2279923,
+    "ast_hash": "86656aeeda600b2d0cd56dd1d6776600",
+    "semantic_hash": "86656aeeda600b2d0cd56dd1d6776600"
+  },
+  "scripts/validate-artifacthub-annotations.py": {
+    "mtime": 1764867312.1171021,
+    "ast_hash": "d63c6a865586d99416cc4882bc88bbd8",
+    "semantic_hash": "d63c6a865586d99416cc4882bc88bbd8"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.rtk/filters.toml` (RTK CLI config)
- Add `graphify-out/` artifacts (manifest, graph, analysis) generated by graphify, not covered by the existing `graphify-out/cache/*` ignore rule

## Test plan
- N/A (tooling artifacts only, no chart changes)