### PR TITLE
feat: add wg-easy native Prometheus metrics toggle and Grafana dashboard

### DIFF
--- a/charts/wg-easy/dashboards/wg-easy.json
+++ b/charts/wg-easy/dashboards/wg-easy.json
@@ -1,0 +1,832 @@
+{
+  "__elements": {},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Dashboard for wg-easy exporter\r\nhttps://github.com/wg-easy/wg-easy",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "wireguard_configured_peers{job=\"$job\", instance=\"$node\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Configured Peers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "wireguard_enabled_peers{job=\"$job\", instance=\"$node\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Enabled Peers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "wireguard_connected_peers{job=\"$job\", instance=\"$node\"}",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Connected Peers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "decimals": 0,
+          "fieldMinMax": false,
+          "mappings": [],
+          "min": 1,
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Last *"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Online"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Field"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Client"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "wireguard_latest_handshake_seconds{job=\"$job\", instance=\"$node\"}",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}}",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Online Clients",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "equal",
+                  "options": {
+                    "value": ""
+                  }
+                },
+                "fieldName": "Last *"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #RX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Upload"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #TX"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Download"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "name"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Client"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "id": 12,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Tx"
+          }
+        ]
+      },
+      "pluginVersion": "11.1.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(name) (wireguard_received_bytes{job=\"$job\", instance=\"$node\"})",
+          "format": "table",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": true,
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "RX",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "sum by(name) (wireguard_sent_bytes{job=\"$job\", instance=\"$node\"})",
+          "format": "table",
+          "fullMetaSearch": false,
+          "hide": false,
+          "includeNullMetadata": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{name}}",
+          "range": false,
+          "refId": "TX",
+          "useBackend": false
+        }
+      ],
+      "title": "Panel Title",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sent 10.70.0.2"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsZero",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "gte",
+                "reducer": "allIsNull",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": true,
+                  "tooltip": true,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "min"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "irate(wireguard_received_bytes{job=\"$job\", instance=\"$node\"}[5m])",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "instant": false,
+          "intervalFactor": 1,
+          "legendFormat": "received {{name}}",
+          "refId": "A",
+          "useBackend": false
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "irate(wireguard_sent_bytes{job=\"$job\", instance=\"$node\"}[5m])",
+          "format": "time_series",
+          "fullMetaSearch": false,
+          "includeNullMetadata": true,
+          "intervalFactor": 1,
+          "legendFormat": "sent {{name}}",
+          "range": true,
+          "refId": "B",
+          "useBackend": false
+        }
+      ],
+      "title": "Throughput",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "prometheus",
+    "network",
+    "Wireguard",
+    "wg-easy"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "label": "Data source",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "refresh": 1,
+        "regex": "",
+        "options": [],
+        "skipUrlSync": false
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(wireguard_configured_peers,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(wireguard_configured_peers,job)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(wireguard_configured_peers{job=\"$job\"},instance)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Node",
+        "multi": false,
+        "name": "node",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(wireguard_configured_peers{job=\"$job\"},instance)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "Europe/Moscow",
+  "title": "WireGuard wg-easy",
+  "uid": "wg-easy-metrics",
+  "version": 15,
+  "weekStart": "monday",
+  "gnetId": 21733
+}

--- a/charts/wg-easy/readme.md
+++ b/charts/wg-easy/readme.md
@@ -50,7 +50,7 @@ kubectl create namespace wg-easy && kubectl label namespace wg-easy pod-security
 
 ## Security
 
-By default the container runs `privileged: true` with the `NET_ADMIN` and `SYS_MODULE` capabilities. This is required by the [wg-easy](https://github.com/wg-easy/wg-easy) image to create the `wg0` interface and, if not already present on the host, to load the WireGuard kernel module.
+By default the container runs `privileged: true` with the `NET_ADMIN` capability. The privileged flag is the default because wg-easy must set `net.ipv4.*` sysctls itself (`ip_forward`, `conf.all.src_valid_mark`), and those "unsafe" sysctls are not allow-listed by Kubernetes by default.
 
 As a result:
 - `pod-security.kubernetes.io/enforce: privileged` is required on the namespace (see Prerequisites)
@@ -59,8 +59,11 @@ As a result:
 What the chart hardens by default regardless:
 - `seccompProfile: RuntimeDefault` for the pod and the container
 - `serviceAccount.automount: false` — the chart never talks to the Kubernetes API
+- `SYS_MODULE` is **not** added by default (most modern kernels and Talos already provide the WireGuard module). Set `loadKernelModule: true` only if `wg0` fails because the module is missing.
 
-If the WireGuard kernel module is already loaded on every host node, you can try running without `privileged: true` using `capabilities: {add: [NET_ADMIN, SYS_MODULE], drop: [ALL]}` instead - see the commented example in `values.yaml`. This is untested and not the default.
+`securityContext` defaults to `{}`, which renders the chart default shown above (`NET_ADMIN` + `privileged: true`). Setting `securityContext` overrides it completely.
+
+**To harden (drop `privileged`)** on clusters where you control the nodes, allow-list the sysctls on every node that can run the pod — e.g. Talos `machine.sysctls` (`net.ipv4.ip_forward`, `net.ipv4.conf.all.src_valid_mark`) or kubelet `--allowed-unsafe-sysctls` — set them on the pod via `podSecurityContext.sysctls`, and override `securityContext` with `capabilities.add: [NET_ADMIN]` + `privileged: false`. See the worked example in `values.yaml`.
 
 ## Initialization Mode and Metrics
 
@@ -88,7 +91,9 @@ type: Opaque
 ```
 > **Note:** The initial username and password is not checked for complexity. Make sure to set a long enough username and password. Otherwise, the user won't be able to log in.
 
-> **Note:** You have to enable the Prometheus metrics in the Web UI manually and copy this token as plain text (not Base64) in the UI. This can't be done automatically. The secret here is used for the serviceMonitor, for Prometheus autodetection.
+> **Note:** Set `metrics.enabled: true` to have the chart export `ENABLE_PROMETHEUS_METRICS=true` so wg-easy serves `/metrics/prometheus` automatically. On some image versions the env var is ignored and the toggle must still be set once in **Admin Panel > General** (see [wg-easy#1373](https://github.com/wg-easy/wg-easy/issues/1373)). The metrics token is copied as plain text (not Base64) in the UI; the secret here is used by the ServiceMonitor for Prometheus autodetection.
+
+> **Grafana dashboard:** set `metrics.grafanaDashboard.enabled: true` to deploy a ConfigMap with the official wg-easy dashboard (Grafana.com ID 21733), labelled `grafana_dashboard: "1"` so the Grafana sidecar imports it automatically.
 
 ```yaml
 # ./samples/advanced.values.yaml

--- a/charts/wg-easy/templates/grafana-dashboard.yaml
+++ b/charts/wg-easy/templates/grafana-dashboard.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.grafanaDashboard.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wg-easy.fullname" . }}-grafana-dashboard
+  namespace: {{ default .Release.Namespace .Values.metrics.grafanaDashboard.namespace }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+    {{- with .Values.metrics.grafanaDashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+data:
+  ## Official wg-easy WireGuard dashboard (Grafana.com ID 21733), adapted for sidecar auto-import.
+  wg-easy.json: |-
+    {{- .Files.Get "dashboards/wg-easy.json" | nindent 4 }}
+{{- end -}}

--- a/charts/wg-easy/templates/statefulset.yaml
+++ b/charts/wg-easy/templates/statefulset.yaml
@@ -63,10 +63,20 @@ spec:
           {{- if .Values.securityContext }}
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- else }}
+            # wg-easy needs NET_ADMIN to manage the wg0 interface and routing. On a stock cluster
+            # it also needs the broad privileged flag so it can set the required net.ipv4.* sysctls
+            # (ip_forward, conf.all.src_valid_mark) itself, because those "unsafe" sysctls are not
+            # allow-listed by Kubernetes by default. To HARDEN (drop privileged): allow-list those
+            # sysctls on your nodes (e.g. Talos machine.sysctls / kubelet --allowed-unsafe-sysctls)
+            # and override `securityContext` with `capabilities.add: [NET_ADMIN]` + `privileged: false`.
+            # SYS_MODULE is added only when the host has not pre-loaded the wireguard module
+            # (set loadKernelModule=true).
             capabilities:
               add:
                 - NET_ADMIN
+                {{- if .Values.loadKernelModule }}
                 - SYS_MODULE
+                {{- end }}
             privileged: true
             seccompProfile:
               type: RuntimeDefault
@@ -82,6 +92,13 @@ spec:
               value: {{ .Values.config.insecure | quote }}
             - name: DISABLE_IPV6
               value: {{ .Values.config.disable_ipv6 | quote }}
+            {{- if .Values.metrics.enabled }}
+            # Enable wg-easy's native Prometheus endpoint at /metrics/prometheus.
+            # NOTE: depending on the image version this toggle may also need to be set once in
+            # Admin Panel > General (https://github.com/wg-easy/wg-easy/issues/1373).
+            - name: ENABLE_PROMETHEUS_METRICS
+              value: "true"
+            {{- end }}
             {{- if .Values.config.init.enabled }}
             - name: INIT_ENABLED
               value: "true"

--- a/charts/wg-easy/values.schema.json
+++ b/charts/wg-easy/values.schema.json
@@ -342,6 +342,41 @@
       },
       "required": []
     },
+    "metrics": {
+      "title": "Metrics",
+      "type": "object",
+      "additionalProperties": false,
+      "description": "wg-easy native Prometheus metrics endpoint and Grafana dashboard.",
+      "properties": {
+        "enabled": {
+          "title": "Enable metrics endpoint",
+          "type": "boolean",
+          "description": "Sets ENABLE_PROMETHEUS_METRICS=true so wg-easy exposes /metrics/prometheus. On some image versions this must also be toggled once in Admin Panel > General (see wg-easy issue #1373)."
+        },
+        "grafanaDashboard": {
+          "title": "Grafana dashboard",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "title": "Deploy dashboard ConfigMap",
+              "type": "boolean",
+              "description": "Deploy a ConfigMap with the official wg-easy Grafana dashboard (Grafana.com ID 21733)."
+            },
+            "namespace": {
+              "title": "Dashboard namespace",
+              "type": "string",
+              "description": "Namespace for the dashboard ConfigMap (defaults to the release namespace)."
+            },
+            "labels": {
+              "title": "Dashboard labels",
+              "type": "object",
+              "description": "Extra labels for the dashboard ConfigMap (grafana_dashboard: \"1\" is always added)."
+            }
+          }
+        }
+      }
+    },
     "extraEnvVars": {
       "title": "Extra environment variables",
       "type": "array",
@@ -493,6 +528,11 @@
           "boolean"
         ]
       }
+    },
+    "loadKernelModule": {
+      "title": "Load Kernel Module",
+      "type": "boolean",
+      "description": "Add the SYS_MODULE capability so the container can load the wireguard kernel module. Leave false where the module is already built in/loaded (modern kernels, Talos); set true only if wg0 fails to come up because the module is missing."
     },
     "podSecurityContext": {
       "title": "Pod security context",

--- a/charts/wg-easy/values.yaml
+++ b/charts/wg-easy/values.yaml
@@ -156,6 +156,28 @@ config:
     ## @param config.init.ipv6_cidr string IPv6 CIDR for WireGuard network
     ipv6_cidr: "2001:0DB8::/32"
 
+## @section Metrics
+## @descriptionStart
+## wg-easy ships a native Prometheus endpoint at /metrics/prometheus. Setting metrics.enabled wires
+## ENABLE_PROMETHEUS_METRICS=true so it is turned on automatically instead of via the Admin Panel.
+## Pair with serviceMonitor.create=true to scrape it, and metrics.grafanaDashboard.enabled=true for
+## the official dashboard (Grafana.com ID 21733).
+## NOTE: on some wg-easy image versions the env var is ignored and the toggle must still be set once
+## in Admin Panel > General — see https://github.com/wg-easy/wg-easy/issues/1373.
+## The endpoint is unauthenticated unless you set a Bearer password in the wg-easy UI; restrict it
+## with networkPolicy in the meantime.
+## @descriptionEnd
+metrics:
+  ## @param metrics.enabled bool Enable wg-easy's native Prometheus metrics endpoint (sets ENABLE_PROMETHEUS_METRICS=true)
+  enabled: false
+  grafanaDashboard:
+    ## @param metrics.grafanaDashboard.enabled bool Deploy a ConfigMap with the official wg-easy Grafana dashboard (Grafana.com ID 21733)
+    enabled: false
+    ## @param metrics.grafanaDashboard.namespace string Namespace for the dashboard ConfigMap (defaults to the release namespace)
+    namespace: ""
+    ## @param metrics.grafanaDashboard.labels object Extra labels for the dashboard ConfigMap (grafana_dashboard: "1" is always added so the Grafana sidecar imports it)
+    labels: {}
+
 ## @section Extra Environment Variables
 ## @descriptionStart
 ## Additional environment variables for the WG-Easy container.
@@ -222,46 +244,45 @@ podLabels: {}
 ## @section Security Context
 ## @descriptionStart
 ## Security context configuration for pod and container.
-## Note: WG-Easy typically requires privileged mode for WireGuard kernel module.
-## E.g.
-## ```yaml
-## podSecurityContext:
-##   fsGroup: 1000
+## Leaving `securityContext` empty uses the chart default: NET_ADMIN + `privileged: true`. The
+## privileged flag is the default because wg-easy must set net.ipv4.* sysctls itself, and those
+## "unsafe" sysctls are not allow-listed by Kubernetes by default.
 ##
-## securityContext:
-##   privileged: true
-##   capabilities:
-##     add:
-##       - NET_ADMIN
-##       - SYS_MODULE
-## ```
-##
-## Alternative without `privileged: true` (only works if the WireGuard kernel
-## module is already loaded on the host node - untested, see readme.md "Security"):
-## ```yaml
-## securityContext:
-##   privileged: false
-##   capabilities:
-##     add:
-##       - NET_ADMIN
-##       - SYS_MODULE
-##     drop:
-##       - ALL
-##   seccompProfile:
-##     type: RuntimeDefault
-## ```
+## To HARDEN (drop privileged) on clusters where you control the nodes:
+##   1. Allow-list the sysctls on every node that can run the pod, e.g. on Talos:
+##      ```yaml
+##      machine:
+##        sysctls:
+##          net.ipv4.ip_forward: "1"
+##          net.ipv4.conf.all.src_valid_mark: "1"
+##      ```
+##      (or kubelet `--allowed-unsafe-sysctls=net.ipv4.ip_forward,net.ipv4.conf.all.src_valid_mark`)
+##   2. Set them on the pod and drop privileged:
+##      ```yaml
+##      podSecurityContext:
+##        sysctls:
+##          - { name: net.ipv4.ip_forward, value: "1" }
+##          - { name: net.ipv4.conf.all.src_valid_mark, value: "1" }
+##      securityContext:
+##        capabilities:
+##          add: [NET_ADMIN]
+##        privileged: false
+##        allowPrivilegeEscalation: false
+##        seccompProfile:
+##          type: RuntimeDefault
+##      ```
 ## @descriptionEnd
+
+## @param loadKernelModule bool Add the SYS_MODULE capability so the container can load the wireguard kernel module. Leave false where the module is already built in/loaded (modern kernels, Talos); set true only if wg0 fails to come up because the module is missing.
+loadKernelModule: false
 
 ## @param podSecurityContext object Security context for the pod
 podSecurityContext:
   seccompProfile:
     type: RuntimeDefault
 
-## @param securityContext object Security context for the container
-securityContext:
-  privileged: true
-  seccompProfile:
-    type: RuntimeDefault
+## @param securityContext object Security context for the container. Empty = chart default (NET_ADMIN + privileged). Set to override completely (see the Security Context section for a hardened, non-privileged example).
+securityContext: {}
 
 ## @section Service configuration
 service:


### PR DESCRIPTION
## What

- `metrics.enabled` exports `ENABLE_PROMETHEUS_METRICS=true` so wg-easy serves `/metrics/prometheus` without the manual Admin Panel toggle (with the [wg-easy#1373](https://github.com/wg-easy/wg-easy/issues/1373) caveat that some image versions still need the UI toggle).
- `metrics.grafanaDashboard.enabled` deploys the official dashboard (Grafana.com ID 21733) as a `grafana_dashboard: "1"` sidecar-imported ConfigMap.
- New `loadKernelModule` flag gates `SYS_MODULE` (default off; the privileged default already covers module loading); `securityContext` now defaults to `{}` and renders the same NET_ADMIN + privileged default (fully overridable).

## Testing

- `helm lint` + `helm template` ✓ — default still renders `privileged: true`; metrics env + dashboard ConfigMap render; custom `securityContext` override drops privileged.
- Cluster verify on Talos fails only at the **known** upstream nftables `wg-quick` issue (documented in the README "Known Issues") — not a regression; both Services render correctly.

No breaking changes — additive features plus an equivalent `securityContext` default rendering.

## Docs

README Security section updated (`SYS_MODULE` now opt-in, hardening example); native metrics toggle + Grafana dashboard documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
