### PR TITLE
fix: drop unresolved newDigestShort from renovate title templates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -106,8 +106,8 @@
             "matchFileNames": [
                 "charts/**"
             ],
-            "groupName": "chart/{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}/{{{depName}}}/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
-            "branchTopic": "chart-{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "groupName": "chart/{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}/{{{depName}}}/{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "chart-{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"
@@ -128,8 +128,8 @@
             "matchPackageNames": [
                 "docker.io/linuxserver/wireguard"
             ],
-            "groupName": "chart/wireguard/wireguard/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
-            "branchTopic": "chart-wireguard-wireguard-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}"
+            "groupName": "chart/wireguard/wireguard/{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "chart-wireguard-wireguard-{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}"
         },
         {
             "description": "Group subchart updates per dependency with version-specific branch names",
@@ -139,8 +139,8 @@
             "matchFileNames": [
                 "charts/**"
             ],
-            "groupName": "subchart/{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}/{{{depName}}}/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
-            "branchTopic": "subchart-{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "groupName": "subchart/{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}/{{{depName}}}/{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "subchart-{{{ replace '/samples' '' (replace 'charts/' '' parentDir) }}}-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"
@@ -157,8 +157,8 @@
             "matchFileNames": [
                 "charts/wordpress/**"
             ],
-            "groupName": "subchart/wordpress/{{{depName}}}/{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
-            "branchTopic": "subchart-wordpress-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}"
+            "groupName": "subchart/wordpress/{{{depName}}}/{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "subchart-wordpress-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}"
         },
         {
             "description": "Per-package GitHub Actions workflow updates with version-specific branches",
@@ -168,7 +168,7 @@
             "matchFileNames": [
                 ".github/workflows/**"
             ],
-            "branchTopic": "github-actions-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest-{{{newDigestShort}}}{{else}}{{{newVersion}}}{{/if}}",
+            "branchTopic": "github-actions-{{{depNameSanitized}}}-{{#if (equals updateType 'digest')}}digest{{else}}{{{newVersion}}}{{/if}}",
             "labels": [
                 "dependencies",
                 "renovate"


### PR DESCRIPTION
## Summary
- Renovate's `newDigestShort` template field doesn't resolve inside `packageRules`-scoped `groupName`/`branchTopic` templates ([renovatebot/renovate#31378](https://github.com/renovatebot/renovate/discussions/31378)) — every digest-only update PR title/branch name ended up with a dangling `digest-` suffix, e.g. [#418](https://github.com/SlyBase/helm-charts/pull/418): `fix(deps): update chart/wordpress/docker.io/wordpress/digest-`. Same pattern visible on #398, #408, #412, #415.
- Replaced the unresolvable `digest-{{{newDigestShort}}}` with a plain `digest` literal across all 9 occurrences (chart direct deps, wireguard, subcharts, wordpress subcharts, github-actions rules).

## Test plan
- [x] `renovate.json` is still valid JSON
- [ ] Next digest-only Renovate PR title reads `.../digest` instead of `.../digest-`