### PR TITLE
ci: make Trivy image scan non-blocking in OCI release

### DIFF
--- a/.github/workflows/oci-release.yaml
+++ b/.github/workflows/oci-release.yaml
@@ -291,7 +291,9 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin "v${TRIVY_VERSION}"
           trivy version
 
-      - name: Trivy image scan (referenced images, blocking on CRITICAL)
+      # Upstream images are not built by us, so CRITICAL findings only warn —
+      # they must not block publishing the chart.
+      - name: Trivy image scan (referenced images, non-blocking)
         shell: bash
         run: |
           set -euo pipefail
@@ -299,8 +301,13 @@ jobs:
           while IFS= read -r image; do
             [ -z "$image" ] && continue
             echo "::group::trivy image scan: ${image}"
-            trivy image --severity CRITICAL --exit-code 1 --ignore-unfixed --scanners vuln "$image"
+            rc=0
+            trivy image --severity CRITICAL --exit-code 1 --ignore-unfixed --scanners vuln "$image" || rc=$?
             echo "::endgroup::"
+            if [ "$rc" -ne 0 ]; then
+              echo "::warning title=Trivy CRITICAL findings::${image} has CRITICAL vulnerabilities (upstream image, release not blocked)"
+              echo "⚠️ Trivy found CRITICAL vulnerabilities in \`${image}\` (upstream image, release not blocked)" >> "$GITHUB_STEP_SUMMARY"
+            fi
           done < images.txt
 
       - name: Dry run summary


### PR DESCRIPTION
## Why

Trivy blocked the wordpress 5.1.1 and 5.1.2 releases ([run 1](https://github.com/SlyBase/helm-charts/actions/runs/28299503269), [run 2](https://github.com/SlyBase/helm-charts/actions/runs/28367917254)) because of CVE-2026-55200 in the upstream `wordpress:7.0.0-php8.3-apache` image.

Since the referenced images are upstream and not built in this repo, CRITICAL findings should not block publishing the chart.

## What

The Trivy image scan in `oci-release.yaml` now emits a `::warning` annotation and a step-summary note per affected image instead of failing the job. The full scan table still appears in the logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)