### PR TITLE
feat(wordpress): tune OPcache, add wp-content storage mode, pin auth salts for HA

### DIFF
--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -93,9 +93,17 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 - **Valkey**: Enable Valkey (Redis fork) as alternative caching.
 
 ### High Availability / Workload Controller
-- **`controllerType`**: Run WordPress as a `deployment` (default, single shared PVC) or a `statefulset`.
-- **Per-Pod ReadWriteOnce storage**: With `controllerType: statefulset`, each replica gets its own RWO volume via `volumeClaimTemplates` — true HA without depending on a single RWX share-manager (no shared single point of failure).
-- **Headless Service** for stable Pod DNS, plus `statefulset.*` tunables: `podManagementPolicy`, `updateStrategy`, and `persistentVolumeClaimRetentionPolicy`.
+
+Two first-class HA models — pick based on whether you have RWX storage:
+
+| Model | How | When |
+|---|---|---|
+| **StatefulSet + per-Pod RWO** | `controllerType: statefulset` — each replica gets its own ReadWriteOnce volume via `volumeClaimTemplates`. A storage outage affects at most one replica (no shared RWX share-manager SPOF). Adds a headless Service and `statefulset.*` tunables (`podManagementPolicy`, `updateStrategy`, `persistentVolumeClaimRetentionPolicy`). | No RWX available, or you want to avoid a shared-storage single point of failure. See `samples/ha-statefulset.values.yaml`. |
+| **Deployment + RWX + ephemeral core** | `controllerType: deployment` + `storage.mode: wp-content` — the WordPress core is re-copied from the image onto an `emptyDir` each start (pods become stateless and freely reschedulable), and only `wp-content` is persisted on one ReadWriteMany volume shared by all replicas. | You have an RWX storage class (NFS, CephFS, Longhorn RWX, JuiceFS, …) and want shared `wp-content`. See `samples/ha-deployment-rwx.values.yaml`. |
+
+- **`storage.mode`**: `full` (default — one volume for all of `/var/www/html`) or `wp-content` (ephemeral `emptyDir` core + persistent `wp-content`). `wp-content` mode pairs well with an object cache and offloaded uploads for truly stateless pods.
+- **Consistent auth keys/salts**: for per-Pod (`statefulset`) and ephemeral-core (`storage.mode: wp-content`) layouts the chart auto-generates and persists the eight WordPress `AUTH_KEY`/`SALT` values in its Secret and injects them into every Pod, so login cookies remain valid across replicas and restarts. Default `full`-mode Deployments are unchanged (their single shared `wp-config.php` already has consistent salts).
+- **Multi-replica checklist** (see the HA samples): enable an **object cache** (memcached/redis/valkey) so sessions/transients are shared; set **`resources.requests`** (required for the HPA); add a **`podDisruptionBudget`**, **`podAntiAffinity`** and **`topologySpreadConstraints`** to spread replicas; and for Deployments set **`updateStrategy.type: RollingUpdate`** (the default is `Recreate`, which causes downtime on upgrades).
 
 ### Metrics and Monitoring
 - **WordPress Metrics**: Automatically install a WordPress Plugin for Prometheus metrics.
@@ -113,6 +121,8 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 - **Apache Default Site Config**: Modify `/etc/apache2/sites-available/000-default.conf` using `apache.customDefaultSiteConfig`.
 - **Apache Ports Config**: Adjust `/etc/apache2/ports.conf` with `apache.customPortsConfig`.
 - **Apache PHP Config**: Set PHP settings like upload limits via `apache.customPhpConfig`.
+- **PHP OPcache**: tuned OPcache defaults ship enabled (`apache.opcache.*`, rendered as the `zz-opcache.ini` conf.d drop-in) — bigger opcode cache and file table than the image's `opcache-recommended.ini` (128 MB / 4000 files), which matters once WordPress runs many plugins. The `zz-` prefix makes it load **last**, so its values are authoritative — tune via `apache.opcache.*` (set `apache.opcache.enabled: false` to fall back to the image defaults). On shared/network filesystems, raise `apache.opcache.revalidateFreq` to reduce `stat()` load.
+- **Debug logging**: `wordpress.debug` enables `WP_DEBUG`; `wordpress.debugDisplay` (default `false`) keeps PHP warnings out of the response body in production, and `wordpress.debugLog` (default `false`) writes them to `wp-content/debug.log` instead.
 
 ### Custom commands in init container
 - **Execute custom shell commands** after init.sh via ConfigMap (`wordpress.init.customInitConfigMap.name`)
@@ -328,6 +338,16 @@ This setup includes everything from the advanced installation plus:
 kubectl apply -f ./samples/advanced.secrets.yaml
 kubectl apply -f ./samples/advanced.configmap.yaml
 helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples/advanced2.values.yaml
+```
+
+Two ready-made HA recipes (object cache + PDB + anti-affinity + topology spread + resources, with auto-pinned auth salts) are provided:
+
+```bash
+# Path 1 — StatefulSet, per-Pod ReadWriteOnce (no shared RWX required)
+helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples/ha-statefulset.values.yaml
+
+# Path 2 — Deployment + shared RWX with an ephemeral core (storage.mode=wp-content)
+helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples/ha-deployment-rwx.values.yaml
 ```
 
 ### Memcached cache setup

--- a/charts/wordpress/samples/ha-deployment-rwx.values.yaml
+++ b/charts/wordpress/samples/ha-deployment-rwx.values.yaml
@@ -1,0 +1,58 @@
+## Sample: High Availability via Deployment + shared RWX, with an ephemeral core (storage.mode=wp-content)
+##
+## The WordPress core is re-copied from the image onto an emptyDir on every start (fast, makes pods
+## stateless and freely reschedulable), while wp-content (plugins/themes/uploads) is shared across
+## all replicas on one ReadWriteMany volume. The chart auto-pins WordPress auth keys/salts in
+## storage.mode=wp-content, so login cookies stay valid across all replicas and restarts.
+##
+## Prefer ha-statefulset.values.yaml if you do NOT have (or do not want to depend on) an RWX
+## storage class — the shared RWX volume's share-manager is a single point of failure for all replicas.
+
+controllerType: deployment
+replicaCount: 3
+
+wordpress:
+  url: "https://example.com"
+  init:
+    enabled: true
+
+storage:
+  mode: wp-content        # ephemeral core (emptyDir) + persistent wp-content only
+  storageClass: ""        # an RWX storage class: NFS, CephFS, Longhorn RWX, JuiceFS, ...
+  size: 10Gi
+  accessModes:
+    - ReadWriteMany
+
+## Deployment default is Recreate (brief downtime on upgrade). For multi-replica, opt into RollingUpdate:
+updateStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
+## Object cache shares sessions/transients/object cache across replicas.
+## Enable exactly one backend (memcached | redis | valkey).
+valkey:
+  enabled: true
+  createConfig: true
+
+podDisruptionBudget:
+  minAvailable: 2
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: wordpress
+
+## Resource requests are required for the HorizontalPodAutoscaler to scale on CPU/memory.
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    memory: 512Mi

--- a/charts/wordpress/samples/ha-statefulset.values.yaml
+++ b/charts/wordpress/samples/ha-statefulset.values.yaml
@@ -1,0 +1,70 @@
+## Sample: High Availability via StatefulSet (per-Pod ReadWriteOnce storage, no shared RWX)
+##
+## Each replica gets its own RWO volume via volumeClaimTemplates, so a storage outage affects
+## at most one replica (no shared RWX share-manager as a single point of failure). Shared state
+## lives in the object cache + the database; uploads should be offloaded (e.g. S3) so replicas
+## do not need a shared filesystem. The chart auto-pins WordPress auth keys/salts in statefulset
+## mode, so login cookies stay valid across all replicas.
+
+controllerType: statefulset
+replicaCount: 3
+
+wordpress:
+  url: "https://example.com"
+  init:
+    enabled: true
+
+storage:
+  storageClass: ""        # any ReadWriteOnce storage class
+  size: 5Gi
+  accessModes:
+    - ReadWriteOnce
+
+statefulset:
+  podManagementPolicy: Parallel
+  updateStrategy:
+    type: RollingUpdate
+
+## Object cache shares sessions/transients/object cache across replicas.
+## Enable exactly one backend (memcached | redis | valkey).
+valkey:
+  enabled: true
+  createConfig: true
+
+## Keep at least 2 replicas available during voluntary disruptions (node drains, upgrades).
+podDisruptionBudget:
+  minAvailable: 2
+
+## Spread replicas across nodes.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: kubernetes.io/hostname
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: wordpress
+
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: wordpress
+
+## Resource requests are required for the HorizontalPodAutoscaler to scale on CPU/memory.
+resources:
+  requests:
+    cpu: 250m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+## Offload uploads so replicas don't need shared storage. Install via composer/plugins, e.g.:
+## wordpress:
+##   plugins:
+##     - name: "https://github.com/humanmade/S3-Uploads/releases/download/3.0.0/s3-uploads.zip"
+##       slug: s3-uploads
+##       activate: true

--- a/charts/wordpress/samples/verify/verify.sh
+++ b/charts/wordpress/samples/verify/verify.sh
@@ -187,6 +187,38 @@ else
   yellow "  [SKIP] Backup not enabled in this values set — nothing to verify"
 fi
 
+# ── 14. OPcache tuning active ─────────────────────────────────────────────────
+bold ""
+bold "==> Step 14: OPcache tuning active (chart default memory_consumption=192)"
+if [[ -n "${WP_POD}" ]]; then
+  # pipe-free read (avoids SIGPIPE aborting the script under set -o pipefail)
+  OPCACHE_MEM=$(kubectl exec "${WP_POD}" -c wordpress -- \
+    php -r 'echo (int) ini_get("opcache.memory_consumption");' 2>/dev/null || true)
+  if [[ "${OPCACHE_MEM}" == "192" ]]; then
+    green "  [OK] OPcache active with chart defaults (memory_consumption=${OPCACHE_MEM})"
+  else
+    red "  [FAIL] OPcache memory_consumption='${OPCACHE_MEM}' (expected 192 — check zz-opcache.ini conf.d load order)"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  yellow "  [SKIP] No wordpress pod — cannot check OPcache"
+fi
+
+# ── 15. WordPress auth keys/salts pinned ──────────────────────────────────────
+bold ""
+bold "==> Step 15: WordPress auth keys/salts pinned (statefulset / wp-content layouts)"
+SALT_COUNT=$(kubectl get secret "${RELEASE}" \
+  -o go-template='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}' 2>/dev/null \
+  | grep -cE '^WORDPRESS_(AUTH|SECURE_AUTH|LOGGED_IN|NONCE)_(KEY|SALT)$' || true)
+if [[ "${SALT_COUNT}" == "8" ]]; then
+  green "  [OK] All 8 auth keys/salts pinned in Secret ${RELEASE} (consistent across replicas)"
+elif [[ "${SALT_COUNT}" == "0" ]]; then
+  yellow "  [SKIP] No pinned salts (expected only for controllerType=statefulset or storage.mode=wp-content)"
+else
+  red "  [FAIL] Found ${SALT_COUNT}/8 auth keys/salts in Secret ${RELEASE} (should be 0 or 8)"
+  ERRORS=$((ERRORS + 1))
+fi
+
 # ── Result ────────────────────────────────────────────────────────────────────
 echo ""
 bold "============================================"

--- a/charts/wordpress/templates/_helpers.tpl
+++ b/charts/wordpress/templates/_helpers.tpl
@@ -418,3 +418,24 @@ Usage: {{ include "wordpress.urlHost" . }}
 
 {{- toYaml (dict "password" $password) -}}
 {{- end -}}
+
+{{/* ============================================================================ */}}
+{{/* Data volume mounts for the WordPress filesystem.                            */}}
+{{/* storage.mode=full       → the PVC / per-Pod volume is mounted at <path>.    */}}
+{{/* storage.mode=wp-content → an ephemeral emptyDir holds the core at <path>,   */}}
+{{/*                           the PVC / per-Pod volume is mounted at <path>/wp-content. */}}
+{{/* Usage: {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/var/www/html") | nindent 12 }} */}}
+{{/* ============================================================================ */}}
+{{- define "wordpress.dataVolumeMounts" -}}
+{{- $ctx := .ctx -}}
+{{- $path := .path -}}
+{{- if eq $ctx.Values.storage.mode "wp-content" -}}
+- name: wordpress-html
+  mountPath: {{ $path }}
+- name: {{ include "wordpress.fullname" $ctx }}
+  mountPath: {{ printf "%s/wp-content" $path }}
+{{- else -}}
+- name: {{ include "wordpress.fullname" $ctx }}
+  mountPath: {{ $path }}
+{{- end -}}
+{{- end -}}

--- a/charts/wordpress/templates/_init-base.tpl
+++ b/charts/wordpress/templates/_init-base.tpl
@@ -82,10 +82,28 @@ if [ -z "$PVC_VERSION" ]; then
       ' /usr/src/wordpress/wp-config-docker.php > /tmp/wordpress/wp-config.php
     fi
 
+    {{- if eq .Values.storage.mode "wp-content" }}
+    # storage.mode=wp-content: wp-content is its own volume (always a mountpoint), so populate
+    # the image skeleton only when the directory is empty — covers a fresh per-Pod RWO volume
+    # or a fresh shared RWX volume. A lock file serializes the copy when replicas start together.
+    if [ -z "$(ls -A /tmp/wordpress/wp-content 2>/dev/null)" ]; then
+        SKEL_LOCK="/tmp/wordpress/wp-content/.wp-content-copy-lock"
+        if (set -o noclobber; echo "$$" > "$SKEL_LOCK") 2>/dev/null; then
+            trap 'rm -f "$SKEL_LOCK"' EXIT
+            echo "Populating empty wp-content from image skeleton..."
+            cp -r /usr/src/wordpress/wp-content/. /tmp/wordpress/wp-content/ 2>/dev/null || true
+            rm -f "$SKEL_LOCK"
+            trap - EXIT
+        else
+            echo "Another pod is populating wp-content, continuing..."
+        fi
+    fi
+    {{- else }}
     # Copy wp-content skeleton if not present
     if [ ! -d /tmp/wordpress/wp-content ]; then
         cp -r /usr/src/wordpress/wp-content /tmp/wordpress/wp-content 2>/dev/null || true
     fi
+    {{- end }}
     echo "Complete! WordPress has been successfully installed to /tmp/wordpress"
 
 elif [ "$IMAGE_VERSION" != "$PVC_VERSION" ]; then

--- a/charts/wordpress/templates/_pod.tpl
+++ b/charts/wordpress/templates/_pod.tpl
@@ -180,8 +180,7 @@
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-c", "chown -R {{ .Values.podSecurityContext.runAsUser | default 33 }}:{{ .Values.podSecurityContext.fsGroup | default 33 }} /tmp/wordpress && echo 'PVC ownership fixed!'"]
           volumeMounts:
-            - name: {{ include "wordpress.fullname" . }}
-              mountPath: /tmp/wordpress
+            {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/tmp/wordpress") | nindent 12 }}
         {{- end }}
         - name: {{ .Chart.Name }}-base
           image: {{ include "slycharts.image" (dict "image" .Values.image "defaultTag" .Chart.AppVersion) }}
@@ -216,8 +215,7 @@
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-            - name: {{ include "wordpress.fullname" . }}
-              mountPath: /tmp/wordpress
+            {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/tmp/wordpress") | nindent 12 }}
             # Mount ConfigMap outside of /tmp to avoid being hidden by emptyDir
             - name: {{ include "wordpress.fullname" . }}-init
               mountPath: /scripts
@@ -436,8 +434,7 @@
           {{- end }}
           {{- end }}
           volumeMounts:
-            - name: {{ include "wordpress.fullname" . }}
-              mountPath: /var/www/html
+            {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/var/www/html") | nindent 12 }}
             - name: tmp
               mountPath: /tmp
             # Mount ConfigMap outside of /tmp
@@ -510,8 +507,7 @@
           volumeMounts:
             - name: wordpress-memcached-ext
               mountPath: /opt/php-ext
-            - name: {{ include "wordpress.fullname" . }}
-              mountPath: /var/www/html
+            {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/var/www/html") | nindent 12 }}
         {{- end }}
       {{- if .Values.initContainers }}
         {{- toYaml .Values.initContainers | nindent 8 }}
@@ -784,8 +780,7 @@
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: {{ include "wordpress.fullname" . }}
-              mountPath: /var/www/html
+            {{- include "wordpress.dataVolumeMounts" (dict "ctx" . "path" "/var/www/html") | nindent 12 }}
             - name: tmp
               mountPath: /tmp
             - name: run
@@ -815,6 +810,11 @@
             - name: {{ include "wordpress.fullname" . }}-configfiles
               mountPath: /usr/local/etc/php/conf.d/custom.ini
               subPath: custom.ini
+            {{- if .Values.apache.opcache.enabled }}
+            - name: {{ include "wordpress.fullname" . }}-configfiles
+              mountPath: /usr/local/etc/php/conf.d/zz-opcache.ini
+              subPath: zz-opcache.ini
+            {{- end }}
         {{- if .Values.metrics.apache.enabled}}
         - name: metrics-apache
           image: {{ include "slycharts.image" (dict "image" .Values.metrics.apache.image) }}
@@ -910,6 +910,10 @@
                 - key: custom.ini
                   path: custom.ini
                 {{- end }}
+                {{- if .Values.apache.opcache.enabled }}
+                - key: zz-opcache.ini
+                  path: zz-opcache.ini
+                {{- end }}
                 {{- if (not .Values.wordpress.htaccessConfigMap) }}
                 - key: htaccess
                   path: .htaccess
@@ -966,6 +970,12 @@
       - name: {{ .Values.externalDatabase.existingSecret }}
         secret:
           secretName: {{ .Values.externalDatabase.existingSecret }}
+      {{- end }}
+      {{- if eq .Values.storage.mode "wp-content" }}
+      # storage.mode=wp-content: the WordPress core lives on this ephemeral emptyDir
+      # (re-copied from the image each start); only wp-content is persisted on the volume below.
+      - name: wordpress-html
+        emptyDir: {}
       {{- end }}
       {{- if ne .Values.controllerType "statefulset" }}
       - name: {{ include "wordpress.fullname" . }}

--- a/charts/wordpress/templates/configmap.yaml
+++ b/charts/wordpress/templates/configmap.yaml
@@ -42,6 +42,19 @@ data:
     {{ .Values.apache.customPhpConfig | nindent 4 }}
     {{- end }}
   {{- end }}
+  {{- if .Values.apache.opcache.enabled }}
+  ## Tuned OPcache drop-in. The "zz-" prefix makes it load LAST in conf.d (after the
+  ## official image's opcache-recommended.ini), so these values are authoritative.
+  ## Tune via apache.opcache.* values rather than apache.customPhpConfig.
+  zz-opcache.ini: |
+    opcache.enable=1
+    opcache.enable_cli=0
+    opcache.memory_consumption={{ .Values.apache.opcache.memoryConsumption }}
+    opcache.interned_strings_buffer={{ .Values.apache.opcache.internedStringsBuffer }}
+    opcache.max_accelerated_files={{ .Values.apache.opcache.maxAcceleratedFiles }}
+    opcache.revalidate_freq={{ .Values.apache.opcache.revalidateFreq }}
+    opcache.validate_timestamps={{ ternary 1 0 .Values.apache.opcache.validateTimestamps }}
+  {{- end }}
   {{- if (not .Values.wordpress.htaccessConfigMap) }}
   htaccess: |
     {{- if and .Values.wordpress.htaccess  (not .Values.wordpress.htaccessConfigMap) }}

--- a/charts/wordpress/templates/secret.yaml
+++ b/charts/wordpress/templates/secret.yaml
@@ -32,6 +32,10 @@ data:
   {{- $url := include "wordpress.normalizedUrl" . }}
   {{/* Always inject WP_HOME and WP_SITEURL (URL is auto-prefixed with http/https if no protocol given) */}}
   {{- $inject = printf "define('WP_HOME', '%s');define('WP_SITEURL', '%s');" $url $url }}
+  {{- if .Values.wordpress.debug }}
+  {{- /* Keep WP_DEBUG_DISPLAY off in prod so PHP warnings never leak into the body; if(!defined()) avoids redefinition notices */}}
+  {{- $inject = printf "%sif(!defined('WP_DEBUG_DISPLAY')){define('WP_DEBUG_DISPLAY', %s);}if(!defined('WP_DEBUG_LOG')){define('WP_DEBUG_LOG', %s);}" $inject (ternary "true" "false" .Values.wordpress.debugDisplay) (ternary "true" "false" .Values.wordpress.debugLog) }}
+  {{- end }}
   {{- if .Values.wordpress.init.jwt.enabled }}
   {{- $inject = printf "%sdefine('JWT_AUTH_SECRET_KEY', getenv('JWT_AUTH_SECRET_KEY'));" $inject }}
   {{- end }}
@@ -160,6 +164,22 @@ data:
   {{- if .Values.externalDatabase.password }}
   WORDPRESS_DB_PASSWORD: {{ .Values.externalDatabase.password | b64enc }}
   {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- /* Pin WordPress auth keys/salts so they are identical across Pods and survive restarts. */}}
+  {{- /* Required for per-Pod wp-config layouts (controllerType=statefulset) and ephemeral-core */}}
+  {{- /* layouts (storage.mode=wp-content); otherwise login cookies break across replicas. */}}
+  {{- /* Generated once, then preserved across upgrades via lookup (like the JWT key above). */}}
+  {{- if or (eq .Values.controllerType "statefulset") (eq .Values.storage.mode "wp-content") }}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "wordpress.fullname" .) }}
+  {{- range $i, $k := (list "WORDPRESS_AUTH_KEY" "WORDPRESS_SECURE_AUTH_KEY" "WORDPRESS_LOGGED_IN_KEY" "WORDPRESS_NONCE_KEY" "WORDPRESS_AUTH_SALT" "WORDPRESS_SECURE_AUTH_SALT" "WORDPRESS_LOGGED_IN_SALT" "WORDPRESS_NONCE_SALT") }}
+  {{- $v := "" }}
+  {{- if and $existing (hasKey $existing.data $k) }}
+  {{- $v = index $existing.data $k | b64dec }}
+  {{- else }}
+  {{- $v = randAlphaNum 64 }}
+  {{- end }}
+  {{ $k }}: {{ $v | b64enc }}
   {{- end }}
   {{- end }}
 {{- if and .Values.wordpress.smtp.enabled (not .Values.wordpress.smtp.existingSecret) .Values.wordpress.smtp.password }}

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -857,7 +857,17 @@
         },
         "debug": {
           "type": "boolean",
-          "description": "Enable WordPress debug mode",
+          "description": "Enable WordPress debug mode (WP_DEBUG)",
+          "default": false
+        },
+        "debugDisplay": {
+          "type": "boolean",
+          "description": "Render PHP warnings/notices into the page (WP_DEBUG_DISPLAY); only applies when debug=true",
+          "default": false
+        },
+        "debugLog": {
+          "type": "boolean",
+          "description": "Write debug output to wp-content/debug.log (WP_DEBUG_LOG); only applies when debug=true",
           "default": false
         },
         "muPluginsConfigMaps": {
@@ -963,12 +973,57 @@
           "type": "string",
           "description": "Name of existing ConfigMap containing PHP config",
           "default": ""
+        },
+        "opcache": {
+          "type": "object",
+          "description": "PHP OPcache tuning rendered as a conf.d drop-in (00-opcache.ini)",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Render tuned PHP OPcache settings",
+              "default": true
+            },
+            "memoryConsumption": {
+              "type": "integer",
+              "description": "opcache.memory_consumption in MB",
+              "default": 192
+            },
+            "internedStringsBuffer": {
+              "type": "integer",
+              "description": "opcache.interned_strings_buffer in MB",
+              "default": 16
+            },
+            "maxAcceleratedFiles": {
+              "type": "integer",
+              "description": "opcache.max_accelerated_files",
+              "default": 20000
+            },
+            "revalidateFreq": {
+              "type": "integer",
+              "description": "opcache.revalidate_freq in seconds",
+              "default": 2
+            },
+            "validateTimestamps": {
+              "type": "boolean",
+              "description": "opcache.validate_timestamps",
+              "default": true
+            }
+          }
         }
       }
     },
     "storage": {
       "type": "object",
       "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "full",
+            "wp-content"
+          ],
+          "description": "Volume layout: 'full' mounts the volume at all of /var/www/html; 'wp-content' uses an ephemeral emptyDir core and persists only wp-content",
+          "default": "full"
+        },
         "existingClaim": {
           "type": "string",
           "description": "Name of an existing PVC to use"

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -439,8 +439,14 @@ wordpress:
   ## @param wordpress.htaccessConfigMap string Name of ConfigMap containing .htaccess (key: htaccess, overrides wordpress.htaccess)
   htaccessConfigMap: ""
 
-  ## @param wordpress.debug bool Enable WordPress debugging
+  ## @param wordpress.debug bool Enable WordPress debugging (WP_DEBUG)
   debug: false
+
+  ## @param wordpress.debugDisplay bool Render PHP warnings/notices into the page (WP_DEBUG_DISPLAY). Keep false in production so errors never leak into the response body. Only applies when debug=true.
+  debugDisplay: false
+
+  ## @param wordpress.debugLog bool Write debug output to wp-content/debug.log (WP_DEBUG_LOG). Only applies when debug=true.
+  debugLog: false
 
   ## @param wordpress.muPluginsConfigMaps list ConfigMaps containing MU-Plugin files (name, optional key)
   ## E.g.
@@ -545,8 +551,28 @@ apache:
   ## @param apache.customPhpConfigMap string Name of ConfigMap containing PHP config (key: custom.ini)
   customPhpConfigMap: ""
 
+  ## PHP OPcache tuning. Rendered as a dedicated conf.d drop-in (zz-opcache.ini) that loads
+  ## LAST — after the official image's opcache-recommended.ini — so these values win.
+  ## Tune via apache.opcache.* (not apache.customPhpConfig). Tuned defaults benefit every
+  ## install (PHP/image defaults of 128 MB / 4000 files are too small for WordPress + plugins).
+  opcache:
+    ## @param apache.opcache.enabled bool Render tuned PHP OPcache settings
+    enabled: true
+    ## @param apache.opcache.memoryConsumption int Shared opcode cache size in MB (opcache.memory_consumption)
+    memoryConsumption: 192
+    ## @param apache.opcache.internedStringsBuffer int Interned strings buffer in MB (opcache.interned_strings_buffer)
+    internedStringsBuffer: 16
+    ## @param apache.opcache.maxAcceleratedFiles int Max cached files (opcache.max_accelerated_files); WordPress + many plugins = lots of PHP files
+    maxAcceleratedFiles: 20000
+    ## @param apache.opcache.revalidateFreq int Seconds between timestamp checks (opcache.revalidate_freq); raise on shared/network FS to reduce stat load
+    revalidateFreq: 2
+    ## @param apache.opcache.validateTimestamps bool Re-check file mtimes (opcache.validate_timestamps); false = max performance but requires a restart to pick up code changes
+    validateTimestamps: true
+
 ## @section Storage parameters
 storage:
+  ## @param storage.mode string Volume layout. "full" (default) mounts the PVC / per-Pod volume at all of /var/www/html. "wp-content" keeps the WordPress core on an ephemeral emptyDir (re-copied from the image each start, ~seconds) and persists only wp-content on the PVC / per-Pod volume — makes pods stateless and fast to reschedule. Pair with an object cache and offloaded uploads (e.g. S3) for true HA. Requires consistent auth keys (auto-pinned by the chart for this mode).
+  mode: full
   ## @param storage.existingClaim string Name of an existing PVC to use
   existingClaim: ""
   ## @param storage.storageClass string Storage class for PVC (required when not using existingClaim)


### PR DESCRIPTION
## Why

Generalizes the WordPress chart's multi-replica optimizations so **every** consumer benefits — especially anyone running more than one replica — rather than relying on environment-specific deployment values. Two HA models are now first-class: **StatefulSet + per-Pod RWO** and **Deployment + RWX + ephemeral core**.

## What

- **`apache.opcache.*` (on by default)** — tuned OPcache rendered as a `zz-opcache.ini` conf.d drop-in that loads **after** the image's `opcache-recommended.ini`, so the chart's values are authoritative (image/PHP defaults of 128 MB / 4000 files are too small for WordPress + many plugins).
- **`wordpress.debugDisplay` / `wordpress.debugLog`** — split `WP_DEBUG_DISPLAY`/`WP_DEBUG_LOG` so production can log without leaking PHP warnings into the response body.
- **`storage.mode: wp-content`** — opt-in ephemeral `emptyDir` core + persistent `wp-content` volume → stateless, freely reschedulable pods. Default `full` layout is unchanged.
- **Auth key/salt pinning** — the 8 WordPress `AUTH_KEY`/`SALT` values are generated once, preserved across upgrades via `lookup`, and injected as env for `controllerType=statefulset` and `storage.mode=wp-content`. Without this, per-Pod / ephemeral-core layouts give each replica different salts → login cookies break across replicas. Default deployments render unchanged.
- **Docs/samples** — `samples/ha-statefulset.values.yaml`, `samples/ha-deployment-rwx.values.yaml`, a rewritten README "High Availability" section, and `verify.sh` extended with OPcache + auth-salt assertions.

## Compatibility

Backwards-compatible: with defaults (`controllerType: deployment`, `storage.mode: full`, `wordpress.debug: false`) the rendered output is identical except for the new OPcache drop-in. `feat` → chart **minor** bump.

## Verification

- `helm lint` + `helm template` for `full`, `statefulset`, and `wp-content` modes.
- `samples/verify/verify.sh` on a live cluster — **15/15 checks passed**: both StatefulSet replicas Ready, HTTP 200, metrics reachable, OPcache active (`memory_consumption=192`), all 8 auth salts pinned and identical across replicas.
- Single-replica `wp-content` smoke: core on emptyDir, `wp-content` on PVC, default themes populated, HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
