### PR TITLE
feat!: run wireguard without privileged by default, add loadKernelModule

### DIFF
--- a/charts/wireguard/readme.md
+++ b/charts/wireguard/readme.md
@@ -48,21 +48,22 @@ kubectl create namespace wireguard && kubectl label namespace wireguard pod-secu
 
 ## Security
 
-The container runs as `root` (`runAsUser: 0`) with `privileged: true` and the `NET_ADMIN` capability. This is required by the underlying [linuxserver/wireguard](https://github.com/linuxserver/docker-wireguard) image:
+By default the container runs as `root` (`runAsUser: 0`) with the `NET_ADMIN` capability but **without** `privileged: true`. The broad privileged flag (which grants *all* capabilities plus device access and `SYS_ADMIN`) is intentionally dropped: the underlying [linuxserver/wireguard](https://github.com/linuxserver/docker-wireguard) image runs an s6-overlay init that only needs the container's **default** capability set (`SETUID`/`SETGID`/`CHOWN`/…) to start, plus `NET_ADMIN` for `wg-quick` (interface creation and, in server mode, routing/NAT). The chart keeps those defaults and adds only `NET_ADMIN` — verified working for server mode.
 
-- its s6-overlay init system needs root capabilities beyond `NET_ADMIN` (e.g. `CAP_SETUID`/`CAP_SETGID`) to start up — running with a restricted capability set (`drop: [ALL]`, `add: [NET_ADMIN]`) without `privileged: true` causes the container to crash with `s6-overlay-suexec: fatal: unable to setgid to root`
-- `wg-quick` (interface creation, and in server mode routing/NAT) needs `NET_ADMIN`, and on some host kernels `SYS_MODULE` to load the WireGuard kernel module
+Because of the s6-overlay init:
+- `allowPrivilegeEscalation: true` **is** required (the s6 `suexec` step needs it); without it the container crashes with `s6-overlay-suexec: fatal: unable to setgid to root`
+- the container's default capability set is kept (the chart does **not** `drop: [ALL]`), so `pod-security.kubernetes.io/enforce: privileged` is still required on the namespace (see Prerequisites) and the chart cannot meet the `restricted`/`baseline` Pod Security Standard
 
-As a result:
-- `pod-security.kubernetes.io/enforce: privileged` is required on the namespace (see Prerequisites)
-- the chart **cannot** meet the `restricted` or `baseline` Pod Security Standard
-
-What the chart hardens by default regardless:
+What the chart hardens by default:
+- **`privileged: false`** — the broad privileged flag is no longer set (this is the v2.0.0 default; see [Notable changes](#notable-changes))
 - `seccompProfile: RuntimeDefault` for the pod and the container
-- `capabilities: {drop: [ALL], add: [NET_ADMIN]}` (`SYS_MODULE` is commented out — only needed if the host kernel doesn't already have the WireGuard module loaded)
 - `serviceAccount.automount: false` — the chart never talks to the Kubernetes API
 
-`allowPrivilegeEscalation: false` is intentionally **not** set: Kubernetes rejects the combination `privileged: true` + `allowPrivilegeEscalation: false` (`cannot set allowPrivilegeEscalation to false and privileged to true`), and `privileged: true` is a hard functional requirement as described above.
+**Kernel module:** most modern kernels (and Talos) already provide the WireGuard module, so the chart does **not** add `SYS_MODULE` by default. If `wg0` fails to come up because the module is missing, set `wireguard.loadKernelModule: true` to add the `SYS_MODULE` capability.
+
+> **Full-tunnel client note:** a CLIENT with `AllowedIPs: 0.0.0.0/0` uses fwmark policy routing, which may require allow-listing the `net.ipv4.conf.all.src_valid_mark` sysctl on your nodes (or running `privileged`). Override `securityContext` if your setup needs it.
+
+To override these defaults completely, set `securityContext` in your values (see the commented example in `values.yaml`).
 
 ## Server mode
 Sample see in TL;DR.
@@ -179,3 +180,10 @@ Set `podDisruptionBudget.minAvailable` or `podDisruptionBudget.maxUnavailable` t
 ### Topology Spread Constraints and Priority Class
 
 `topologySpreadConstraints` and `priorityClassName` are passed through to the pod spec for advanced scheduling control.
+
+## Notable changes
+
+### To 2.0.0
+- ⚠️ **`privileged: true` is no longer the default.** The container now runs with the s6-overlay default capability set plus `NET_ADMIN` and `privileged: false` (verified for server mode). The namespace still needs `pod-security.kubernetes.io/enforce: privileged` because the default capabilities are kept (no `drop: [ALL]`). To restore the old behaviour, set `securityContext` explicitly. See [Security](#security).
+- ⚠️ **`updateStrategy.type` now defaults to `Recreate`** (was `RollingUpdate`). Server mode uses a single ReadWriteOnce PVC; `RollingUpdate` would deadlock the new pod waiting for the old one to release the volume.
+- Added **`wireguard.loadKernelModule`** (default `false`): adds the `SYS_MODULE` capability so the container can load the WireGuard kernel module on hosts where it is not already present.

--- a/charts/wireguard/templates/deployment.yaml
+++ b/charts/wireguard/templates/deployment.yaml
@@ -72,38 +72,29 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-          {{ if not (empty .Values.securityContext) }}
-            {{ toYaml .Values.securityContext | nindent 12 }}
-          {{ else if .Values.wireguard.server.enabled }}
-            # Server mode needs more privileges for interface creation and routing
+          {{- if not (empty .Values.securityContext) }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- else }}
+            # privileged:true is intentionally NOT used: it grants ALL capabilities plus device
+            # access and SYS_ADMIN. The linuxserver/wireguard image runs s6-overlay, which needs
+            # the container's *default* capability set (SETUID/SETGID/CHOWN/...) to initialise, so
+            # we keep those defaults and only ADD what WireGuard needs. This drops the broad
+            # privileged flag while remaining functional. SYS_MODULE is added only when the host
+            # has not pre-loaded the wireguard kernel module (set wireguard.loadKernelModule=true).
             capabilities:
               add:
                 - NET_ADMIN
-                # - SYS_MODULE
-              drop:
-                - ALL
-            privileged: true
-            allowPrivilegeEscalation: true
+                {{- if .Values.wireguard.loadKernelModule }}
+                - SYS_MODULE
+                {{- end }}
+            privileged: false
+            allowPrivilegeEscalation: true   # required by the s6-overlay suexec init
             readOnlyRootFilesystem: false
             runAsNonRoot: false
             runAsUser: 0
             seccompProfile:
               type: RuntimeDefault
-          {{ else }}
-            # Client mode - more secure with minimal capabilities
-            capabilities:
-              add:
-                - NET_ADMIN
-              drop:
-                - ALL
-            privileged: true
-            allowPrivilegeEscalation: true
-            readOnlyRootFilesystem: false
-            runAsNonRoot: false
-            runAsUser: 0
-            seccompProfile:
-              type: RuntimeDefault
-          {{ end }}
+          {{- end }}
           image: {{ include "slycharts.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:

--- a/charts/wireguard/tests/deployment_test.yaml
+++ b/charts/wireguard/tests/deployment_test.yaml
@@ -33,6 +33,9 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.privileged
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: true
       - equal:
           path: spec.template.spec.containers[0].securityContext.runAsUser
@@ -40,6 +43,9 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.add
           content: NET_ADMIN
+      - notContains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: SYS_MODULE
 
   - it: defaults the container securityContext for server mode
     template: deployment.yaml
@@ -50,10 +56,23 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].securityContext.privileged
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
           value: true
       - contains:
           path: spec.template.spec.containers[0].securityContext.capabilities.add
           content: NET_ADMIN
+
+  - it: adds SYS_MODULE only when loadKernelModule is enabled
+    template: deployment.yaml
+    set:
+      wireguard:
+        loadKernelModule: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: SYS_MODULE
 
   - it: allows overriding the container securityContext
     template: deployment.yaml

--- a/charts/wireguard/values.schema.json
+++ b/charts/wireguard/values.schema.json
@@ -249,6 +249,11 @@
           "title": "Process Group ID",
           "description": "Group ID for the main process (linuxserver default: 1000). Optional."
         },
+        "loadKernelModule": {
+          "type": "boolean",
+          "title": "Load Kernel Module",
+          "description": "Add the SYS_MODULE capability so the container can load the wireguard kernel module. Leave false where the module is already built in/loaded (modern kernels, Talos); set true only if wg0 fails to come up because the module is missing."
+        },
         "server": {
           "type": "object",
           "title": "Wireguard Server Settings",

--- a/charts/wireguard/values.yaml
+++ b/charts/wireguard/values.yaml
@@ -80,8 +80,8 @@ replicaCount: 1
 ## ```
 ## @descriptionEnd
 updateStrategy:
-  ## @param updateStrategy.type string Deployment strategy type (RollingUpdate or Recreate)
-  type: RollingUpdate
+  ## @param updateStrategy.type string Deployment strategy type (RollingUpdate or Recreate). Defaults to Recreate: server mode uses a single ReadWriteOnce PVC, and RollingUpdate would deadlock the new pod waiting for the old one to release the volume.
+  type: Recreate
 
 ## @section Init and Sidecar Containers
 ## @descriptionStart
@@ -125,6 +125,9 @@ wireguard:
   PUID: "1000"
   ## @param wireguard.PGID string Group ID for the container process (default: 1000)
   PGID: "1000"
+
+  ## @param wireguard.loadKernelModule bool Add the SYS_MODULE capability so the container can load the wireguard kernel module. Leave false on hosts where the module is already built in/loaded (e.g. modern kernels, Talos); set true only if wg0 fails to come up because the module is missing.
+  loadKernelModule: false
 
   ## @param wireguard.extraEnvVars list Extra environment variables for the wireguard container
   ## E.g.
@@ -239,9 +242,16 @@ podLabels: {}
 ##   capabilities:
 ##     add:
 ##       - NET_ADMIN
-##       - SYS_MODULE
-##   privileged: true # required by the linuxserver/wireguard s6-overlay init, see readme.md "Security"
+##       # - SYS_MODULE   # only if the host hasn't pre-loaded the wireguard module
+##   privileged: false
+##   allowPrivilegeEscalation: true   # the linuxserver s6-overlay suexec init needs this
 ## ```
+## By default the chart drops the broad `privileged: true` and runs with the container's default
+## capability set plus NET_ADMIN (verified working for server mode). The s6-overlay init needs the
+## default caps, so we do not `drop: ALL`. Setting `securityContext` here fully overrides the
+## default. Note: a full-tunnel CLIENT (AllowedIPs 0.0.0.0/0) uses fwmark policy routing which may
+## require allow-listing the `net.ipv4.conf.all.src_valid_mark` sysctl on your nodes (or privileged).
+## See readme.md "Security".
 ## @descriptionEnd
 
 ## @param podSecurityContext object Security context for the pod


### PR DESCRIPTION
## What

Drops the broad `privileged: true` from the default wireguard container securityContext and runs with the linuxserver/wireguard s6-overlay default capability set plus `NET_ADMIN` (`privileged: false`, `allowPrivilegeEscalation: true`). Adds `wireguard.loadKernelModule` (default `false`) to opt into `SYS_MODULE`, and defaults `updateStrategy.type` to `Recreate` for the single ReadWriteOnce PVC.

## Breaking changes ⚠️

- `privileged: true` is no longer the default — set `securityContext` explicitly to restore it.
- `updateStrategy.type` defaults to `Recreate` (was `RollingUpdate`); `RollingUpdate` deadlocks the new pod waiting for the old one to release the RWO volume.

The namespace still needs `pod-security.kubernetes.io/enforce: privileged` (the container's default caps are kept, no `drop: ALL`).

## Testing

- `helm lint` + `helm template` (server & client modes, `loadKernelModule` on/off) ✓
- Cluster verify (`samples/verify/verify.sh`) on Talos: **ALL CHECKS PASSED** — s6 init boots, `wg0` comes up, `wg show` reports listening port 51820 + 2 peers, NodePort exposed.

> Note: full-tunnel CLIENT mode (`AllowedIPs 0.0.0.0/0`) may still need the `net.ipv4.conf.all.src_valid_mark` sysctl allow-listed — documented in the README Security section.

## Docs

README Security section rewritten to reflect the non-privileged default; added "Notable changes → To 2.0.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
