### PR TITLE
ci: auto-merge patch/minor release-please PRs

### DIFF
--- a/.github/workflows/release-please-automerge.yml
+++ b/.github/workflows/release-please-automerge.yml
@@ -1,0 +1,168 @@
+name: Release Please Auto-merge
+
+# Auto-merges release-please "release PRs" so dependency-driven releases ship
+# without a manual click. release-please opens one PR per chart (e.g.
+# "chore(main): release wordpress 4.7.8"); this workflow merges it once ALL of
+# the following hold:
+#   * the bump is PATCH or MINOR — a MAJOR (breaking, feat!) release stays manual,
+#   * the release version is final (no -alpha/-beta/-rc prerelease),
+#   * the artifacthub.io/changes annotation has already been synced onto the PR
+#     (release-please.yml does that right after opening the PR), and
+#   * every other PR check (PR Chart Validate, Chart Install Test) is green.
+#
+# IMPORTANT: the merge uses the PAT (SLYBASE_GHCR_TOKEN), NOT GITHUB_TOKEN.
+# A merge pushed by GITHUB_TOKEN would NOT re-trigger release-please.yml, so the
+# git tag + GitHub Release (and therefore oci-release.yaml) would never fire.
+# Merging with the PAT mirrors a maintainer merging the PR by hand.
+#
+# Note on "approval": main has no branch protection requiring reviews, so an
+# explicit approve is not needed to merge (and Actions is not permitted to
+# approve PRs anyway). Merging is the release.
+#
+# Security: pull_request_target runs with repo secrets in the base-repo context.
+# It therefore only ever acts on same-repo release-please branches (never forks)
+# and only runs repo-owned scripts against the PR's data files — it never
+# executes code checked out from the PR head.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Release PR number to evaluate and merge"
+        required: true
+        type: string
+
+# One run per PR; a newer head supersedes an in-flight check wait.
+concurrency:
+  group: release-please-automerge-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  automerge:
+    name: automerge
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    # Cheap guard for the PR event (no forks, release-please branches only); the
+    # full validation happens in the "Decide whether to merge" step below.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       startsWith(github.event.pull_request.head.ref, 'release-please--branches--main--components--'))
+    steps:
+      - name: Resolve PR number
+        id: pr
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            num="${{ inputs.pr }}"
+          else
+            num="${{ github.event.pull_request.number }}"
+          fi
+          echo "number=$num" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout base (trusted scripts + manifest)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to merge
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          skip() { echo "decision: SKIP — $1"; echo "merge=false" >> "$GITHUB_OUTPUT"; exit 0; }
+
+          meta=$(gh pr view "$PR" --json state,headRefName,isCrossRepository,title)
+          state=$(jq -r .state <<<"$meta")
+          head_ref=$(jq -r .headRefName <<<"$meta")
+          cross=$(jq -r .isCrossRepository <<<"$meta")
+          title=$(jq -r .title <<<"$meta")
+
+          [ "$state" = "OPEN" ] || skip "PR is $state"
+          [ "$cross" != "true" ] || skip "cross-repository PR"
+          case "$head_ref" in
+            release-please--branches--main--components--*) ;;
+            *) skip "not a release-please branch ($head_ref)" ;;
+          esac
+
+          chart="${head_ref##*--components--}"
+          [ -f "charts/$chart/Chart.yaml" ] || skip "no chart at charts/$chart"
+
+          old=$(jq -r --arg c "charts/$chart" '.[$c] // empty' .release-please-manifest.json)
+          git fetch --quiet origin "$head_ref"
+          new=$(git show "FETCH_HEAD:.release-please-manifest.json" \
+                | jq -r --arg c "charts/$chart" '.[$c] // empty')
+          echo "chart=$chart  old=$old  new=$new  title=$title"
+
+          { [ -n "$old" ] && [ -n "$new" ]; } || skip "could not read versions"
+          [ "$old" != "$new" ] || skip "no version change"
+          case "$new" in *-*) skip "prerelease $new" ;; esac
+
+          # Patch + Minor auto-merge; a MAJOR bump stays manual.
+          if [ "${new%%.*}" != "${old%%.*}" ]; then
+            skip "major bump $old -> $new (manual review)"
+          fi
+
+          # The artifacthub.io/changes annotation is derived from CHANGELOG.md by
+          # release-please.yml right after the PR is opened. Re-run that (idempotent)
+          # script against the PR's files: no diff => already synced => safe to merge.
+          # A diff means the sync push hasn't landed yet; bail and let the resulting
+          # 'synchronize' event re-run this workflow.
+          git checkout --quiet FETCH_HEAD -- "charts/$chart/Chart.yaml" "charts/$chart/CHANGELOG.md"
+          python3 .github/scripts/sync-artifacthub-changes.py --chart-dir "charts/$chart"
+          git diff --quiet -- "charts/$chart/Chart.yaml" \
+            || skip "artifacthub.io/changes not synced yet"
+
+          echo "decision: MERGE — $chart $old -> $new"
+          {
+            echo "merge=true"
+            echo "chart=$chart"
+            echo "version=$new"
+            echo "head_sha=$(git rev-parse FETCH_HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Wait for PR checks
+        if: steps.gate.outputs.merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          self="Release Please Auto-merge"   # never wait on ourselves
+          deadline=$(( $(date +%s) + 1500 )) # 25 min budget for CI
+          while :; do
+            raw=$(gh pr checks "$PR" --json name,workflow,bucket 2>/dev/null) || true
+            [ -n "$raw" ] || raw='[]'
+            relevant=$(jq -c --arg s "$self" '[.[] | select(.workflow != $s)]' <<<"$raw")
+            total=$(jq 'length' <<<"$relevant")
+            pending=$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$relevant")
+            failed=$(jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' <<<"$relevant")
+            echo "checks: total=$total pending=$pending failed=$failed"
+            [ "$failed" -eq 0 ] || { echo "::error::PR checks failed; not merging"; exit 1; }
+            if [ "$total" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              echo "all checks green"; break
+            fi
+            [ "$(date +%s)" -lt "$deadline" ] || { echo "::error::timed out waiting for checks"; exit 1; }
+            sleep 20
+          done
+
+      - name: Merge release PR (PAT so the release tag fires)
+        if: steps.gate.outputs.merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SLYBASE_GHCR_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          echo "Merging release PR #$PR: ${{ steps.gate.outputs.chart }} ${{ steps.gate.outputs.version }}"
+          # --match-head-commit pins the merge to the exact commit the gate validated;
+          # if the PR head advanced meanwhile (e.g. another dep landed), the merge is
+          # refused and the resulting 'synchronize' event re-runs this workflow.
+          gh pr merge "$PR" --squash --match-head-commit "${{ steps.gate.outputs.head_sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Releases are driven by **release-please** + **git tags**, not by hand-editing `v
 2. **release-please** (`.github/workflows/release-please.yml`, config `release-please-config.json` + `.release-please-manifest.json`) keeps one release PR per chart, bumping `Chart.yaml:version` (via `extra-files`) and generating `CHANGELOG.md`.
 3. A bridge step runs `.github/scripts/sync-artifacthub-changes.py` on the release PR to derive the `artifacthub.io/changes` (+ `artifacthub.io/prerelease`) annotation from the new CHANGELOG entry — single source of truth.
 4. Merging a release PR creates a per-chart tag (`<chart>-v<version>`, e.g. `wordpress-v4.5.0`) + GitHub Release, which triggers `oci-release.yaml` to package, push, Cosign-sign and upload ArtifactHub metadata.
+5. **Auto-merge** (`.github/workflows/release-please-automerge.yml`): release PRs that are **patch or minor** bumps (i.e. not a breaking-major `feat!` and not a `-alpha/-beta/-rc` prerelease) are merged automatically once the ArtifactHub sync commit has landed and all PR checks (`pr-chart-validate.yml`, `chart-install-test.yml`) are green. **Major/breaking releases stay manual.** The merge uses the PAT (`SLYBASE_GHCR_TOKEN`) — a `GITHUB_TOKEN` merge would not re-trigger release-please, so step 4's tag/OCI chain would never fire. No PR approval is involved: `main` has no required-review protection.
 
 Feature PRs use conventional commits (`feat:`/`fix:`/`feat!:`) the same way to drive their chart's bump. PR validation (lint/template) lives in `pr-chart-validate.yml`.
 
@@ -75,6 +76,7 @@ Each script installs the chart via `install.sh` into a dedicated `*-verify` name
 |---|---|
 | Detect changed charts in CI | `.github/actions/detect-changed-charts/action.yml` |
 | Release automation (per-chart) | `.github/workflows/release-please.yml`, `release-please-config.json`, `.release-please-manifest.json` |
+| Auto-merge patch/minor release PRs | `.github/workflows/release-please-automerge.yml` |
 | OCI publish on release tag | `.github/workflows/oci-release.yaml` |
 | CHANGELOG → ArtifactHub annotation bridge | `.github/scripts/sync-artifacthub-changes.py` |
 | Script usage docs | `.github/scripts/README.md` |


### PR DESCRIPTION
## Was

Neuer Workflow `release-please-automerge.yml`, der release-please **Release-PRs automatisch merged** — für **wordpress**, **wireguard** und **wg-easy**.

Gemerged wird automatisch, wenn **alle** Bedingungen erfüllt sind:

- Bump ist **Patch oder Minor** (Breaking-**Major** `feat!` bleibt manuell)
- finale Version (kein `-alpha/-beta/-rc` Prerelease)
- der `artifacthub.io/changes`-Sync-Commit ist schon auf der PR
- **alle** PR-Checks (`PR Chart Validate`, `Chart Install Test`) sind grün

## Warum so

- **Merge per PAT (`SLYBASE_GHCR_TOKEN`), nicht `GITHUB_TOKEN`** — nur so triggert der Merge-Push auf `main` erneut `release-please.yml` → Tag → `oci-release.yaml` (Cosign-Signierung). Mit `GITHUB_TOKEN` bliebe die Tag-/OCI-Kette tot. Verhält sich exakt wie ein manueller Merge.
- **Kein „Approve":** `main` hat keine Branch-Protection mit Pflicht-Review, und Actions darf nicht approven. Der Merge ist das Release.
- **Sync-Race vermieden:** das idempotente `sync-artifacthub-changes.py` wird gegen die PR-Dateien ausgeführt — kein Diff = synchron = mergebar; sonst überspringen und auf den nächsten `synchronize`-Lauf warten.
- **Merge an validierten Commit gepinnt** (`--match-head-commit`): bewegt sich der Head zwischenzeitlich, wird abgebrochen und neu evaluiert.
- **Security:** `pull_request_target` agiert nur auf same-repo release-please-Branches (keine Forks) und führt nur Repo-eigene Skripte gegen PR-*Daten* aus — niemals PR-Code.

## Validierung (lokal)

- `actionlint` inkl. shellcheck der Bash-Blöcke: **PASS**
- Versions-Klassifikation: Patch/Minor → merge; Major (auch `9.9.9→10.0.0`) & Prerelease → skip
- Sync-Idempotenz auf allen 3 Charts bestätigt (kein Diff)

## Hinweis

`pull_request_target` lädt die Workflow-Datei von der Default-Branch — **aktiv erst nach Merge auf `main`**, dann ab der nächsten Release-PR. Für manuelles Auslösen gibt es `workflow_dispatch` mit `pr`-Input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
