### PR TITLE
ci: retrigger automerge for open release PRs on push to main

### DIFF
--- a/.github/workflows/release-please-automerge-retrigger.yml
+++ b/.github/workflows/release-please-automerge-retrigger.yml
@@ -1,0 +1,41 @@
+name: Release Please Auto-merge Retrigger
+
+# After any push to main, re-evaluate all open release-please PRs so that the
+# automerge picks up version-bump changes that main introduced without a new
+# commit landing on the release PR branch (which would otherwise leave the PR
+# unmergeable or stale with no retrigger event).
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  actions: write  # gh workflow run
+  pull-requests: read
+
+jobs:
+  retrigger:
+    name: retrigger automerge for open release PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch automerge for each open release-please PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          prs=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --json number,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release-please--branches--main--components--")) | .number]')
+
+          count=$(echo "$prs" | jq 'length')
+          echo "open release PRs: $count"
+          [ "$count" -gt 0 ] || exit 0
+
+          echo "$prs" | jq -r '.[]' | while read -r num; do
+            echo "dispatching automerge for PR #$num"
+            gh workflow run release-please-automerge.yml \
+              --repo "$GITHUB_REPOSITORY" \
+              --field pr="$num"
+          done


### PR DESCRIPTION
## Problem

When `main` advances (e.g. a feature PR merges) without a new commit landing on
the release-please PR branch, no `synchronize` event fires and the automerge
never re-evaluates. The release PR can be left unmergeable or simply stale until
someone manually dispatches the automerge.

## Fix

New workflow `release-please-automerge-retrigger.yml` triggers on every push to
`main`, finds all open release-please PRs, and `workflow_dispatch`es the
automerge for each one. The automerge itself is idempotent (it skips if already
merged, not a release branch, version unchanged, etc.), so dispatching it
multiple times is safe.

## Test plan

- [ ] Merge this PR, then verify the retrigger fires when the next commit lands on main
- [ ] Confirm it dispatches for PR [#447](https://github.com/SlyBase/helm-charts/pull/447) (wordpress 5.0.1) if still open