### PR TITLE
feat!: add wordpress backup restore Job and VolumeSnapshot, harden SA token

### DIFF
--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -162,6 +162,17 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 - Backup PVC is annotated `helm.sh/resource-policy: keep` — it survives `helm uninstall`.
 - See `samples/backup.values.yaml` and `samples/backup-s3.secrets.yaml`
 
+### Backup restore
+- **One-shot restore Job** (`backup.restore.enabled`) replays a backup created by the CronJob: it restores the database dump (and `wp-content` when the backup included files).
+- Runs as a Helm **`pre-upgrade` hook** so it completes against the running database before the new WordPress pods roll.
+- Restores from the **backup PVC** (default) or pulls the backup from **S3** first (`backup.restore.fromS3: true`).
+- Pick a backup with `backup.restore.timestamp` (the `YYYYMMDD-HHMMSS` folder), or leave it empty to restore the newest. Set `backup.restore.enabled: false` again after a successful restore so it does not re-run on the next upgrade.
+
+### VolumeSnapshot
+- **Declarative CSI VolumeSnapshot** (`backup.volumeSnapshot.enabled`) of the WordPress data PVC — requires the external-snapshotter CRDs and a `VolumeSnapshotClass` on the cluster.
+- A new timestamped VolumeSnapshot is rendered on each `helm upgrade`; combine with your storage backend's retention to prune old snapshots.
+- `backup.volumeSnapshot.className` selects a specific class (empty = cluster default).
+
 ### commonLabels / commonAnnotations
 - **Apply labels or annotations to every resource** created by the chart via `commonLabels` and `commonAnnotations`.
 - Resource-specific annotations always win over `commonAnnotations` (merge: specific overrides common).
@@ -185,8 +196,9 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 
 ## Security by default
 
-- **Pod Security Context**: Configured by default for secure permissions.
+- **Pod Security Context**: Configured by default for secure permissions. Runs as `runAsUser`/`runAsGroup`/`fsGroup` `33` (www-data).
 - **Container Security Context**: RunAsNonRoot and additional security measures enabled.
+- **ServiceAccount token**: `serviceAccount.automount` defaults to `false` — the WordPress pod needs no Kubernetes API access. The chart automatically forces the token on only when the Application Password feature must write a Secret via the ServiceAccount.
 
 
 ## WordPress configuration
@@ -627,6 +639,38 @@ kubectl logs -l job-name=manual-backup-1 -c backup -f
 
 > **Note:** `backup.includeFiles: true` tars `wp-content` in addition to the database dump. Only enable this when the WordPress PVC supports concurrent readers (RWX storage or VolumeSnapshot). With standard RWO storage (OpenEBS ZFS, Longhorn RWO, etc.) leave it `false` (default) to avoid mount conflicts.
 
+### Restore a backup
+Replay a backup created by the CronJob. The restore runs as a Helm `pre-upgrade` hook Job against the running database, before the WordPress pods roll.
+
+```yaml
+# snippet to merge into your values
+backup:
+  enabled: true
+  restore:
+    enabled: true                 # set back to false after a successful restore
+    timestamp: "20260625-084235"  # YYYYMMDD-HHMMSS folder; empty = newest available
+    fromS3: false                 # true = pull the backup from S3 (rclone) first
+```
+
+```bash
+helm upgrade <release> ./charts/wordpress -f values.yaml
+kubectl logs job/<release>-wordpress-restore   # => "restore complete (<timestamp>)"
+# then set backup.restore.enabled=false and upgrade once more so it does not re-run
+```
+
+### VolumeSnapshot
+Create a CSI snapshot of the WordPress data PVC. Requires the external-snapshotter CRDs and a `VolumeSnapshotClass` on the cluster. A new timestamped snapshot is created on every `helm upgrade`.
+
+```yaml
+# snippet to merge into your values
+backup:
+  volumeSnapshot:
+    enabled: true
+    className: ""   # empty = cluster default VolumeSnapshotClass
+```
+
+> **Note:** for `controllerType: statefulset` the data PVC is per-replica (`<fullname>-<fullname>-0`); set `storage.existingClaim` to the PVC you want snapshotted.
+
 ### commonLabels and commonAnnotations
 Apply uniform labels or annotations to every Kubernetes resource the chart creates. See `samples/commonLabels.values.yaml`.
 
@@ -753,6 +797,12 @@ Without `slug`, URL plugins/themes use `basename` of the URL as a best-effort gu
 - **Network activation** (`networkActivate` / `networkEnable`)
 
 ## Notable changes
+
+### To 5.0.0
+- ⚠️ **`serviceAccount.automount` now defaults to `false`** (was `true`). The WordPress pod no longer mounts a Kubernetes API token unless it is actually needed — the chart force-enables it automatically when the Application Password feature must write a Secret via the ServiceAccount. If external tooling relied on the mounted token, set `serviceAccount.automount: true` explicitly.
+- ⚠️ **`podSecurityContext.runAsGroup: 33` is now set by default** (matching `runAsUser`/`fsGroup` = www-data). On pre-existing volumes whose files are owned by a different GID, adjust ownership or override `runAsGroup`.
+- Added **Backup restore** (`backup.restore`): one-shot Job (Helm `pre-upgrade` hook) that restores a CronJob backup — database (and `wp-content` when included) — from the backup PVC or from S3 (`fromS3`). Select a backup with `restore.timestamp` or restore the newest.
+- Added **VolumeSnapshot** (`backup.volumeSnapshot`): declarative CSI VolumeSnapshot of the WordPress data PVC, created per `helm upgrade`.
 
 ### To 4.6.0
 - Added **StatefulSet controller** (`controllerType: statefulset`): each replica runs on its own **ReadWriteOnce** volume via `volumeClaimTemplates`, removing the Longhorn RWX share-manager single point of failure that could take down all replicas at once during a rebuild/share-manager recreation. Adds a headless Service and `statefulset.*` tunables (`podManagementPolicy`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy`). Default remains `controllerType: deployment` (backwards-compatible).

--- a/charts/wordpress/templates/restore-job.yaml
+++ b/charts/wordpress/templates/restore-job.yaml
@@ -1,0 +1,188 @@
+{{- if .Values.backup.restore.enabled }}
+{{- $fullName := include "wordpress.fullname" . -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $fullName }}-restore
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: restore
+  annotations:
+    # Run before the upgrade rolls the WordPress pods, against the already-running database.
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backoffLimit: {{ .Values.backup.restore.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "wordpress.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: restore
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "wordpress.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.backup.restore.fromS3 }}
+      initContainers:
+        - name: s3-pull
+          image: {{ .Values.backup.s3.image.repository }}:{{ .Values.backup.s3.image.tag }}
+          imagePullPolicy: {{ .Values.backup.s3.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: RCLONE_CONFIG
+              value: /config/rclone.conf
+            - name: S3_REMOTE
+              value: {{ .Values.backup.s3.remote | quote }}
+            - name: S3_BUCKET
+              value: {{ .Values.backup.s3.bucket | quote }}
+            - name: S3_PATH
+              value: {{ .Values.backup.s3.path | quote }}
+            - name: TS
+              value: {{ .Values.backup.restore.timestamp | quote }}
+            {{- if and .Values.backup.s3.ca.existingSecret .Values.backup.s3.ca.existingSecretKey }}
+            - name: RCLONE_CA_CERT
+              value: /etc/rclone/custom-ca/ca.crt
+            {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              if [ -z "${TS}" ]; then
+                echo "==> resolving newest backup in s3"
+                TS=$(rclone lsf "${S3_REMOTE}:${S3_BUCKET}/${S3_PATH}/" --dirs-only | sed 's#/##' | grep -E '^[0-9]{8}-[0-9]{6}$' | sort | tail -1)
+              fi
+              [ -n "${TS}" ] || { echo "no backup found in s3" >&2; exit 1; }
+              echo "==> pulling ${TS} from s3"
+              mkdir -p "/staging/${TS}"
+              rclone copy "${S3_REMOTE}:${S3_BUCKET}/${S3_PATH}/${TS}/" "/staging/${TS}" --transfers=2
+              echo "${TS}" > /staging/.restore_ts
+          volumeMounts:
+            - name: staging
+              mountPath: /staging
+            - name: rclone-config
+              mountPath: /config
+              readOnly: true
+            {{- if and .Values.backup.s3.ca.existingSecret .Values.backup.s3.ca.existingSecretKey }}
+            - name: rclone-custom-ca
+              mountPath: /etc/rclone/custom-ca
+              readOnly: true
+            {{- end }}
+      {{- end }}
+      containers:
+        - name: restore
+          image: {{ include "slycharts.image" (dict "image" .Values.backup.image) }}
+          imagePullPolicy: {{ .Values.backup.image.pullPolicy }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DB_HOST
+              value: {{ ternary (include "wordpress.mariadb.fullname" .) .Values.externalDatabase.host .Values.mariadb.enabled | quote }}
+            - name: DB_PORT
+              value: {{ ternary (.Values.mariadb.service.port | toString) (.Values.externalDatabase.port | toString) .Values.mariadb.enabled | quote }}
+            - name: DB_NAME
+              value: {{ ternary .Values.mariadb.auth.database .Values.externalDatabase.database .Values.mariadb.enabled | quote }}
+            - name: DB_USER
+              value: {{ ternary .Values.mariadb.auth.username .Values.externalDatabase.username .Values.mariadb.enabled | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  {{- if .Values.mariadb.enabled }}
+                  name: {{ .Values.mariadb.auth.existingSecret | default (printf "%s-mariadb" .Release.Name) }}
+                  key: {{ .Values.mariadb.auth.secretKeys.userPasswordKey | default "mariadb-password" }}
+                  {{- else if .Values.externalDatabase.existingSecret }}
+                  name: {{ .Values.externalDatabase.existingSecret }}
+                  key: {{ .Values.externalDatabase.secretKeys.userPasswordKey | default "db.password" }}
+                  {{- else }}
+                  name: {{ $fullName }}
+                  key: WORDPRESS_DB_PASSWORD
+                  {{- end }}
+            - name: TS
+              value: {{ .Values.backup.restore.timestamp | quote }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              set -euo pipefail
+              {{- if .Values.backup.restore.fromS3 }}
+              BACKUP_ROOT=/staging
+              TS=$(cat /staging/.restore_ts)
+              {{- else }}
+              BACKUP_ROOT=/backup
+              if [ -z "${TS}" ]; then
+                TS=$(ls -1 "$BACKUP_ROOT" 2>/dev/null | grep -E '^[0-9]{8}-[0-9]{6}$' | sort | tail -1 || true)
+              fi
+              {{- end }}
+              [ -n "${TS}" ] || { echo "no backup folder to restore (set backup.restore.timestamp)" >&2; exit 1; }
+              SRC="${BACKUP_ROOT}/${TS}"
+              echo "==> restoring database from ${SRC}/${DB_NAME}.sql.gz"
+              test -f "${SRC}/${DB_NAME}.sql.gz" || { echo "dump not found: ${SRC}/${DB_NAME}.sql.gz" >&2; exit 1; }
+              gunzip -c "${SRC}/${DB_NAME}.sql.gz" \
+                | mariadb -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME"
+              {{- if .Values.backup.includeFiles }}
+              if [ -f "${SRC}/wp-content.tar.gz" ]; then
+                echo "==> restoring wp-content"
+                tar -xzf "${SRC}/wp-content.tar.gz" -C /var/www/html/wp-content
+              fi
+              {{- end }}
+              echo "==> restore complete (${TS})"
+          volumeMounts:
+            {{- if .Values.backup.restore.fromS3 }}
+            - name: staging
+              mountPath: /staging
+            {{- else }}
+            - name: backup
+              mountPath: /backup
+              readOnly: true
+            {{- end }}
+            {{- if .Values.backup.includeFiles }}
+            - name: wordpress
+              mountPath: /var/www/html
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+          {{- with .Values.backup.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- if .Values.backup.restore.fromS3 }}
+        - name: staging
+          emptyDir: {}
+        - name: rclone-config
+          secret:
+            secretName: {{ required "backup.s3.existingSecret is required when backup.restore.fromS3=true" .Values.backup.s3.existingSecret }}
+        {{- if and .Values.backup.s3.ca.existingSecret .Values.backup.s3.ca.existingSecretKey }}
+        - name: rclone-custom-ca
+          secret:
+            secretName: {{ .Values.backup.s3.ca.existingSecret | quote }}
+            items:
+              - key: {{ .Values.backup.s3.ca.existingSecretKey | quote }}
+                path: ca.crt
+        {{- end }}
+        {{- else }}
+        - name: backup
+          persistentVolumeClaim:
+            claimName: {{ .Values.backup.persistence.existingClaim | default (printf "%s-backup" $fullName) }}
+        {{- end }}
+        {{- if .Values.backup.includeFiles }}
+        - name: wordpress
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.existingClaim | default $fullName }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/wordpress/templates/serviceaccount.yaml
+++ b/charts/wordpress/templates/serviceaccount.yaml
@@ -10,5 +10,13 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- /* The pod only needs API access when the Application Password feature writes a Secret via
+       the SA. Force the token on in that case; otherwise honour serviceAccount.automount
+       (default false) so a compromised WordPress pod cannot reach the Kubernetes API. */}}
+{{- $hasAdminAppPass := not (empty .Values.wordpress.init.applicationPassword) }}
+{{- $hasUserAppPass := false }}
+{{- range .Values.wordpress.users }}
+{{- if .applicationPassword }}{{- $hasUserAppPass = true }}{{- end }}
+{{- end }}
+automountServiceAccountToken: {{ if (or $hasAdminAppPass $hasUserAppPass) }}true{{ else }}{{ .Values.serviceAccount.automount }}{{ end }}
 {{- end }}

--- a/charts/wordpress/templates/volumesnapshot.yaml
+++ b/charts/wordpress/templates/volumesnapshot.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.backup.volumeSnapshot.enabled }}
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  # Timestamped so each `helm upgrade` records a new snapshot; prune via your storage backend.
+  name: {{ include "wordpress.fullname" . }}-{{ now | date "20060102-150405" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wordpress.labels" . | nindent 4 }}
+    app.kubernetes.io/component: snapshot
+    {{- with .Values.backup.volumeSnapshot.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.backup.volumeSnapshot.className }}
+  volumeSnapshotClassName: {{ . }}
+  {{- end }}
+  source:
+    # Deployment mode: single PVC named after the release. For controllerType=statefulset, set
+    # storage.existingClaim to the per-replica PVC (e.g. <fullname>-<fullname>-0).
+    persistentVolumeClaimName: {{ .Values.storage.existingClaim | default (include "wordpress.fullname" .) }}
+{{- end }}

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -2223,6 +2223,48 @@
           "type": "object",
           "additionalProperties": true
         },
+        "restore": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "One-shot restore Job for a backup created by the backup CronJob.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Run a one-shot restore Job (disable again afterwards)."
+            },
+            "timestamp": {
+              "type": "string",
+              "description": "Backup folder to restore (YYYYMMDD-HHMMSS). Empty = newest available."
+            },
+            "fromS3": {
+              "type": "boolean",
+              "description": "Pull the backup from S3 (rclone) before restoring instead of the backup PVC."
+            },
+            "backoffLimit": {
+              "type": "integer",
+              "description": "Retries before the restore Job is marked failed."
+            }
+          }
+        },
+        "volumeSnapshot": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Declarative CSI VolumeSnapshot of the WordPress data PVC.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create a VolumeSnapshot of the WordPress data PVC."
+            },
+            "className": {
+              "type": "string",
+              "description": "VolumeSnapshotClass to use (empty = cluster default)."
+            },
+            "labels": {
+              "type": "object",
+              "description": "Extra labels for the VolumeSnapshot."
+            }
+          }
+        },
         "persistence": {
           "type": "object",
           "additionalProperties": true

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -569,8 +569,8 @@ storage:
 serviceAccount:
   ## @param serviceAccount.create bool Specifies whether a service account should be created
   create: true
-  ## @param serviceAccount.automount bool Automatically mount ServiceAccount API credentials
-  automount: true
+  ## @param serviceAccount.automount bool Automatically mount ServiceAccount API credentials. Default false (the WordPress pod needs no Kubernetes API access); the chart forces it on automatically when the Application Password feature must write a Secret via the SA.
+  automount: false
   ## @param serviceAccount.annotations object Annotations to add to the service account
   annotations: {}
   ## @param serviceAccount.name string Name of the service account (generated if not set and create is true)
@@ -610,6 +610,7 @@ podSecurityContext:
   fsGroup: 33
   fsGroupChangePolicy: "Always"
   runAsUser: 33
+  runAsGroup: 33
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
@@ -1198,7 +1199,7 @@ backup:
       ## @param backup.s3.image.repository string rclone image repository
       repository: rclone/rclone
       ## @param backup.s3.image.tag string rclone image tag
-      tag: "1.74"
+      tag: "1.74@sha256:623378ad0ff3ebd5cebf77720843c0e02edfe46e2d5b5ac6bed54c6371780dfb"
       ## @param backup.s3.image.pullPolicy string Pull policy for rclone image
       pullPolicy: IfNotPresent
     ## @param backup.s3.existingSecret string Secret containing key rclone.conf with the configured remote
@@ -1215,6 +1216,37 @@ backup:
       existingSecret: ""
       ## @param backup.s3.ca.existingSecretKey string Key in the secret that holds the CA certificate (PEM)
       existingSecretKey: ""
+  ## @section Backup restore
+  ## @descriptionStart
+  ## One-shot restore of a previous backup created by the backup CronJob. Workflow:
+  ##   1. set `backup.restore.enabled=true` and `backup.restore.timestamp=<dir>` (the YYYYMMDD-HHMMSS
+  ##      folder name under the backup PVC, or in S3 when `fromS3=true`),
+  ##   2. `helm upgrade` — a Job restores the DB (and wp-content if the backup included files),
+  ##   3. set `backup.restore.enabled=false` again so it does not re-run on the next upgrade.
+  ## The Job runs as a pre-upgrade/pre-install hook so it completes before the WordPress pods roll.
+  ## @descriptionEnd
+  restore:
+    ## @param backup.restore.enabled bool Run a one-shot restore Job (remember to disable again afterwards)
+    enabled: false
+    ## @param backup.restore.timestamp string Backup folder to restore (YYYYMMDD-HHMMSS). Empty = newest available
+    timestamp: ""
+    ## @param backup.restore.fromS3 bool Pull the backup from S3 (rclone) before restoring instead of reading the backup PVC
+    fromS3: false
+    ## @param backup.restore.backoffLimit int Number of retries before marking the restore Job failed
+    backoffLimit: 1
+  ## @section Backup VolumeSnapshot
+  ## @descriptionStart
+  ## Declarative CSI VolumeSnapshot of the WordPress data PVC (needs the external-snapshotter CRDs and
+  ## a VolumeSnapshotClass). Renders a new VolumeSnapshot on each `helm upgrade`; combine with your
+  ## storage backend's retention policy to prune old snapshots.
+  ## @descriptionEnd
+  volumeSnapshot:
+    ## @param backup.volumeSnapshot.enabled bool Create a VolumeSnapshot of the WordPress data PVC
+    enabled: false
+    ## @param backup.volumeSnapshot.className string VolumeSnapshotClass to use (empty = cluster default)
+    className: ""
+    ## @param backup.volumeSnapshot.labels object Extra labels for the VolumeSnapshot
+    labels: {}
 
 ## @section External Database configuration
 ## @descriptionStart
@@ -1501,7 +1533,7 @@ redis:
     ## @param redis.image.repository string Redis image repository
     repository: docker.io/redis
     ## @param redis.image.tag string Redis image tag
-    tag: "8.8.0-trixie"
+    tag: "8.8.0-trixie@sha256:027002f3d4161eb427643e0cc71023b582fb461c6199e699f46db843f0b39fb1"
     ## @param redis.image.pullPolicy string Redis image pull policy
     pullPolicy: IfNotPresent
 
@@ -1611,7 +1643,7 @@ valkey:
     ## @param valkey.image.repository string Valkey image repository
     repository: docker.io/valkey/valkey
     ## @param valkey.image.tag string Valkey image tag
-    tag: "9.1.0-trixie"
+    tag: "9.1.0-trixie@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9"
     ## @param valkey.image.pullPolicy string Valkey image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

- **`backup.restore`** — one-shot Job (Helm `pre-upgrade` hook) that restores a CronJob backup (database, plus `wp-content` when included) from the backup PVC or from S3 (`fromS3`), selectable by `timestamp` (empty = newest).
- **`backup.volumeSnapshot`** — declarative CSI VolumeSnapshot of the WordPress data PVC on each `helm upgrade`.
- Hardening: `serviceAccount.automount` now defaults to `false` (the chart forces it on automatically only when the Application Password feature must write a Secret via the SA); `podSecurityContext.runAsGroup: 33`.
- Refreshed the redis image digest to the current `8.8.0-trixie` build.

## Breaking changes ⚠️

- `serviceAccount.automount` now defaults to `false` — set it `true` if external tooling relied on the mounted API token.
- `podSecurityContext.runAsGroup` is now `33` — on pre-existing volumes owned by a different GID, adjust ownership or override `runAsGroup`.

## Testing

- `helm lint` + `helm template` (restore PVC & S3 modes, volumeSnapshot, SA automount both directions) ✓
- Cluster verify (`samples/verify/verify.sh`): **ALL CHECKS PASSED**.
- **Functional backup → restore → snapshot round-trip** on Talos (OpenEBS ZFS, RWO):
  - Backup CronJob triggered → `mariadb-dump` produced `wp.sql.gz`
  - Restore: changed a DB value (`blogname`) → restore Job (`pre-upgrade` hook) → value reverted to the backed-up state ✓
  - VolumeSnapshot created → `readyToUse=true` ✓

## Docs

README: restore + VolumeSnapshot (features + usage snippets), "Security by default" notes, and "Notable changes → To 5.0.0" with breaking-change callouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
