### PR TITLE
fix(wordpress): clarify init.enabled semantics

### DIFF
--- a/charts/wordpress/README.md
+++ b/charts/wordpress/README.md
@@ -56,6 +56,15 @@ helm install wordpress oci://ghcr.io/slybase/charts/wordpress --values ./samples
 - **Debug Mode**: Enable debugging for the installation.
 - **Permalinks**: Configure permalink structures (e.g., post name, day and name).
 
+#### What `wordpress.init.enabled` does
+
+The chart's init containers **always run** on every pod start — they manage plugins, themes, MU-plugins, `.htaccess` and configuration regardless of this setting. `wordpress.init.enabled` only controls the automatic WordPress **core installation** step inside the init container:
+
+- **`true`**: On first start the init container runs `wp core install` with the configured admin credentials, blog title and (optionally) multisite setup. It is idempotent — if WordPress is already installed, the installation is skipped, but language, permalinks and admin metadata (first/last name) are still applied.
+- **`false`** (default): No automatic installation. The chart expects a database with an **already-installed WordPress** (e.g. a migration or an external/restored database). If the WordPress tables are missing, the init container fails fast with instructions instead of starting an unconfigured site — the pod will not become ready until either `wordpress.init.enabled=true` is set or the database is provisioned. Note that `wordpress.language`, `wordpress.permalinks.*` and the `wordpress.init.*` admin settings are **not** applied in this mode.
+
+For a fresh installation you therefore effectively need `wordpress.init.enabled: true` together with admin credentials (either `wordpress.init.username/password/email` or `wordpress.init.existingSecret`).
+
 ### User Management
 - **Automatic User Generation**: Create additional users with roles (Administrator, Editor, etc.).
 - **Email Notification**: Automatically send emails with generated passwords.
@@ -221,7 +230,7 @@ Two first-class HA models — pick based on whether you have RWX storage:
 > **Note:** If you need full manual control over `WP_HOME` / `WP_SITEURL` (e.g. different values for each, or a reverse proxy setup), set `wordpress.configExtraInject: false` to disable the automatic injection into `wp-config.php` and define the constants yourself via `wordpress.configExtra`. The environment variables `WP_HOME` and `WP_SITEURL` in the container are always derived from `wordpress.url`.
 
 ### Recommended parameters
-- `wordpress.init`: Admin credentials and blog setup
+- `wordpress.init`: Admin credentials and blog setup. For a **fresh installation** set `wordpress.init.enabled: true` — otherwise the chart expects an already-installed WordPress database and the init container fails on an empty one (see [What `wordpress.init.enabled` does](#what-wordpressinitenabled-does)).
 - `service.type`: If you want to access WordPress internally set it to NodePort
 
 ### Additional parameters

--- a/charts/wordpress/templates/_init-script.tpl
+++ b/charts/wordpress/templates/_init-script.tpl
@@ -191,6 +191,13 @@ echo "Setting up WordPress..."
 echo "========================================="
 
 if [ "${WP_INIT}" = "true" ]; then
+  echo "WP_INIT=true: WordPress core installation enabled (skipped if already installed)."
+else
+  echo "WP_INIT=false: skipping WordPress core installation (wordpress.init.enabled=false)."
+  echo "The init container still manages plugins, themes and configuration."
+fi
+
+if [ "${WP_INIT}" = "true" ]; then
   # Check both: wp-cli installation status AND database tables existence
   WP_INSTALLED=false
   if run wp core is-installed --url="${WP_URL}" 2>/dev/null; then

--- a/charts/wordpress/templates/_pod.tpl
+++ b/charts/wordpress/templates/_pod.tpl
@@ -592,10 +592,6 @@
               value: {{ .Values.externalDatabase.password | quote }}
           {{- end }}
           {{- end }}
-          {{ if .Values.wordpress.init.enabled }}
-            - name: WP_INIT
-              value: {{ .Values.wordpress.init.enabled | quote }}
-          {{- end }}
           {{ if .Values.metrics.wordpress.enabled }}
             - name: SLYMETRICS_BEARER_TOKEN
               valueFrom:

--- a/charts/wordpress/values.schema.json
+++ b/charts/wordpress/values.schema.json
@@ -312,7 +312,7 @@
             },
             "enabled": {
               "type": "boolean",
-              "description": "Enable init container for first installation",
+              "description": "Enable automatic WordPress core installation on first start (the init container itself always runs; when false, an already-installed WordPress database is expected)",
               "default": false
             },
             "existingSecret": {

--- a/charts/wordpress/values.yaml
+++ b/charts/wordpress/values.yaml
@@ -160,8 +160,13 @@ wordpress:
   ## @section WordPress initialization settings
   ## @descriptionStart
   ## These settings are set with an init container.
-  ## Note: If WordPress is already installed and wordpress.init.enabled is true, the installation process will be skipped,
-  ## but the following will still be applied: firstname, lastname, permalinks, plugins, users
+  ## Note: The init container itself always runs — it manages plugins, themes, MU-plugins and configuration on every pod start.
+  ## wordpress.init.enabled only controls the automatic WordPress core installation (wp core install) inside it:
+  ##   - true: install WordPress on first start (admin user, title, optional multisite); if WordPress is already installed,
+  ##     the installation is skipped, but firstname, lastname, language, permalinks, plugins and users are still applied.
+  ##   - false (default): no automatic installation — the chart expects an already-installed WordPress database
+  ##     (e.g. migration / external DB). On an empty database the init container fails fast with instructions.
+  ##     language, permalinks and the init.* admin settings are NOT applied in this mode.
   ## @descriptionEnd
   init:
     ## @section Init container image
@@ -175,7 +180,7 @@ wordpress:
       ## @param wordpress.init.image.pullPolicy string Image pull policy for init container
       pullPolicy: IfNotPresent
 
-    ## @param wordpress.init.enabled bool Enable init container for first installation
+    ## @param wordpress.init.enabled bool Enable automatic WordPress core installation on first start (the init container itself always runs; when false, an already-installed WordPress database is expected)
     enabled: false
     ## @param wordpress.init.existingSecret string Existing secret with keys: wordpress.username, wordpress.password, wordpress.email
     existingSecret: ""


### PR DESCRIPTION
## Summary
- Reworded `wordpress.init.enabled` description to clarify it only toggles automatic WordPress core installation, not the init container itself
- Added comprehensive README section explaining when to use `true` (fresh install) vs. `false` (bring-your-own database)
- Init container now logs which mode is active for better debugging
- Removed unused `WP_INIT` env var from the main container
- Fixes #450

## Test plan
- Helm template render verified (only expected diffs)
- 23/23 unit tests pass
- `verify.sh` smoke test: **ALL CHECKS PASSED**
- Both `init.enabled=true` and `init.enabled=false` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)